### PR TITLE
OpenShift compatibility

### DIFF
--- a/valkey/README.md
+++ b/valkey/README.md
@@ -13,6 +13,7 @@ A Helm chart for Kubernetes
 | affinity | object | `{}` |  |
 | auth.aclConfig | string | `"# Users and permissions can be defined here\n# Example:\n# user default off\n# user default on >defaultpassword ~*  &* +@all \n"` |  |
 | auth.enabled | bool | `false` |  |
+| compat.openshift.adaptSecurityContext | string | `"auto"` |  |
 | dataStorage.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | dataStorage.annotations | object | `{}` |  |
 | dataStorage.className | string | `nil` |  |
@@ -47,11 +48,13 @@ A Helm chart for Kubernetes
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
+| podSecurityContext.enabled | bool | `true` |  |
 | podSecurityContext.fsGroup | int | `1000` |  |
 | podSecurityContext.runAsGroup | int | `1000` |  |
 | podSecurityContext.runAsUser | int | `1000` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
+| securityContext.enabled | bool | `true` |  |
 | securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | securityContext.readOnlyRootFilesystem | bool | `true` |  |
 | securityContext.runAsNonRoot | bool | `true` |  |

--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -19,10 +19,10 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
       annotations:
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
         checksum/initconfig: {{ include (print $.Template.BasePath "/init_config.yaml") . | sha256sum | trunc 32 }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -31,16 +31,26 @@ spec:
       {{- end }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
       serviceAccountName: {{ include "valkey.serviceAccountName" . }}
+      {{- $psc := include "valkey.compat.renderSecurityContext" (dict "secContext" .Values.podSecurityContext "context" $) | trim -}}
+      {{- $pscVals := .Values.podSecurityContext -}}
+      {{- $pscHasEnabled := hasKey $pscVals "enabled" -}}
+      {{- $pscEnabled := ternary true (get $pscVals "enabled") (not $pscHasEnabled) -}}
+      {{- if and $pscEnabled ($psc) }}
       securityContext:
-      {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      
+      {{- $psc | nindent 8 }}
+      {{- end }}
+
       initContainers:
         - name: {{ .Chart.Name }}-init
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.securityContext }}
+          {{- $cscInit := include "valkey.compat.renderSecurityContext" (dict "secContext" .Values.securityContext "context" $) | trim -}}
+          {{- $cscVals := .Values.securityContext -}}
+          {{- $cscHasEnabled := hasKey $cscVals "enabled" -}}
+          {{- $cscEnabled := ternary true (get $cscVals "enabled") (not $cscHasEnabled) -}}
+          {{- if and $cscEnabled ($cscInit) }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- $cscInit | nindent 12 }}
           {{- end }}
           command: [ "/scripts/init.sh" ]
           volumeMounts:
@@ -71,8 +81,14 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command: [ "valkey-server" ]
           args: [ "/data/conf/valkey.conf" ]
+          {{- $csc := include "valkey.compat.renderSecurityContext" (dict "secContext" .Values.securityContext "context" $) | trim -}}
+          {{- $cscVals2 := .Values.securityContext -}}
+          {{- $cscHasEnabled2 := hasKey $cscVals2 "enabled" -}}
+          {{- $cscEnabled2 := ternary true (get $cscVals2 "enabled") (not $cscHasEnabled2) -}}
+          {{- if and $cscEnabled2 ($csc) }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- $csc | nindent 12 }}
+          {{- end }}
           env:
             {{- range $key, $val := .Values.env }}
             - name: {{ $key }}

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -2,6 +2,20 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
+        "compat": {
+            "type": "object",
+            "properties": {
+                "openshift": {
+                    "type": "object",
+                    "properties": {
+                        "adaptSecurityContext": {
+                            "type": "string",
+                            "enum": ["auto", "force", "disabled"]
+                        }
+                    }
+                }
+            }
+        },
         "affinity": {
             "type": "object"
         },
@@ -123,6 +137,9 @@
         "podSecurityContext": {
             "type": "object",
             "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
                 "fsGroup": {
                     "type": "integer"
                 },
@@ -143,6 +160,9 @@
         "securityContext": {
             "type": "object",
             "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
                 "capabilities": {
                     "type": "object",
                     "properties": {

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -32,18 +32,29 @@ podLabels: {}
 
 # Security context for the pod (applies to all containers)
 podSecurityContext:
+  enabled: true
   fsGroup: 1000
   runAsUser: 1000
   runAsGroup: 1000
 
 # Security context for the Valkey containers
 securityContext:
+  enabled: true
   capabilities:
     drop:
       - ALL
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 1000
+
+# Compatibility adaptations for Kubernetes platforms
+compat:
+  # Adaptations for OpenShift
+  openshift:
+    # Adapt the securityContext sections to make them compatible with OpenShift restricted-v2 SCC.
+    # Removes runAsUser, runAsGroup and fsGroup to let the platform use allowed default IDs.
+    # Possible values: auto (detect OpenShift), force (always adapt), disabled (never adapt).
+    adaptSecurityContext: auto
 
 service:
   # Type of Kubernetes service (ClusterIP, NodePort, LoadBalancer)


### PR DESCRIPTION
Adds OpenShift compatibility by introducing `compat.openshift.adaptSecurityContext` (auto|force|disabled) and a helper that detects OpenShift. Adapts pod/container `securityContext` without changing defaults on vanilla Kubernetes.

This approach is similar to the pattern used by Bitnami's Valkey chart, which we are glad to have an official alternative to :)