### PR TITLE
fix: change topologySpreadConstraints from object to array

### DIFF
--- a/valkey/README.md
+++ b/valkey/README.md
@@ -63,6 +63,7 @@ A Helm chart for Kubernetes
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
 | tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |
 | valkeyConfig | string | `""` |  |
 | valkeyLogLevel | string | `"notice"` |  |
 

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -197,7 +197,10 @@
             "type": "array"
         },
         "topologySpreadConstraints": {
-            "type": "object"
+            "type": "array",
+            "items": {
+                "type": "object"
+            }
         },
         "valkeyConfig": {
             "type": "string"

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -141,7 +141,7 @@ tolerations: []
 affinity: {}
 
 # See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints
-topologySpreadConstraints: {}
+topologySpreadConstraints: []
 
 # Valkey logging level: debug, verbose, notice, warning
 valkeyLogLevel: "notice"


### PR DESCRIPTION
According to Kubernetes API specification, topologySpreadConstraints should be an array of TopologySpreadConstraint objects, not a single object. This change aligns the schema with the official Kubernetes PodSpec definition.

Refs:
- https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field
- https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podspec-v1-core

This allows users to define constraints correctly as a list:
```yaml
topologySpreadConstraints:
  - labelSelector:
      matchLabels:
        app.kubernetes.io/name: valkey
    maxSkew: 1
    minDomains: 2
    topologyKey: kubernetes.io/hostname
    whenUnsatisfiable: DoNotSchedule
  - labelSelector:
      matchLabels:
        app.kubernetes.io/name: valkey
    maxSkew: 1
    minDomains: 2
    topologyKey: topology.kubernetes.io/zone
    whenUnsatisfiable: DoNotSchedule

```