### PR TITLE
Add support for custom nodePort when service type is "NodePort".

### DIFF
--- a/valkey/README.md
+++ b/valkey/README.md
@@ -59,6 +59,7 @@ A Helm chart for Kubernetes
 | securityContext.runAsUser | int | `1000` |  |
 | service.port | int | `6379` |  |
 | service.type | string | `"ClusterIP"` |  |
+| service.nodePort | int | `0` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.automount | bool | `false` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/valkey/templates/service.yaml
+++ b/valkey/templates/service.yaml
@@ -15,5 +15,8 @@ spec:
       targetPort: tcp
       protocol: TCP
       name: tcp
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "valkey.selectorLabels" . | nindent 4 }}

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -177,6 +177,9 @@
                 },
                 "type": {
                     "type": "string"
+                },
+                "nodePort": {
+                    "type": "integer"
                 }
             }
         },

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -51,6 +51,8 @@ service:
   # Port on which Valkey will be exposed
   port: 6379
   annotations: {}
+  # NodePort value (if service.type is NodePort)
+  nodePort: 0
 
 # Network policy to control traffic to the pods
 # More info: https://kubernetes.io/docs/concepts/services-networking/network-policies/


### PR DESCRIPTION
Hi, this is my first PR here, so bear with me. The goal of the PR is to add support for custom `nodePort` for users who might need it when using `service.type: NodePort`.

This PR aims to maintain the current defaults and shouldn't produce any changes unless _both_ `service.type=NodePort` and `service.nodePort` are set.

No diff between the latest released valkey chart 0.7.6 and this branch.
```diff
$ diff <(helm template valkey valkey/valkey --version 0.7.6) <(helm template valkey ./valkey)
$
```

### Helm values permutations

#### Service with default values

`helm template valkey ./valkey`

```yaml
  type: ClusterIP
  ports:
    - port: 6379
      targetPort: tcp
      protocol: TCP
      name: tcp
```

#### Service with node port set

`helm template valkey ./valkey --set service.nodePort=30007`

```yaml
  type: ClusterIP
  ports:
    - port: 6379
      targetPort: tcp
      protocol: TCP
      name: tcp
```

#### Service with type: NodePort, but no node port set

`helm template valkey ./valkey --set service.type=NodePort`

```yaml
  type: NodePort
  ports:
    - port: 6379
      targetPort: tcp
      protocol: TCP
      name: tcp
```

#### Finally, service with type: NodePort and custom node port

`helm template valkey ./valkey --set service.type=NodePort --set service.nodePort=30007`

```yaml
  type: NodePort
  ports:
    - port: 6379
      targetPort: tcp
      protocol: TCP
      name: tcp
      nodePort: 30007
```

### Validation against a kubernetes cluster

```
$ helm upgrade -i valkey ./valkey --set service.type=NodePort --set service.nodePort=30007
$ kubectl get service valkey
NAME     TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
valkey   NodePort   10.43.233.122   <none>        6379:30007/TCP   45m
```

Closes https://github.com/valkey-io/valkey-helm/issues/39.