### PR TITLE
Support restricted PSS

### DIFF
--- a/valkey/README.md
+++ b/valkey/README.md
@@ -53,10 +53,12 @@ A Helm chart for Kubernetes
 | podSecurityContext.runAsUser | int | `1000` |  |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
+| securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | securityContext.readOnlyRootFilesystem | bool | `true` |  |
 | securityContext.runAsNonRoot | bool | `true` |  |
 | securityContext.runAsUser | int | `1000` |  |
+| securityContext.seccompProfile.type | string | `RuntimeDefault` |  |
 | service.port | int | `6379` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -147,6 +147,9 @@
         "securityContext": {
             "type": "object",
             "properties": {
+                "allowPrivilegeEscalation": {
+                    "type": "boolean"
+                },
                 "capabilities": {
                     "type": "object",
                     "properties": {
@@ -166,6 +169,14 @@
                 },
                 "runAsUser": {
                     "type": "integer"
+                },
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -38,12 +38,15 @@ podSecurityContext:
 
 # Security context for the Valkey containers
 securityContext:
+  allowPrivilegeEscalation: false
   capabilities:
     drop:
       - ALL
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 service:
   # Type of Kubernetes service (ClusterIP, NodePort, LoadBalancer)


### PR DESCRIPTION
When deploying in a restricted namespace, `allowPrivilegeEscalation=false` and `seccompProfile.type=RuntimeDefault` are required.

Tested on K3s v1.33.4+k3s1 with `pod-security.kubernetes.io/enforce: 'restricted'`