### PR TITLE
Support reading ACLs from a secret

### DIFF
--- a/valkey/README.md
+++ b/valkey/README.md
@@ -13,6 +13,8 @@ A Helm chart for Kubernetes
 | affinity | object | `{}` |  |
 | auth.aclConfig | string | `"# Users and permissions can be defined here\n# Example:\n# user default off\n# user default on >defaultpassword ~*  &* +@all \n"` |  |
 | auth.enabled | bool | `false` |  |
+| auth.existingACLSecret.key | string | `"users.acl"` |  |
+| auth.existingACLSecret.name | string | `""` |  |
 | dataStorage.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | dataStorage.annotations | object | `{}` |  |
 | dataStorage.className | string | `nil` |  |

--- a/valkey/templates/NOTES.txt
+++ b/valkey/templates/NOTES.txt
@@ -36,14 +36,19 @@ Port:         {{ .Values.service.port }}
 
 {{ if .Values.auth.enabled }}
 🔐 Authentication is ENABLED (ACL)
-- Provide the username and password from `.auth.aclConfig`.
+- Source of ACLs:
+  {{- if .Values.auth.existingACLSecret.name }}
+  - From Secret: `{{ .Values.auth.existingACLSecret.name }}`, key: `{{ default "users.acl" .Values.auth.existingACLSecret.key }}`
+  {{- else }}
+  - From values: `.auth.aclConfig`
+  {{- end }}
 - Default user:
   $ valkey-cli -h {{ include "valkey.fullname" . }} -p {{ .Values.service.port }} -a <password> PING
 - Named user:
   $ valkey-cli -h {{ include "valkey.fullname" . }} -p {{ .Values.service.port }} --user <user> -a <password> PING
 {{ else }}
 🔓 Authentication is DISABLED
-- Enable with: `--set auth.enabled=true` and provide `.auth.aclConfig`.
+- Enable with: `--set auth.enabled=true` and provide `.auth.aclConfig`, or use `auth.existingACLSecret`.
 {{ end }}
 
 ✅ Quick test

--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -48,6 +48,10 @@ spec:
               mountPath: /data
             - name: scripts
               mountPath: /scripts
+            {{- if and .Values.auth.enabled .Values.auth.existingACLSecret.name }}
+            - name: authacl
+              mountPath: /authacl
+            {{- end }}
             {{- if .Values.valkeyConfig }}
             - name: valkey-config
               mountPath: /usr/local/etc/valkey/valkey.conf
@@ -108,6 +112,11 @@ spec:
           configMap:
             name: {{ include "valkey.fullname" . }}-init-scripts
             defaultMode: 0555
+        {{- if and .Values.auth.enabled .Values.auth.existingACLSecret.name }}
+        - name: authacl
+          secret:
+            secretName: {{ .Values.auth.existingACLSecret.name }}
+        {{- end }}
         {{- if .Values.valkeyConfig }}
         - name: valkey-config
           configMap:

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -45,9 +45,19 @@ data:
 
     {{- if .Values.auth.enabled }}
     echo "aclfile /data/conf/users.acl" >>"$VALKEY_CONFIG"
+    {{- if .Values.auth.existingACLSecret.name }}
+    # Load ACLs from mounted secret
+    if [ -f "/authacl/{{ default "users.acl" .Values.auth.existingACLSecret.key }}" ]; then
+      cp "/authacl/{{ default "users.acl" .Values.auth.existingACLSecret.key }}" /data/conf/users.acl
+    else
+      echo "Expected key '{{ default "users.acl" .Values.auth.existingACLSecret.key }}' not found in secret volume /authacl" | tee -a "$LOGFILE"
+      exit 1
+    fi
+    {{- else }}
     cat <<EOF > /data/conf/users.acl
 {{ .Values.auth.aclConfig | indent 6 }}
     EOF
+    {{- end }}
     {{- end }}
 
     # Append extra configs if present

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -11,6 +11,13 @@
                 "aclConfig": {
                     "type": "string"
                 },
+                "existingACLSecret": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "key": { "type": "string" }
+                    }
+                },
                 "enabled": {
                     "type": "boolean"
                 }

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -131,6 +131,21 @@ auth:
     # user default off
     # user default on >defaultpassword ~*  &* +@all 
 
+  # Load ACLs from an existing Secret. If provided, takes precedence over `aclConfig`.
+  # The Secret should contain a key with the ACL file content as expected by Valkey.
+  #
+  # Example:
+  #   kind: Secret
+  #   type: Opaque
+  #   stringData:
+  #     users.acl: |
+  #       user username on >password ~* &* +@read -@write -@dangerous
+  existingACLSecret:
+    # Name of the Secret containing the ACL content
+    name: ""
+    # Key within the Secret that holds the ACL content
+    key: "users.acl"
+
 # Node selector for pod assignment
 nodeSelector: {}
 


### PR DESCRIPTION
Adds support for loading ACLs from a Kubernetes Secret via `auth.existingACLSecret`, mounting it into the init container when authentication is enabled. Allows managing credentials as secrets and helps keep sensitive data out of charts/CD.