### PR TITLE
fix: setting config using valkeyConfig value

### DIFF
--- a/valkey/Chart.yaml
+++ b/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: A Helm chart for Kubernetes
 type: application
-version: 0.7.2
+version: 0.7.3
 appVersion: "8.1.3"
 home: https://valkey.io/valkey-helm/
 sources:

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -1,6 +1,6 @@
 # valkey
 
-![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.3](https://img.shields.io/badge/AppVersion-8.1.3-informational?style=flat-square)
+![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.3](https://img.shields.io/badge/AppVersion-8.1.3-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/valkey/templates/configmap.yaml
+++ b/valkey/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.valkeyConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "valkey.fullname" . }}-config
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+data:
+  valkey.conf: |
+    {{- .Values.valkeyConfig | nindent 4 }}
+{{- end }}

--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -49,7 +49,7 @@ spec:
             - name: scripts
               mountPath: /scripts
             {{- if .Values.valkeyConfig }}
-            - name: config
+            - name: valkey-config
               mountPath: /usr/local/etc/valkey/valkey.conf
               subPath: valkey.conf
             {{- end }}
@@ -109,9 +109,9 @@ spec:
             name: {{ include "valkey.fullname" . }}-init-scripts
             defaultMode: 0555
         {{- if .Values.valkeyConfig }}
-        - name: {{ include "valkey.fullname" . }}-config
+        - name: valkey-config
           configMap:
-            name: valkey-config
+            name: {{ include "valkey.fullname" . }}-config
         {{- end }}
         {{- range .Values.extraValkeySecrets }}
         - name: {{ .name }}-valkey


### PR DESCRIPTION
Added a missing ConfigMap for saving the `valkey.conf`.
Also cleaned the naming scheme for it:
- Both volume and mount are now called `valkey-conf`
- ConfigMap is named using the `valkey.fullname` template

Fixes #16.