### PR TITLE
Fix security vulnerability CVE-2025-49844 by using newer valkey app version 8.1.4

### DIFF
--- a/valkey/Chart.yaml
+++ b/valkey/Chart.yaml
@@ -3,7 +3,7 @@ name: valkey
 description: A Helm chart for Kubernetes
 type: application
 version: 0.7.4
-appVersion: "8.1.3"
+appVersion: "8.1.4"
 home: https://valkey.io/valkey-helm/
 sources:
   - https://github.com/valkey-io/valkey-helm.git

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -1,6 +1,6 @@
 # valkey
 
-![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.3](https://img.shields.io/badge/AppVersion-8.1.3-informational?style=flat-square)
+![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.1.4](https://img.shields.io/badge/AppVersion-8.1.4-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 


### PR DESCRIPTION
8.1.4 fixed several vulnerabilites, see https://github.com/valkey-io/valkey/releases/tag/8.1.4