### PR TITLE
feat: Add standalone and sentinel mode configuration for Valkey

### DIFF
--- a/valkey/README.md
+++ b/valkey/README.md
@@ -6,75 +6,160 @@ A Helm chart for Kubernetes
 
 **Homepage:** <https://valkey.io/valkey-helm/>
 
-## Values
+## Maintainers
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| affinity | object | `{}` |  |
-| auth.aclConfig | string | `"# Users and permissions can be defined here\n# Example:\n# user default off\n# user default on >defaultpassword ~*  &* +@all \n"` |  |
-| auth.enabled | bool | `false` |  |
-| dataStorage.accessModes[0] | string | `"ReadWriteOnce"` |  |
-| dataStorage.annotations | object | `{}` |  |
-| dataStorage.className | string | `nil` |  |
-| dataStorage.enabled | bool | `false` |  |
-| dataStorage.keepPvc | bool | `false` |  |
-| dataStorage.labels | object | `{}` |  |
-| dataStorage.persistentVolumeClaimName | string | `nil` |  |
-| dataStorage.requestedSize | string | `nil` |  |
-| dataStorage.volumeName | string | `"valkey-data"` |  |
-| deploymentStrategy | string | `RollingUpdate` | |
-| env | object | `{}` |  |
-| extraSecretValkeyConfigs | bool | `false` |  |
-| extraStorage | list | `[]` |  |
-| extraValkeyConfigs | list | `[]` |  |
-| extraValkeySecrets | list | `[]` |  |
-| fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"docker.io/valkey/valkey"` |  |
-| image.tag | string | `""` |  |
-| imagePullSecrets | list | `[]` |  |
-| ingress.annotations | object | `{}` |  |
-| ingress.className | string | `""` |  |
-| ingress.enabled | bool | `false` |  |
-| ingress.hosts[0].host | string | `"chart-example.local"` |  |
-| ingress.hosts[0].paths[0].path | string | `"/"` |  |
-| ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
-| ingress.tls | list | `[]` |  |
-| initResources | object | `{}` |  |
-| metrics.enabled | bool | `false` |  |
-| metrics.exporter.extraExporterSecrets | list | `[]` |  |
-| nameOverride | string | `""` |  |
-| networkPolicy | object | `{}` |  |
-| nodeSelector | object | `{}` |  |
-| podAnnotations | object | `{}` |  |
-| podLabels | object | `{}` |  |
-| podSecurityContext.fsGroup | int | `1000` |  |
-| podSecurityContext.runAsGroup | int | `1000` |  |
-| podSecurityContext.runAsUser | int | `1000` |  |
-| replicaCount | int | `1` |  |
-| resources | object | `{}` |  |
-| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| securityContext.readOnlyRootFilesystem | bool | `true` |  |
-| securityContext.runAsNonRoot | bool | `true` |  |
-| securityContext.runAsUser | int | `1000` |  |
-| service.port | int | `6379` |  |
-| service.type | string | `"ClusterIP"` |  |
-| service.nodePort | int | `0` |  |
-| serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.automount | bool | `false` |  |
-| serviceAccount.create | bool | `true` |  |
-| serviceAccount.name | string | `""` |  |
-| tolerations | list | `[]` |  |
-| valkeyConfig | string | `""` |  |
-| valkeyLogLevel | string | `"notice"` |  |
+| Name | Email | Url |
+| ---- | ------ | --- |
+| raven |  | <https://github.com/mk-raven> |
 
 ## Source Code
 
 * <https://github.com/valkey-io/valkey-helm.git>
 * <https://valkey.io>
 
-## Maintainers
+## Values
 
-| Name | Email | Url |
-| ---- | ------ | --- |
-| raven |  | <https://github.com/mk-raven> |
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| auth.acl.config | string | `""` |  |
+| auth.acl.enabled | bool | `false` |  |
+| auth.acl.existingSecret | string | `""` |  |
+| auth.acl.existingSecretKey | string | `"acl.conf"` |  |
+| auth.aclConfig | string | `"# Users and permissions can be defined here\n# Example:\n# user default off\n# user default on >defaultpassword ~*  &* +@all\n"` |  |
+| auth.enabled | bool | `false` |  |
+| auth.existingSecret | string | `""` |  |
+| auth.existingSecretPasswordKey | string | `"password"` |  |
+| auth.password | string | `""` |  |
+| backup.affinity | object | `{}` |  |
+| backup.annotations | object | `{}` |  |
+| backup.compression.enabled | bool | `true` |  |
+| backup.compression.level | int | `6` |  |
+| backup.enabled | bool | `false` |  |
+| backup.encryption.enabled | bool | `false` |  |
+| backup.encryption.gpgRecipient | string | `""` |  |
+| backup.extraEnv | list | `[]` |  |
+| backup.failedJobsHistoryLimit | int | `3` |  |
+| backup.image.pullPolicy | string | `"IfNotPresent"` |  |
+| backup.image.repository | string | `"amazon/aws-cli"` |  |
+| backup.image.tag | string | `"latest"` |  |
+| backup.labels | object | `{}` |  |
+| backup.nodeSelector | object | `{}` |  |
+| backup.resources.limits.cpu | string | `"500m"` |  |
+| backup.resources.limits.memory | string | `"512Mi"` |  |
+| backup.resources.requests.cpu | string | `"100m"` |  |
+| backup.resources.requests.memory | string | `"128Mi"` |  |
+| backup.retention.hourly | int | `240` |  |
+| backup.schedule | string | `"0 * * * *"` |  |
+| backup.storage.azure.container | string | `""` |  |
+| backup.storage.azure.existingSecret | string | `""` |  |
+| backup.storage.azure.prefix | string | `"backups/"` |  |
+| backup.storage.azure.storageAccount | string | `""` |  |
+| backup.storage.gcs.bucket | string | `""` |  |
+| backup.storage.gcs.existingSecret | string | `""` |  |
+| backup.storage.gcs.prefix | string | `"backups/"` |  |
+| backup.storage.gcs.projectId | string | `""` |  |
+| backup.storage.s3.accessKeyId | string | `""` |  |
+| backup.storage.s3.bucket | string | `""` |  |
+| backup.storage.s3.endpoint | string | `""` |  |
+| backup.storage.s3.existingSecret | string | `""` |  |
+| backup.storage.s3.pathStyle | bool | `false` |  |
+| backup.storage.s3.prefix | string | `"backups/"` |  |
+| backup.storage.s3.region | string | `"us-east-1"` |  |
+| backup.storage.s3.secretAccessKey | string | `""` |  |
+| backup.storage.type | string | `"s3"` |  |
+| backup.successfulJobsHistoryLimit | int | `3` |  |
+| backup.tolerations | list | `[]` |  |
+| dataStorage.accessModes[0] | string | `"ReadWriteOnce"` |  |
+| dataStorage.annotations | object | `{}` |  |
+| dataStorage.className | string | `""` |  |
+| dataStorage.enabled | bool | `false` |  |
+| dataStorage.keepPvc | bool | `false` |  |
+| dataStorage.labels | object | `{}` |  |
+| dataStorage.persistentVolumeClaimName | string | `""` |  |
+| dataStorage.requestedSize | string | `""` |  |
+| dataStorage.sentinelSize | string | `"1Gi"` |  |
+| dataStorage.volumeName | string | `"valkey-data"` |  |
+| deploymentStrategy | string | `"RollingUpdate"` |  |
+| env | object | `{}` |  |
+| extraContainers | list | `[]` |  |
+| extraInitContainers | list | `[]` |  |
+| extraSecretValkeyConfigs | bool | `false` |  |
+| extraStorage | list | `[]` |  |
+| extraValkeyConfigs | list | `[]` |  |
+| extraValkeySecrets | list | `[]` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"docker.io/valkey/valkey"` |  |
+| image.tag | string | `""` |  |
+| imagePullSecrets | list | `[]` |  |
+| initResources | object | `{}` |  |
+| logging.level | string | `"notice"` |  |
+| logging.slowlogLogSlowerThan | int | `10000` |  |
+| logging.slowlogMaxLen | int | `128` |  |
+| metrics.enabled | bool | `false` |  |
+| metrics.exporter.extraExporterSecrets | list | `[]` |  |
+| metrics.exporter.image.pullPolicy | string | `"IfNotPresent"` |  |
+| metrics.exporter.image.repository | string | `"oliver006/redis_exporter"` |  |
+| metrics.exporter.image.tag | string | `"v1.55.0"` |  |
+| metrics.exporter.resources | object | `{}` |  |
+| metrics.serviceMonitor.annotations | object | `{}` |  |
+| metrics.serviceMonitor.enabled | bool | `false` |  |
+| metrics.serviceMonitor.interval | string | `"30s"` |  |
+| metrics.serviceMonitor.labels | object | `{}` |  |
+| metrics.serviceMonitor.namespace | string | `""` |  |
+| nameOverride | string | `""` |  |
+| networkPolicy.annotations | object | `{}` |  |
+| networkPolicy.egress | list | `[]` |  |
+| networkPolicy.enabled | bool | `false` |  |
+| networkPolicy.ingress | list | `[]` |  |
+| networkPolicy.labels | object | `{}` |  |
+| networkPolicy.policyTypes | list | `[]` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podDisruptionBudget.enabled | bool | `false` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext.fsGroup | int | `1000` |  |
+| podSecurityContext.runAsGroup | int | `1000` |  |
+| podSecurityContext.runAsUser | int | `1000` |  |
+| replicaCount | int | `1` |  |
+| replication.antiAffinity.enabled | bool | `true` |  |
+| replication.antiAffinity.topologyKey | string | `"kubernetes.io/hostname"` |  |
+| replication.antiAffinity.type | string | `"hard"` |  |
+| replication.disklessSync | bool | `true` |  |
+| replication.disklessSyncDelay | int | `5` |  |
+| replication.minReplicas.maxLag | int | `10` |  |
+| replication.minReplicas.toWrite | int | `1` |  |
+| replication.readOnly | bool | `true` |  |
+| resources | object | `{}` |  |
+| securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| securityContext.runAsNonRoot | bool | `true` |  |
+| securityContext.runAsUser | int | `1000` |  |
+| sentinel | object | `{"affinity":{},"announce":{"enabled":true},"antiAffinity":{"enabled":true,"topologyKey":"kubernetes.io/hostname","type":"hard"},"auth":{"enabled":false,"existingSecret":"","existingSecretPasswordKey":"sentinel-password","password":""},"customConfig":"","downAfterMilliseconds":30000,"enabled":false,"failoverTimeout":180000,"image":{"pullPolicy":"","repository":"","tag":""},"nodeSelector":{},"parallelSyncs":1,"port":26379,"quorum":2,"replicas":3,"resources":{},"tolerations":[]}` | --------------------------------------------------------------------------- |
+| service.annotations | object | `{}` |  |
+| service.labels | object | `{}` |  |
+| service.nodePort | int | `0` |  |
+| service.port | int | `6379` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.automount | bool | `false` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| standalone | object | `{"enabled":true}` | --------------------------------------------------------------------------- |
+| tls.certCAFilename | string | `"ca.crt"` |  |
+| tls.certFilename | string | `"tls.crt"` |  |
+| tls.certKeyFilename | string | `"tls.key"` |  |
+| tls.certificatesSecret | string | `""` |  |
+| tls.enabled | bool | `false` |  |
+| tolerations | list | `[]` |  |
+| topologySpreadConstraints | list | `[]` |  |
+| updateStrategy.rollingUpdate.maxUnavailable | int | `1` |  |
+| updateStrategy.type | string | `"RollingUpdate"` |  |
+| valkeyConfig | string | `""` |  |
+| valkeyLogLevel | string | `"notice"` |  |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/valkey/templates/NOTES.txt
+++ b/valkey/templates/NOTES.txt
@@ -9,59 +9,139 @@ Release:      {{ .Release.Name }}
 Namespace:    {{ .Release.Namespace }}
 Chart:        {{ .Chart.Name }} {{ .Chart.Version }}
 App version:  {{ .Chart.AppVersion }}
+{{- if .Values.standalone.enabled }}
+Mode:         Standalone
+{{- else if .Values.sentinel.enabled }}
+Mode:         Sentinel (High Availability)
+{{- end }}
+
+{{- if .Values.standalone.enabled }}
+===============================================================================
+STANDALONE MODE
+===============================================================================
 
 Service:      {{ include "valkey.fullname" . }}
 Type:         {{ .Values.service.type }}
 Port:         {{ .Values.service.port }}
+Replicas:     {{ .Values.replicaCount }}
 
 1) In-cluster access
    From another Pod:
-   $ valkey-cli -h {{ include "valkey.fullname" . }} -p {{ .Values.service.port }} PING
+   $ valkey-cli -h {{ include "valkey.fullname" . }} -p {{ .Values.service.port }}{{ if .Values.auth.enabled }} -a <password>{{ end }} PING
 
 2) Local access via kubectl port-forward
    $ kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "valkey.fullname" . }} 6379:{{ .Values.service.port }}
    In another terminal:
-   $ valkey-cli -h 127.0.0.1 -p 6379 PING
+   $ valkey-cli -h 127.0.0.1 -p 6379{{ if .Values.auth.enabled }} -a <password>{{ end }} PING
 
 {{ if eq .Values.service.type "LoadBalancer" }}
 3) External access (LoadBalancer)
    $ export SERVICE_IP=$(kubectl -n {{ .Release.Namespace }} get svc {{ include "valkey.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-   $ valkey-cli -h $SERVICE_IP -p {{ .Values.service.port }} PING
+   $ valkey-cli -h $SERVICE_IP -p {{ .Values.service.port }}{{ if .Values.auth.enabled }} -a <password>{{ end }} PING
 {{ else if eq .Values.service.type "NodePort" }}
 3) External access (NodePort)
    $ export NODE_PORT=$(kubectl -n {{ .Release.Namespace }} get svc {{ include "valkey.fullname" . }} -o jsonpath='{.spec.ports[0].nodePort}')
    $ export NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
-   $ valkey-cli -h $NODE_IP -p $NODE_PORT PING
+   $ valkey-cli -h $NODE_IP -p $NODE_PORT{{ if .Values.auth.enabled }} -a <password>{{ end }} PING
 {{ end }}
+{{- end }}
 
+{{- if .Values.sentinel.enabled }}
+===============================================================================
+SENTINEL MODE (High Availability)
+===============================================================================
+
+Valkey Service:    {{ include "valkey.fullname" . }}
+Sentinel Service:  {{ include "valkey.fullname" . }}-sentinel
+Sentinels:         {{ .Values.replicaCount }}
+Valkey Replicas:   {{ .Values.replicaCount }} (1 primary + {{ sub .Values.replicaCount 1 }} replicas)
+Quorum:            {{ .Values.sentinel.quorum }}
+
+🔍 CONNECTING TO VALKEY (via Sentinel)
+
+1) Discover current primary using Sentinel
+   $ kubectl -n {{ .Release.Namespace }} exec -it {{ include "valkey.fullname" . }}-sentinel-0 -- \
+     valkey-cli -p 26379{{ if .Values.sentinel.auth.enabled }} -a <sentinel-password>{{ end }} \
+     SENTINEL get-master-addr-by-name {{ include "valkey.fullname" . }}
+
+2) Connect to primary (clients should use Sentinel for discovery)
+   Application configuration:
+   - Sentinel endpoints: {{ include "valkey.fullname" . }}-sentinel:26379
+   - Primary name: {{ include "valkey.fullname" . }}
+   {{- if .Values.auth.enabled }}
+   - Password: <your-valkey-password>
+   {{- end }}
+
+3) Manual connection to current primary
+   First find the primary:
+   $ PRIMARY=$(kubectl -n {{ .Release.Namespace }} exec {{ include "valkey.fullname" . }}-sentinel-0 -- \
+     valkey-cli -p 26379{{ if .Values.sentinel.auth.enabled }} -a <sentinel-password>{{ end }} \
+     SENTINEL get-master-addr-by-name {{ include "valkey.fullname" . }} | head -1)
+
+   Then connect:
+   $ kubectl -n {{ .Release.Namespace }} exec -it {{ include "valkey.fullname" . }}-0 -- \
+     valkey-cli -h $PRIMARY -p 6379{{ if .Values.auth.enabled }} -a <password>{{ end }} PING
+
+4) Port-forward to Sentinel (for client testing)
+   $ kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "valkey.fullname" . }}-sentinel 26379:26379
+
+📊 MONITORING SENTINEL
+
+Check Sentinel status:
+$ kubectl -n {{ .Release.Namespace }} exec -it {{ include "valkey.fullname" . }}-sentinel-0 -- \
+  valkey-cli -p 26379{{ if .Values.sentinel.auth.enabled }} -a <sentinel-password>{{ end }} SENTINEL masters
+
+Check replicas:
+$ kubectl -n {{ .Release.Namespace }} exec -it {{ include "valkey.fullname" . }}-sentinel-0 -- \
+  valkey-cli -p 26379{{ if .Values.sentinel.auth.enabled }} -a <sentinel-password>{{ end }} SENTINEL replicas {{ include "valkey.fullname" . }}
+
+Check Sentinels:
+$ kubectl -n {{ .Release.Namespace }} exec -it {{ include "valkey.fullname" . }}-sentinel-0 -- \
+  valkey-cli -p 26379{{ if .Values.sentinel.auth.enabled }} -a <sentinel-password>{{ end }} SENTINEL sentinels {{ include "valkey.fullname" . }}
+
+🔄 TESTING FAILOVER
+
+Manual failover:
+$ kubectl -n {{ .Release.Namespace }} exec -it {{ include "valkey.fullname" . }}-sentinel-0 -- \
+  valkey-cli -p 26379{{ if .Values.sentinel.auth.enabled }} -a <sentinel-password>{{ end }} SENTINEL failover {{ include "valkey.fullname" . }}
+
+Simulate primary failure:
+$ kubectl -n {{ .Release.Namespace }} delete pod {{ include "valkey.fullname" . }}-0
+{{- end }}
+
+===============================================================================
 {{ if .Values.auth.enabled }}
-🔐 Authentication is ENABLED (ACL)
-- Provide the username and password from `.auth.aclConfig`.
-- Default user:
-  $ valkey-cli -h {{ include "valkey.fullname" . }} -p {{ .Values.service.port }} -a <password> PING
-- Named user:
-  $ valkey-cli -h {{ include "valkey.fullname" . }} -p {{ .Values.service.port }} --user <user> -a <password> PING
+🔐 Authentication is ENABLED
+{{- if .Values.auth.existingSecret }}
+- Password stored in secret: {{ .Values.auth.existingSecret }}
+{{- else }}
+- Password: {{ .Values.auth.password }}
+{{- end }}
 {{ else }}
 🔓 Authentication is DISABLED
-- Enable with: `--set auth.enabled=true` and provide `.auth.aclConfig`.
+- Enable with: `--set auth.enabled=true --set auth.password=<secure-password>`
 {{ end }}
-
-✅ Quick test
-$ valkey-cli -h {{ include "valkey.fullname" . }} -p {{ .Values.service.port }}{{ if .Values.auth.enabled }} --user <user> -a <password>{{ end }}
-valkey> SET foo bar
-valkey> GET foo
-"bar"
 
 {{ if .Values.dataStorage.enabled }}
-💾 Persistence
-- A PVC is enabled. To see it:
-  $ kubectl -n {{ .Release.Namespace }} get pvc -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/name={{ include "valkey.name" . }}
-- Note: `dataStorage.keepPvc={{ .Values.dataStorage.keepPvc }}` controls whether the PVC is kept on uninstall.
+💾 Persistence is ENABLED
+- View PVCs:
+  $ kubectl -n {{ .Release.Namespace }} get pvc -l app.kubernetes.io/instance={{ .Release.Name }}
+{{- if .Values.dataStorage.requestedSize }}
+- Size: {{ .Values.dataStorage.requestedSize }}
+{{- end }}
+- Keep on delete: {{ .Values.dataStorage.keepPvc }}
 {{ else }}
-💾 Persistence
-- Persistence is DISABLED. Data will not survive Pod restarts.
-- Enable with: `--set dataStorage.enabled=true --set dataStorage.requestedSize=5Gi` (optionally set `dataStorage.className`).
+💾 Persistence is DISABLED
+- Data will not survive Pod restarts
+- Enable with: `--set dataStorage.enabled=true --set dataStorage.requestedSize=10Gi`
 {{ end }}
 
+===============================================================================
 🧹 Uninstall
 $ helm -n {{ .Release.Namespace }} uninstall {{ .Release.Name }}
+
+📚 Documentation
+- Valkey: https://valkey.io/docs/
+{{- if .Values.sentinel.enabled }}
+- Sentinel: https://valkey.io/topics/sentinel/
+{{- end }}

--- a/valkey/templates/_validation.tpl
+++ b/valkey/templates/_validation.tpl
@@ -1,0 +1,58 @@
+{{/*
+Validate deployment mode configuration
+Only ONE mode should be enabled at a time
+*/}}
+{{- define "valkey.validateMode" -}}
+{{- $enabledModes := list -}}
+{{- if .Values.standalone.enabled -}}
+  {{- $enabledModes = append $enabledModes "standalone" -}}
+{{- end -}}
+{{- if .Values.sentinel.enabled -}}
+  {{- $enabledModes = append $enabledModes "sentinel" -}}
+{{- end -}}
+{{- if gt (len $enabledModes) 1 -}}
+  {{- fail (printf "ERROR: Multiple deployment modes enabled: %s. Only ONE mode can be enabled at a time. Please set only one of standalone.enabled or sentinel.enabled to true." (join ", " $enabledModes)) -}}
+{{- end -}}
+{{- if eq (len $enabledModes) 0 -}}
+  {{- fail "ERROR: No deployment mode enabled. Please set either standalone.enabled=true or sentinel.enabled=true." -}}
+{{- end -}}
+{{- if .Values.sentinel.enabled -}}
+  {{- if lt (int .Values.replicaCount) 3 -}}
+    {{- fail (printf "ERROR: Sentinel mode requires at least 3 Valkey replicas for high availability. Current replicaCount is %d. Please set replicaCount to at least 3." (int .Values.replicaCount)) -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate ServiceMonitor CRD availability
+Check if Prometheus Operator CRDs are installed when ServiceMonitor is enabled
+*/}}
+{{- define "valkey.validateServiceMonitor" -}}
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled -}}
+  {{- if not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") -}}
+    {{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor" -}}
+      {{/* CRD exists, continue */}}
+    {{- else -}}
+      {{- fail "ERROR: ServiceMonitor is enabled but the Prometheus Operator CRDs are not installed. Please install Prometheus Operator first:\n  kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/bundle.yaml\nOr disable ServiceMonitor:\n  --set metrics.serviceMonitor.enabled=false" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate VolumeSnapshot CRD availability (for future use)
+Check if VolumeSnapshot CRDs are installed when volume snapshots are enabled
+*/}}
+{{- define "valkey.validateVolumeSnapshot" -}}
+{{- if .Values.volumeSnapshots -}}
+  {{- if .Values.volumeSnapshots.enabled -}}
+    {{- if not (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1") -}}
+      {{- if .Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1/VolumeSnapshot" -}}
+        {{/* CRD exists, continue */}}
+      {{- else -}}
+        {{- fail "ERROR: VolumeSnapshot is enabled but the snapshot.storage.k8s.io CRDs are not installed. Please install the volume snapshot CRDs:\n  kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml\nOr disable volume snapshots:\n  --set volumeSnapshots.enabled=false" -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/valkey/templates/auth.yaml
+++ b/valkey/templates/auth.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.auth.enabled (not .Values.auth.existingSecret) .Values.auth.password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "valkey.fullname" . }}-auth
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  password: {{ .Values.auth.password | quote }}
+{{- end }}

--- a/valkey/templates/backup-cronjob.yaml
+++ b/valkey/templates/backup-cronjob.yaml
@@ -1,0 +1,395 @@
+{{- if .Values.backup.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "valkey.fullname" . }}-backup
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+    {{- with .Values.backup.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.backup.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    metadata:
+      labels:
+        {{- include "valkey.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: backup
+    spec:
+      backoffLimit: 3
+      template:
+        metadata:
+          labels:
+            {{- include "valkey.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: backup
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: {{ include "valkey.serviceAccountName" . }}
+
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          {{- with .Values.backup.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          {{- with .Values.backup.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          {{- with .Values.backup.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          containers:
+          - name: backup
+            image: "{{ .Values.backup.image.repository }}:{{ .Values.backup.image.tag }}"
+            imagePullPolicy: {{ .Values.backup.image.pullPolicy }}
+
+            command:
+            - /bin/sh
+            - -c
+            - |
+              set -euo pipefail
+
+              echo "========================================"
+              echo "Valkey Backup Job Started"
+              echo "Timestamp: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+              echo "========================================"
+
+              # Generate backup filename with timestamp
+              TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+              BACKUP_NAME="valkey-backup-${TIMESTAMP}.rdb"
+              BACKUP_PATH="/tmp/${BACKUP_NAME}"
+
+              echo ""
+              echo "Step 1: Triggering RDB snapshot..."
+
+              {{- if .Values.auth.enabled }}
+              # Trigger BGSAVE with authentication
+              if ! valkey-cli -h {{ include "valkey.fullname" . }} -p {{ .Values.service.port }} \
+                {{- if .Values.tls.enabled }}
+                --tls \
+                --cacert /tls/{{ .Values.tls.certCAFilename }} \
+                {{- end }}
+                -a "${VALKEY_PASSWORD}" BGSAVE; then
+                echo "ERROR: Failed to trigger BGSAVE"
+                exit 1
+              fi
+              {{- else }}
+              # Trigger BGSAVE without authentication
+              if ! valkey-cli -h {{ include "valkey.fullname" . }} -p {{ .Values.service.port }} \
+                {{- if .Values.tls.enabled }}
+                --tls \
+                --cacert /tls/{{ .Values.tls.certCAFilename }} \
+                {{- end }}
+                BGSAVE; then
+                echo "ERROR: Failed to trigger BGSAVE"
+                exit 1
+              fi
+              {{- end }}
+
+              echo "BGSAVE triggered successfully"
+
+              echo ""
+              echo "Step 2: Waiting for snapshot to complete..."
+
+              # Wait for BGSAVE to complete (check every 2 seconds, timeout after 5 minutes)
+              TIMEOUT=150
+              ELAPSED=0
+              while [ $ELAPSED -lt $TIMEOUT ]; do
+                {{- if .Values.auth.enabled }}
+                SAVE_STATUS=$(valkey-cli -h {{ include "valkey.fullname" . }} -p {{ .Values.service.port }} \
+                  {{- if .Values.tls.enabled }}
+                  --tls \
+                  --cacert /tls/{{ .Values.tls.certCAFilename }} \
+                  {{- end }}
+                  -a "${VALKEY_PASSWORD}" INFO persistence | grep rdb_bgsave_in_progress | cut -d: -f2 | tr -d '\r')
+                {{- else }}
+                SAVE_STATUS=$(valkey-cli -h {{ include "valkey.fullname" . }} -p {{ .Values.service.port }} \
+                  {{- if .Values.tls.enabled }}
+                  --tls \
+                  --cacert /tls/{{ .Values.tls.certCAFilename }} \
+                  {{- end }}
+                  INFO persistence | grep rdb_bgsave_in_progress | cut -d: -f2 | tr -d '\r')
+                {{- end }}
+
+                if [ "$SAVE_STATUS" = "0" ]; then
+                  echo "Snapshot completed!"
+                  break
+                fi
+
+                sleep 2
+                ELAPSED=$((ELAPSED + 2))
+
+                if [ $((ELAPSED % 10)) -eq 0 ]; then
+                  echo "Still waiting... (${ELAPSED}s elapsed)"
+                fi
+              done
+
+              if [ $ELAPSED -ge $TIMEOUT ]; then
+                echo "ERROR: Snapshot timeout after ${TIMEOUT} seconds"
+                exit 1
+              fi
+
+              echo ""
+              echo "Step 3: Copying RDB file from primary pod..."
+
+              # Copy RDB file from the primary Valkey pod
+              if [ -f /data/dump.rdb ]; then
+                cp /data/dump.rdb "${BACKUP_PATH}"
+                echo "RDB file copied successfully ($(du -h ${BACKUP_PATH} | cut -f1))"
+              else
+                echo "ERROR: RDB file not found at /data/dump.rdb"
+                exit 1
+              fi
+
+              {{- if .Values.backup.compression.enabled }}
+              echo ""
+              echo "Step 4: Compressing backup..."
+              gzip -{{ .Values.backup.compression.level }} "${BACKUP_PATH}"
+              BACKUP_PATH="${BACKUP_PATH}.gz"
+              echo "Compression completed ($(du -h ${BACKUP_PATH} | cut -f1))"
+              {{- end }}
+
+              {{- if .Values.backup.encryption.enabled }}
+              echo ""
+              echo "Step 5: Encrypting backup..."
+              gpg --batch --yes --recipient {{ .Values.backup.encryption.gpgRecipient }} \
+                --encrypt "${BACKUP_PATH}"
+              rm "${BACKUP_PATH}"
+              BACKUP_PATH="${BACKUP_PATH}.gpg"
+              echo "Encryption completed"
+              {{- end }}
+
+              echo ""
+              echo "Step 6: Uploading to {{ .Values.backup.storage.type }} storage..."
+
+              {{- if or (eq .Values.backup.storage.type "s3") (eq .Values.backup.storage.type "minio") }}
+              # S3/MinIO upload
+              {{- if .Values.backup.storage.s3.endpoint }}
+              # Configure custom endpoint for MinIO or S3-compatible storage
+              aws configure set default.s3.endpoint_url {{ .Values.backup.storage.s3.endpoint }}
+              {{- if .Values.backup.storage.s3.pathStyle }}
+              aws configure set default.s3.addressing_style path
+              {{- end }}
+              {{- end }}
+
+              S3_PATH="s3://{{ .Values.backup.storage.s3.bucket }}/{{ .Values.backup.storage.s3.prefix }}$(basename ${BACKUP_PATH})"
+
+              if aws s3 cp "${BACKUP_PATH}" "${S3_PATH}" \
+                --region {{ .Values.backup.storage.s3.region }} \
+                --server-side-encryption AES256; then
+                echo "Upload successful: ${S3_PATH}"
+              else
+                echo "ERROR: Failed to upload backup to S3"
+                exit 1
+              fi
+
+              # Verify upload
+              if aws s3 ls "${S3_PATH}" --region {{ .Values.backup.storage.s3.region }} > /dev/null 2>&1; then
+                echo "Backup verified in S3"
+              else
+                echo "ERROR: Backup verification failed"
+                exit 1
+              fi
+
+              {{- else if eq .Values.backup.storage.type "gcs" }}
+              # GCS upload
+              GCS_PATH="gs://{{ .Values.backup.storage.gcs.bucket }}/{{ .Values.backup.storage.gcs.prefix }}$(basename ${BACKUP_PATH})"
+
+              if gsutil cp "${BACKUP_PATH}" "${GCS_PATH}"; then
+                echo "Upload successful: ${GCS_PATH}"
+              else
+                echo "ERROR: Failed to upload backup to GCS"
+                exit 1
+              fi
+
+              {{- else if eq .Values.backup.storage.type "azure" }}
+              # Azure Blob upload
+              AZURE_PATH="{{ .Values.backup.storage.azure.prefix }}$(basename ${BACKUP_PATH})"
+
+              if az storage blob upload \
+                --account-name {{ .Values.backup.storage.azure.storageAccount }} \
+                --container-name {{ .Values.backup.storage.azure.container }} \
+                --name "${AZURE_PATH}" \
+                --file "${BACKUP_PATH}"; then
+                echo "Upload successful: ${AZURE_PATH}"
+              else
+                echo "ERROR: Failed to upload backup to Azure"
+                exit 1
+              fi
+              {{- end }}
+
+              echo ""
+              echo "Step 7: Cleanup old backups (retention policy)..."
+
+              {{- if or (eq .Values.backup.storage.type "s3") (eq .Values.backup.storage.type "minio") }}
+              # Keep only the last N backups based on retention policy
+              RETENTION_COUNT={{ .Values.backup.retention.hourly }}
+
+              echo "Retention policy: Keep last ${RETENTION_COUNT} backups"
+
+              # List all backups, sort by date (newest first), and delete old ones
+              BACKUP_COUNT=$(aws s3 ls s3://{{ .Values.backup.storage.s3.bucket }}/{{ .Values.backup.storage.s3.prefix }} \
+                --region {{ .Values.backup.storage.s3.region }} | \
+                grep "valkey-backup-" | \
+                wc -l)
+
+              echo "Current backup count: ${BACKUP_COUNT}"
+
+              if [ "${BACKUP_COUNT}" -gt "${RETENTION_COUNT}" ]; then
+                TO_DELETE=$((BACKUP_COUNT - RETENTION_COUNT))
+                echo "Deleting ${TO_DELETE} old backup(s)..."
+
+                aws s3 ls s3://{{ .Values.backup.storage.s3.bucket }}/{{ .Values.backup.storage.s3.prefix }} \
+                  --region {{ .Values.backup.storage.s3.region }} | \
+                  grep "valkey-backup-" | \
+                  sort | \
+                  head -n ${TO_DELETE} | \
+                  awk '{print $4}' | \
+                  while read -r old_backup; do
+                    if [ -n "${old_backup}" ]; then
+                      echo "  Deleting: ${old_backup}"
+                      aws s3 rm "s3://{{ .Values.backup.storage.s3.bucket }}/{{ .Values.backup.storage.s3.prefix }}${old_backup}" \
+                        --region {{ .Values.backup.storage.s3.region }} || echo "  Warning: Failed to delete ${old_backup}"
+                    fi
+                  done
+                echo "Cleanup completed"
+              else
+                echo "No cleanup needed (${BACKUP_COUNT} <= ${RETENTION_COUNT})"
+              fi
+              {{- end }}
+
+              echo ""
+              echo "========================================"
+              echo "Backup Job Completed Successfully!"
+              echo "Backup: $(basename ${BACKUP_PATH})"
+              echo "Size: $(du -h ${BACKUP_PATH} 2>/dev/null | cut -f1 || echo 'N/A')"
+              echo "Timestamp: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+              echo "========================================"
+
+            env:
+            {{- if .Values.auth.enabled }}
+            - name: VALKEY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.auth.existingSecret }}
+                  name: {{ .Values.auth.existingSecret }}
+                  key: {{ .Values.auth.existingSecretPasswordKey }}
+                  {{- else }}
+                  name: {{ include "valkey.fullname" . }}-auth
+                  key: password
+                  {{- end }}
+            {{- end }}
+
+            {{- if or (eq .Values.backup.storage.type "s3") (eq .Values.backup.storage.type "minio") }}
+            - name: AWS_REGION
+              value: {{ .Values.backup.storage.s3.region | quote }}
+
+            {{- if .Values.backup.storage.s3.existingSecret }}
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.backup.storage.s3.existingSecret }}
+                  key: access-key-id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.backup.storage.s3.existingSecret }}
+                  key: secret-access-key
+            {{- else if .Values.backup.storage.s3.accessKeyId }}
+            - name: AWS_ACCESS_KEY_ID
+              value: {{ .Values.backup.storage.s3.accessKeyId | quote }}
+            - name: AWS_SECRET_ACCESS_KEY
+              value: {{ .Values.backup.storage.s3.secretAccessKey | quote }}
+            {{- end }}
+            {{- end }}
+
+            {{- if eq .Values.backup.storage.type "gcs" }}
+            {{- if .Values.backup.storage.gcs.existingSecret }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /secrets/gcs/service-account.json
+            {{- end }}
+            - name: GCP_PROJECT_ID
+              value: {{ .Values.backup.storage.gcs.projectId | quote }}
+            {{- end }}
+
+            {{- if eq .Values.backup.storage.type "azure" }}
+            {{- if .Values.backup.storage.azure.existingSecret }}
+            - name: AZURE_STORAGE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.backup.storage.azure.existingSecret }}
+                  key: storage-account-key
+            {{- end }}
+            {{- end }}
+
+            {{- with .Values.backup.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+            volumeMounts:
+            - name: data
+              mountPath: /data
+              readOnly: true
+
+            {{- if .Values.tls.enabled }}
+            - name: tls
+              mountPath: /tls
+              readOnly: true
+            {{- end }}
+
+            {{- if and (eq .Values.backup.storage.type "gcs") .Values.backup.storage.gcs.existingSecret }}
+            - name: gcs-credentials
+              mountPath: /secrets/gcs
+              readOnly: true
+            {{- end }}
+
+            {{- with .Values.backup.resources }}
+            resources:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+
+          volumes:
+          - name: data
+            persistentVolumeClaim:
+              {{- if .Values.sentinel.enabled }}
+              claimName: data-{{ include "valkey.fullname" . }}-0
+              {{- else }}
+              {{- if .Values.persistence.enabled }}
+              {{- if .Values.persistence.existingClaim }}
+              claimName: {{ .Values.persistence.existingClaim }}
+              {{- else }}
+              claimName: data-{{ include "valkey.fullname" . }}-0
+              {{- end }}
+              {{- else }}
+              emptyDir: {}
+              {{- end }}
+              {{- end }}
+
+          {{- if .Values.tls.enabled }}
+          - name: tls
+            secret:
+              secretName: {{ .Values.tls.certificatesSecret }}
+          {{- end }}
+
+          {{- if and (eq .Values.backup.storage.type "gcs") .Values.backup.storage.gcs.existingSecret }}
+          - name: gcs-credentials
+            secret:
+              secretName: {{ .Values.backup.storage.gcs.existingSecret }}
+          {{- end }}
+{{- end }}

--- a/valkey/templates/configmap.yaml
+++ b/valkey/templates/configmap.yaml
@@ -9,3 +9,109 @@ data:
   valkey.conf: |
     {{- .Values.valkeyConfig | nindent 4 }}
 {{- end }}
+---
+{{- if .Values.sentinel.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "valkey.fullname" . }}-valkey-base-config
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+    app.kubernetes.io/component: valkey
+data:
+  valkey.conf: |
+    # Network
+    port 6379
+    bind 0.0.0.0
+    protected-mode no
+
+    # Directories
+    dir /data
+
+    # Logging
+    loglevel {{ .Values.logging.level }}
+    logfile ""
+
+    # Slowlog
+    slowlog-log-slower-than {{ .Values.logging.slowlogLogSlowerThan }}
+    slowlog-max-len {{ .Values.logging.slowlogMaxLen }}
+
+    {{- if .Values.persistence.enabled }}
+    # Persistence
+    save 900 1
+    save 300 10
+    save 60 10000
+    appendonly yes
+    appendfsync everysec
+    {{- end }}
+
+    {{- if .Values.auth.enabled }}
+    # Authentication
+    {{- if .Values.auth.existingSecret }}
+    requirepass "PLACEHOLDER"
+    masterauth "PLACEHOLDER"
+    {{- else }}
+    requirepass {{ .Values.auth.password | quote }}
+    masterauth {{ .Values.auth.password | quote }}
+    {{- end }}
+    {{- end }}
+
+    # Replication
+    replica-read-only {{ if .Values.replication.readOnly }}yes{{ else }}no{{ end }}
+    min-replicas-to-write {{ .Values.replication.minReplicas.toWrite }}
+    min-replicas-max-lag {{ .Values.replication.minReplicas.maxLag }}
+
+    {{- if .Values.replication.disklessSync }}
+    repl-diskless-sync yes
+    repl-diskless-sync-delay {{ .Values.replication.disklessSyncDelay }}
+    {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "valkey.fullname" . }}-sentinel-base-config
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sentinel
+data:
+  sentinel.conf: |
+    # Sentinel port
+    port 26379
+    bind 0.0.0.0
+
+    # Monitoring
+    # Note: Primary host will be resolved to IP by init script
+    sentinel monitor {{ include "valkey.fullname" . }} PRIMARY_HOST_PLACEHOLDER 6379 {{ .Values.sentinel.quorum }}
+
+    # Timings
+    sentinel down-after-milliseconds {{ include "valkey.fullname" . }} {{ .Values.sentinel.downAfterMilliseconds }}
+    sentinel failover-timeout {{ include "valkey.fullname" . }} {{ .Values.sentinel.failoverTimeout }}
+    sentinel parallel-syncs {{ include "valkey.fullname" . }} {{ .Values.sentinel.parallelSyncs }}
+
+    {{- if .Values.auth.enabled }}
+    # Valkey authentication
+    {{- if .Values.auth.existingSecret }}
+    sentinel auth-pass {{ include "valkey.fullname" . }} "PLACEHOLDER"
+    {{- else }}
+    sentinel auth-pass {{ include "valkey.fullname" . }} {{ .Values.auth.password | quote }}
+    {{- end }}
+    {{- end }}
+
+    {{- if .Values.sentinel.auth.enabled }}
+    # Sentinel authentication
+    {{- if .Values.sentinel.auth.existingSecret }}
+    requirepass "PLACEHOLDER"
+    {{- else }}
+    requirepass {{ .Values.sentinel.auth.password | quote }}
+    {{- end }}
+    {{- end }}
+
+    # Logging
+    loglevel {{ .Values.logging.level }}
+    logfile ""
+
+    {{- if .Values.sentinel.customConfig }}
+    # Custom configuration
+    {{ .Values.sentinel.customConfig | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -1,3 +1,5 @@
+{{- include "valkey.validateMode" . }}
+{{- if .Values.standalone.enabled }}
 {{- $fullname := include "valkey.fullname" . }}
 {{- $storage := .Values.dataStorage }}
 {{- $createPVC := and $storage.enabled (not (empty $storage.requestedSize)) (empty $storage.persistentVolumeClaimName) }}
@@ -105,6 +107,43 @@ spec:
             - name: {{ $config.name }}-valkey
               mountPath: {{ $config.mountPath }}
             {{- end }}
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          image: "{{ .Values.metrics.exporter.image.repository }}:{{ .Values.metrics.exporter.image.tag }}"
+          imagePullPolicy: {{ .Values.metrics.exporter.image.pullPolicy }}
+          ports:
+            - name: metrics
+              containerPort: 9121
+              protocol: TCP
+          env:
+            - name: REDIS_ADDR
+              value: "redis://localhost:6379"
+            {{- if .Values.auth.enabled }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.auth.existingSecret }}
+                  name: {{ .Values.auth.existingSecret }}
+                  key: {{ .Values.auth.existingSecretPasswordKey }}
+                  {{- else }}
+                  name: {{ include "valkey.fullname" . }}-auth
+                  key: password
+                  {{- end }}
+            {{- end }}
+          {{- range .Values.metrics.exporter.extraExporterSecrets }}
+          volumeMounts:
+            - name: {{ .name }}-exporter
+              mountPath: {{ .mountPath }}
+              readOnly: true
+          {{- end }}
+          {{- with .Values.metrics.exporter.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       volumes:
         - name: scripts
           configMap:
@@ -164,3 +203,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
 data:
+  {{- if .Values.standalone.enabled }}
   init.sh: |-
     #!/bin/sh
     set -euo pipefail
@@ -31,9 +32,8 @@ data:
 
     log "Creating configuration in $DATA_DIR..."
     mkdir -p "$DATA_DIR"
-    rm -f "$VALKEY_CONFIG" 
+    rm -f "$VALKEY_CONFIG"
 
- 
     # Base valkey.conf
     log "Generating base valkey.conf"
     {
@@ -59,4 +59,88 @@ data:
       log "Appending files in /extravalkeyconfigs/"
       cat /extravalkeyconfigs/* >>"$VALKEY_CONFIG"
     fi
+  {{- end }}
+
+  {{- if .Values.sentinel.enabled }}
+  init-valkey.sh: |-
+    #!/bin/bash
+    set -euo pipefail
+
+    HOSTNAME=$(hostname)
+    POD_INDEX=${HOSTNAME##*-}
+    PRIMARY_HOST="{{ include "valkey.fullname" . }}-0.{{ include "valkey.fullname" . }}-headless.{{ .Release.Namespace }}.svc.cluster.local"
+
+    echo "Initializing Valkey on $HOSTNAME (pod index: $POD_INDEX)"
+
+    # Copy base config
+    cp /config-base/valkey.conf /data/valkey.conf
+
+    # Determine role and configure replication
+    if [ "$POD_INDEX" = "0" ]; then
+      echo "Configured as INITIAL PRIMARY"
+    else
+      echo "Configured as REPLICA of $PRIMARY_HOST"
+      echo "replicaof $PRIMARY_HOST 6379" >> /data/valkey.conf
+    fi
+
+    # Kubernetes announcements
+    ANNOUNCE_IP=$(hostname -i)
+    cat <<EOF >> /data/valkey.conf
+    replica-announce-ip $ANNOUNCE_IP
+    replica-announce-port 6379
+    EOF
+
+    {{- if .Values.valkeyConfig }}
+    # Custom config
+    cat <<'CUSTOM_EOF' >> /data/valkey.conf
+    {{ .Values.valkeyConfig }}
+    CUSTOM_EOF
+    {{- end }}
+
+    echo "Valkey configuration complete"
+
+  init-sentinel.sh: |-
+    #!/bin/bash
+    set -euo pipefail
+
+    HOSTNAME=$(hostname)
+    PRIMARY_HOST="{{ include "valkey.fullname" . }}-0.{{ include "valkey.fullname" . }}-headless.{{ .Release.Namespace }}.svc.cluster.local"
+
+    echo "Initializing Sentinel on $HOSTNAME"
+
+    # Copy base config
+    cp /config-base/sentinel.conf /data/sentinel.conf
+
+    # Resolve primary host to IP (required for Sentinel to start)
+    echo "Resolving primary host: $PRIMARY_HOST"
+    PRIMARY_IP=""
+    for i in {1..30}; do
+      PRIMARY_IP=$(getent hosts "$PRIMARY_HOST" | awk '{print $1}' | head -n1)
+      if [ -n "$PRIMARY_IP" ]; then
+        echo "Resolved $PRIMARY_HOST to $PRIMARY_IP"
+        break
+      fi
+      echo "Waiting for primary DNS resolution... (attempt $i/30)"
+      sleep 2
+    done
+
+    if [ -z "$PRIMARY_IP" ]; then
+      echo "ERROR: Failed to resolve primary host $PRIMARY_HOST"
+      exit 1
+    fi
+
+    # Replace placeholder with actual IP
+    sed -i "s/PRIMARY_HOST_PLACEHOLDER/$PRIMARY_IP/g" /data/sentinel.conf
+
+    {{- if .Values.sentinel.announce.enabled }}
+    # Kubernetes announcements (critical for Sentinel)
+    ANNOUNCE_IP=$(hostname -i)
+    cat <<EOF >> /data/sentinel.conf
+    sentinel announce-ip $ANNOUNCE_IP
+    sentinel announce-port 26379
+    EOF
+    {{- end }}
+
+    echo "Sentinel configuration complete"
+  {{- end }}
 

--- a/valkey/templates/service.yaml
+++ b/valkey/templates/service.yaml
@@ -1,9 +1,13 @@
+{{- if .Values.standalone.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "valkey.fullname" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
+  {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -18,5 +22,133 @@ spec:
       {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
+    {{- if .Values.metrics.enabled }}
+    - port: 9121
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+    {{- end }}
   selector:
     {{- include "valkey.selectorLabels" . | nindent 4 }}
+{{- end }}
+---
+{{- if .Values.sentinel.enabled }}
+# Valkey Headless Service (for StatefulSet DNS discovery)
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "valkey.fullname" . }}-headless
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+    app.kubernetes.io/component: valkey
+  {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: 6379
+      targetPort: tcp
+      protocol: TCP
+      name: tcp
+  selector:
+    {{- include "valkey.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: valkey
+---
+# Sentinel Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "valkey.fullname" . }}-sentinel
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sentinel
+  {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.sentinel.port }}
+      targetPort: sentinel
+      protocol: TCP
+      name: sentinel
+  selector:
+    {{- include "valkey.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: sentinel
+---
+# Sentinel Headless Service (for Sentinel StatefulSet DNS discovery)
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "valkey.fullname" . }}-sentinel-headless
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sentinel
+  {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: {{ .Values.sentinel.port }}
+      targetPort: sentinel
+      protocol: TCP
+      name: sentinel
+  selector:
+    {{- include "valkey.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: sentinel
+{{- end }}
+---
+{{- if .Values.sentinel.enabled }}
+# Valkey Service (for Sentinel mode client connections)
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "valkey.fullname" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+    app.kubernetes.io/component: valkey
+  {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: tcp
+      protocol: TCP
+      name: tcp
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+    {{- if .Values.metrics.enabled }}
+    - port: 9121
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+    {{- end }}
+  selector:
+    {{- include "valkey.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: valkey
+{{- end }}

--- a/valkey/templates/servicemonitor.yaml
+++ b/valkey/templates/servicemonitor.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+{{- include "valkey.validateServiceMonitor" . }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "valkey.fullname" . }}
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.metrics.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "valkey.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- if .Values.auth.enabled }}
+      # Redis exporter automatically uses REDIS_PASSWORD env var for authentication
+      {{- end }}
+{{- end }}

--- a/valkey/templates/statefulset-sentinel.yaml
+++ b/valkey/templates/statefulset-sentinel.yaml
@@ -1,0 +1,218 @@
+{{- include "valkey.validateMode" . }}
+{{- if .Values.sentinel.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "valkey.fullname" . }}-sentinel
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sentinel
+spec:
+  serviceName: {{ include "valkey.fullname" . }}-sentinel-headless
+  replicas: {{ .Values.sentinel.replicas }}
+  {{- if .Values.updateStrategy }}
+  updateStrategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "valkey.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: sentinel
+  template:
+    metadata:
+      labels:
+        {{- include "valkey.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: sentinel
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/init-scripts: {{ include (print $.Template.BasePath "/init_config.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      serviceAccountName: {{ include "valkey.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.sentinel.antiAffinity.enabled }}
+      affinity:
+        podAntiAffinity:
+          {{- if eq .Values.sentinel.antiAffinity.type "hard" }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: {{ .Values.sentinel.antiAffinity.topologyKey }}
+              labelSelector:
+                matchLabels:
+                  {{- include "valkey.selectorLabels" . | nindent 18 }}
+                  app.kubernetes.io/component: sentinel
+          {{- else }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: {{ .Values.sentinel.antiAffinity.topologyKey }}
+                labelSelector:
+                  matchLabels:
+                    {{- include "valkey.selectorLabels" . | nindent 20 }}
+                    app.kubernetes.io/component: sentinel
+          {{- end }}
+        {{- with .Values.sentinel.affinity }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- else }}
+        {{- with .Values.sentinel.affinity }}
+        affinity:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.sentinel.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sentinel.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        - name: init-sentinel
+          image: "{{ .Values.sentinel.image.repository | default .Values.image.repository }}:{{ .Values.sentinel.image.tag | default (.Values.image.tag | default .Chart.AppVersion) }}"
+          imagePullPolicy: {{ .Values.sentinel.image.pullPolicy | default .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command: ["/bin/bash", "/scripts/init-sentinel.sh"]
+          {{- if .Values.env }}
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: init-scripts
+              mountPath: /scripts
+            - name: sentinel-base-config
+              mountPath: /config-base
+            {{- if .Values.auth.enabled }}
+            {{- if .Values.auth.existingSecret }}
+            - name: valkey-password
+              mountPath: /secrets
+              readOnly: true
+            {{- end }}
+            {{- end }}
+            {{- if .Values.sentinel.auth.enabled }}
+            {{- if .Values.sentinel.auth.existingSecret }}
+            - name: sentinel-password
+              mountPath: /sentinel-secrets
+              readOnly: true
+            {{- end }}
+            {{- end }}
+          {{- with .Values.initResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      containers:
+        - name: sentinel
+          image: "{{ .Values.sentinel.image.repository | default .Values.image.repository }}:{{ .Values.sentinel.image.tag | default (.Values.image.tag | default .Chart.AppVersion) }}"
+          imagePullPolicy: {{ .Values.sentinel.image.pullPolicy | default .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - valkey-sentinel
+            - /data/sentinel.conf
+          ports:
+            - name: sentinel
+              containerPort: 26379
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: sentinel
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - valkey-cli -p 26379 ping
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          {{- if .Values.env }}
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          {{- with .Values.sentinel.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: init-scripts
+          configMap:
+            name: {{ include "valkey.fullname" . }}-init-scripts
+            defaultMode: 0755
+        - name: sentinel-base-config
+          configMap:
+            name: {{ include "valkey.fullname" . }}-sentinel-base-config
+        {{- if .Values.auth.enabled }}
+        {{- if .Values.auth.existingSecret }}
+        - name: valkey-password
+          secret:
+            secretName: {{ .Values.auth.existingSecret }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.sentinel.auth.enabled }}
+        {{- if .Values.sentinel.auth.existingSecret }}
+        - name: sentinel-password
+          secret:
+            secretName: {{ .Values.sentinel.auth.existingSecret }}
+        {{- end }}
+        {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        {{- with .Values.dataStorage.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.dataStorage.labels }}
+        labels:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          {{- toYaml .Values.dataStorage.accessModes | nindent 10 }}
+        {{- if .Values.dataStorage.className }}
+        storageClassName: {{ .Values.dataStorage.className }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.dataStorage.sentinelSize }}
+{{- end }}

--- a/valkey/templates/statefulset-valkey.yaml
+++ b/valkey/templates/statefulset-valkey.yaml
@@ -1,0 +1,301 @@
+{{- include "valkey.validateMode" . }}
+{{- if .Values.sentinel.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "valkey.fullname" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+    app.kubernetes.io/component: valkey
+spec:
+  serviceName: {{ include "valkey.fullname" . }}-headless
+  replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  updateStrategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "valkey.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: valkey
+  template:
+    metadata:
+      labels:
+        {{- include "valkey.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: valkey
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/init-scripts: {{ include (print $.Template.BasePath "/init_config.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      serviceAccountName: {{ include "valkey.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.replication.antiAffinity.enabled }}
+      affinity:
+        podAntiAffinity:
+          {{- if eq .Values.replication.antiAffinity.type "hard" }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: {{ .Values.replication.antiAffinity.topologyKey }}
+              labelSelector:
+                matchLabels:
+                  {{- include "valkey.selectorLabels" . | nindent 18 }}
+                  app.kubernetes.io/component: valkey
+          {{- else }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: {{ .Values.replication.antiAffinity.topologyKey }}
+                labelSelector:
+                  matchLabels:
+                    {{- include "valkey.selectorLabels" . | nindent 20 }}
+                    app.kubernetes.io/component: valkey
+          {{- end }}
+        {{- with .Values.affinity }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- else }}
+        {{- with .Values.affinity }}
+        affinity:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        - name: init-valkey
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command: ["/bin/bash", "/scripts/init-valkey.sh"]
+          {{- if .Values.env }}
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: init-scripts
+              mountPath: /scripts
+            - name: valkey-base-config
+              mountPath: /config-base
+            {{- if .Values.auth.enabled }}
+            {{- if .Values.auth.existingSecret }}
+            - name: valkey-password
+              mountPath: /secrets
+              readOnly: true
+            {{- end }}
+            {{- end }}
+            {{- if .Values.tls.enabled }}
+            - name: valkey-tls
+              mountPath: /tls
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.initResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      containers:
+        - name: valkey
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - valkey-server
+            - /data/valkey.conf
+          ports:
+            - name: tcp
+              containerPort: 6379
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: tcp
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - valkey-cli ping
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          {{- if .Values.env }}
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            {{- if .Values.tls.enabled }}
+            - name: valkey-tls
+              mountPath: /tls
+              readOnly: true
+            {{- end }}
+            {{- range .Values.extraValkeyConfigs }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              {{- if .defaultMode }}
+              defaultMode: {{ .defaultMode }}
+              {{- end }}
+            {{- end }}
+            {{- range .Values.extraValkeySecrets }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              readOnly: true
+              {{- if .defaultMode }}
+              defaultMode: {{ .defaultMode }}
+              {{- end }}
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          image: "{{ .Values.metrics.exporter.image.repository }}:{{ .Values.metrics.exporter.image.tag }}"
+          imagePullPolicy: {{ .Values.metrics.exporter.image.pullPolicy }}
+          ports:
+            - name: metrics
+              containerPort: 9121
+              protocol: TCP
+          env:
+            - name: REDIS_ADDR
+              value: "redis://localhost:6379"
+            {{- if .Values.auth.enabled }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.auth.existingSecret }}
+                  name: {{ .Values.auth.existingSecret }}
+                  key: {{ .Values.auth.existingSecretPasswordKey }}
+                  {{- else }}
+                  name: {{ include "valkey.fullname" . }}-auth
+                  key: password
+                  {{- end }}
+            {{- end }}
+          {{- range .Values.metrics.exporter.extraExporterSecrets }}
+          volumeMounts:
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              readOnly: true
+          {{- end }}
+          {{- with .Values.metrics.exporter.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: init-scripts
+          configMap:
+            name: {{ include "valkey.fullname" . }}-init-scripts
+            defaultMode: 0755
+        - name: valkey-base-config
+          configMap:
+            name: {{ include "valkey.fullname" . }}-valkey-base-config
+        {{- if .Values.auth.enabled }}
+        {{- if .Values.auth.existingSecret }}
+        - name: valkey-password
+          secret:
+            secretName: {{ .Values.auth.existingSecret }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: valkey-tls
+          secret:
+            secretName: {{ .Values.tls.certificatesSecret }}
+        {{- end }}
+        {{- range .Values.extraValkeyConfigs }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .name }}
+        {{- end }}
+        {{- range .Values.extraValkeySecrets }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .name }}
+        {{- end }}
+        {{- range .Values.metrics.exporter.extraExporterSecrets }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .name }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+  {{- if and .Values.dataStorage.enabled .Values.dataStorage.requestedSize }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        {{- with .Values.dataStorage.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.dataStorage.labels }}
+        labels:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          {{- toYaml .Values.dataStorage.accessModes | nindent 10 }}
+        {{- if .Values.dataStorage.className }}
+        storageClassName: {{ .Values.dataStorage.className }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.dataStorage.requestedSize }}
+  {{- else }}
+        - name: data
+          emptyDir: {}
+  {{- end }}
+{{- end }}

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -1,151 +1,107 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://valkey.io/valkey-helm/values.schema.json",
+    "title": "Valkey Helm Chart Values",
+    "description": "Schema for Valkey Helm chart configuration supporting standalone and sentinel deployment modes",
     "type": "object",
     "properties": {
-        "affinity": {
-            "type": "object"
-        },
-        "auth": {
-            "type": "object",
-            "properties": {
-                "aclConfig": {
-                    "type": "string"
-                },
-                "enabled": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "dataStorage": {
-            "type": "object",
-            "properties": {
-                "accessModes": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "annotations": {
-                    "type": "object"
-                },
-                "className": {
-                    "type": "string"
-                },
-                "enabled": {
-                    "type": "boolean"
-                },
-                "keepPvc": {
-                    "type": "boolean"
-                },
-                "labels": {
-                    "type": "object"
-                },
-                "persistentVolumeClaimName": {
-                    "type": "string"
-                },
-                "requestedSize": {
-                    "type": "string"
-                },
-                "volumeName": {
-                    "type": "string"
-                }
-            }
-        },
-        "deploymentStrategy": {
-            "type": "string",
-             "enum": ["RollingUpdate", "Recreate"]
-        },
-        "env": {
-            "type": "object"
-        },
-        "extraSecretValkeyConfigs": {
-            "type": "boolean"
-        },
-        "extraStorage": {
-            "type": "array"
-        },
-        "extraValkeyConfigs": {
-            "type": "array"
-        },
-        "extraValkeySecrets": {
-            "type": "array"
-        },
-        "fullnameOverride": {
-            "type": "string"
-        },
         "image": {
             "type": "object",
+            "description": "Container image configuration",
             "properties": {
-                "pullPolicy": {
-                    "type": "string"
-                },
                 "repository": {
-                    "type": "string"
+                    "type": "string",
+                    "default": "docker.io/valkey/valkey",
+                    "description": "Valkey Docker image repository"
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "enum": ["Always", "IfNotPresent", "Never"],
+                    "default": "IfNotPresent",
+                    "description": "Image pull policy"
                 },
                 "tag": {
-                    "type": "string"
+                    "type": "string",
+                    "default": "",
+                    "description": "Image tag (defaults to Chart.AppVersion if empty)"
                 }
             }
         },
         "imagePullSecrets": {
-            "type": "array"
+            "type": "array",
+            "items": {
+                "type": "object"
+            },
+            "default": [],
+            "description": "List of image pull secrets for private registries"
         },
-        "initResources": {
-            "type": "object"
+        "nameOverride": {
+            "type": "string",
+            "default": "",
+            "description": "Override the chart name"
         },
-        "metrics": {
+        "fullnameOverride": {
+            "type": "string",
+            "default": "",
+            "description": "Override the full resource name"
+        },
+        "serviceAccount": {
             "type": "object",
+            "description": "Service account configuration",
             "properties": {
-                "enabled": {
-                    "type": "boolean"
+                "create": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Create a service account"
                 },
-                "exporter": {
+                "automount": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Automount service account token"
+                },
+                "annotations": {
                     "type": "object",
-                    "properties": {
-                        "extraExporterSecrets": {
-                            "type": "array"
-                        }
-                    }
+                    "default": {},
+                    "description": "Service account annotations"
+                },
+                "name": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Name of existing service account to use"
                 }
             }
         },
-        "nameOverride": {
-            "type": "string"
-        },
-        "networkPolicy": {
-            "type": "object"
-        },
-        "nodeSelector": {
-            "type": "object"
-        },
         "podAnnotations": {
-            "type": "object"
+            "type": "object",
+            "default": {},
+            "description": "Annotations to add to pods"
         },
         "podLabels": {
-            "type": "object"
+            "type": "object",
+            "default": {},
+            "description": "Labels to add to pods"
         },
         "podSecurityContext": {
             "type": "object",
+            "description": "Pod-level security context",
             "properties": {
                 "fsGroup": {
-                    "type": "integer"
-                },
-                "runAsGroup": {
-                    "type": "integer"
+                    "type": "integer",
+                    "default": 1000
                 },
                 "runAsUser": {
-                    "type": "integer"
+                    "type": "integer",
+                    "default": 1000
+                },
+                "runAsGroup": {
+                    "type": "integer",
+                    "default": 1000
                 }
             }
         },
-        "replicaCount": {
-            "type": "integer"
-        },
-        "resources": {
-            "type": "object"
-        },
         "securityContext": {
             "type": "object",
+            "description": "Container-level security context",
             "properties": {
                 "capabilities": {
                     "type": "object",
@@ -154,66 +110,857 @@
                             "type": "array",
                             "items": {
                                 "type": "string"
-                            }
+                            },
+                            "default": ["ALL"]
                         }
                     }
                 },
                 "readOnlyRootFilesystem": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "default": true
                 },
                 "runAsNonRoot": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "default": true
                 },
                 "runAsUser": {
-                    "type": "integer"
+                    "type": "integer",
+                    "default": 1000
                 }
             }
         },
         "service": {
             "type": "object",
+            "description": "Service configuration",
             "properties": {
-                "port": {
-                    "type": "integer"
-                },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": ["ClusterIP", "NodePort", "LoadBalancer"],
+                    "default": "ClusterIP",
+                    "description": "Kubernetes service type"
+                },
+                "port": {
+                    "type": "integer",
+                    "default": 6379,
+                    "minimum": 1,
+                    "maximum": 65535,
+                    "description": "Service port for Valkey"
                 },
                 "nodePort": {
-                    "type": "integer"
+                    "type": "integer",
+                    "default": 0,
+                    "minimum": 0,
+                    "maximum": 65535,
+                    "description": "NodePort value (0 for auto-assignment)"
+                },
+                "annotations": {
+                    "type": "object",
+                    "default": {},
+                    "description": "Annotations to add to all services"
+                },
+                "labels": {
+                    "type": "object",
+                    "default": {},
+                    "description": "Labels to add to all services"
                 }
             }
         },
-        "serviceAccount": {
+        "networkPolicy": {
             "type": "object",
+            "description": "Network policy configuration",
             "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable NetworkPolicy"
+                },
+                "labels": {
+                    "type": "object",
+                    "default": {},
+                    "description": "Labels to add to NetworkPolicy"
+                },
                 "annotations": {
-                    "type": "object"
+                    "type": "object",
+                    "default": {},
+                    "description": "Annotations to add to NetworkPolicy"
                 },
-                "automount": {
-                    "type": "boolean"
+                "policyTypes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["Ingress", "Egress"]
+                    },
+                    "default": [],
+                    "description": "Policy types (automatically set based on ingress/egress if empty)"
                 },
-                "create": {
-                    "type": "boolean"
+                "ingress": {
+                    "type": "array",
+                    "default": [],
+                    "description": "Ingress rules - allow traffic to Valkey pods"
                 },
-                "name": {
-                    "type": "string"
+                "egress": {
+                    "type": "array",
+                    "default": [],
+                    "description": "Egress rules"
                 }
             }
+        },
+        "resources": {
+            "type": "object",
+            "default": {},
+            "description": "Resource limits and requests for Valkey container"
+        },
+        "initResources": {
+            "type": "object",
+            "default": {},
+            "description": "Resource limits and requests for init containers"
+        },
+        "dataStorage": {
+            "type": "object",
+            "description": "Persistent storage configuration",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable persistent storage"
+                },
+                "persistentVolumeClaimName": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Name of existing PVC to use"
+                },
+                "volumeName": {
+                    "type": "string",
+                    "default": "valkey-data",
+                    "description": "Name of the volume (referenced in deployment)"
+                },
+                "requestedSize": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Request size (e.g. 8Gi) for dynamically provisioned volume"
+                },
+                "className": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Name of the storage class to use"
+                },
+                "accessModes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": ["ReadWriteOnce"],
+                    "description": "Access modes for the PVC"
+                },
+                "keepPvc": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If true, keep the PVC on Helm uninstall"
+                },
+                "annotations": {
+                    "type": "object",
+                    "default": {},
+                    "description": "Optional annotations to add to the PVC"
+                },
+                "labels": {
+                    "type": "object",
+                    "default": {},
+                    "description": "Optional labels to add to the PVC"
+                },
+                "sentinelSize": {
+                    "type": "string",
+                    "default": "1Gi",
+                    "description": "Sentinel mode storage size (only used when sentinel.enabled=true)"
+                }
+            }
+        },
+        "auth": {
+            "type": "object",
+            "description": "Authentication configuration",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable authentication"
+                },
+                "password": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Password for authentication (use existingSecret in production)"
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Name of existing secret containing password"
+                },
+                "existingSecretPasswordKey": {
+                    "type": "string",
+                    "default": "password",
+                    "description": "Key in existing secret containing password"
+                },
+                "aclConfig": {
+                    "type": "string",
+                    "default": "",
+                    "description": "ACL configuration for advanced authentication"
+                },
+                "acl": {
+                    "type": "object",
+                    "description": "ACL-based authentication (advanced)",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "config": {
+                            "type": "string",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "default": ""
+                        },
+                        "existingSecretKey": {
+                            "type": "string",
+                            "default": "acl.conf"
+                        }
+                    }
+                }
+            }
+        },
+        "tls": {
+            "type": "object",
+            "description": "TLS/SSL encryption configuration",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "certificatesSecret": {
+                    "type": "string",
+                    "default": ""
+                },
+                "certFilename": {
+                    "type": "string",
+                    "default": "tls.crt"
+                },
+                "certKeyFilename": {
+                    "type": "string",
+                    "default": "tls.key"
+                },
+                "certCAFilename": {
+                    "type": "string",
+                    "default": "ca.crt"
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "description": "Metrics and monitoring configuration",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable metrics exporter sidecar"
+                },
+                "exporter": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "repository": {
+                                    "type": "string",
+                                    "default": "oliver006/redis_exporter"
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "default": "v1.55.0"
+                                },
+                                "pullPolicy": {
+                                    "type": "string",
+                                    "default": "IfNotPresent"
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object",
+                            "default": {}
+                        },
+                        "extraExporterSecrets": {
+                            "type": "array",
+                            "default": []
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "default": "30s"
+                        },
+                        "labels": {
+                            "type": "object",
+                            "default": {}
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "logging": {
+            "type": "object",
+            "description": "Logging configuration",
+            "properties": {
+                "level": {
+                    "type": "string",
+                    "enum": ["debug", "verbose", "notice", "warning"],
+                    "default": "notice"
+                },
+                "slowlogLogSlowerThan": {
+                    "type": "integer",
+                    "default": 10000,
+                    "description": "Slowlog threshold in microseconds"
+                },
+                "slowlogMaxLen": {
+                    "type": "integer",
+                    "default": 128,
+                    "description": "Maximum slowlog entries"
+                }
+            }
+        },
+        "valkeyConfig": {
+            "type": "string",
+            "default": "",
+            "description": "Raw valkey.conf configuration (appended to generated config)"
+        },
+        "valkeyLogLevel": {
+            "type": "string",
+            "enum": ["debug", "verbose", "notice", "warning"],
+            "default": "notice",
+            "deprecated": true,
+            "description": "DEPRECATED: Use logging.level instead"
+        },
+        "extraValkeyConfigs": {
+            "type": "array",
+            "default": [],
+            "description": "Additional ConfigMaps to mount"
+        },
+        "extraValkeySecrets": {
+            "type": "array",
+            "default": [],
+            "description": "Additional Secrets to mount"
+        },
+        "extraSecretValkeyConfigs": {
+            "type": "boolean",
+            "default": false,
+            "deprecated": true,
+            "description": "DEPRECATED: Use extraValkeySecrets instead"
+        },
+        "extraStorage": {
+            "type": "array",
+            "default": [],
+            "description": "Additional volumes to mount"
+        },
+        "extraVolumes": {
+            "type": "array",
+            "default": []
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "default": []
+        },
+        "env": {
+            "type": "object",
+            "default": {},
+            "description": "Environment variables for Valkey container"
+        },
+        "extraInitContainers": {
+            "type": "array",
+            "default": []
+        },
+        "extraContainers": {
+            "type": "array",
+            "default": []
+        },
+        "nodeSelector": {
+            "type": "object",
+            "default": {}
         },
         "tolerations": {
-            "type": "array"
+            "type": "array",
+            "default": []
+        },
+        "affinity": {
+            "type": "object",
+            "default": {}
         },
         "topologySpreadConstraints": {
             "type": "array",
             "items": {
                 "type": "object"
+            },
+            "default": []
+        },
+        "podDisruptionBudget": {
+            "type": "object",
+            "description": "Pod disruption budget for high availability",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "minAvailable": {
+                    "type": ["integer", "string"],
+                    "description": "Minimum available pods"
+                },
+                "maxUnavailable": {
+                    "type": ["integer", "string"],
+                    "description": "Maximum unavailable pods"
+                }
             }
         },
-        "valkeyConfig": {
-            "type": "string"
+        "deploymentStrategy": {
+            "type": "string",
+            "enum": ["RollingUpdate", "Recreate"],
+            "default": "RollingUpdate",
+            "description": "Deployment strategy (only for standalone mode)"
         },
-        "valkeyLogLevel": {
-            "type": "string"
+        "updateStrategy": {
+            "type": "object",
+            "description": "StatefulSet update strategy (for sentinel mode)",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": ["RollingUpdate", "OnDelete"],
+                    "default": "RollingUpdate"
+                },
+                "rollingUpdate": {
+                    "type": "object",
+                    "properties": {
+                        "maxUnavailable": {
+                            "type": ["integer", "string"],
+                            "default": 1
+                        }
+                    }
+                }
+            }
+        },
+        "replicaCount": {
+            "type": "integer",
+            "default": 1,
+            "minimum": 1,
+            "description": "Number of Valkey replicas. Applies to both modes: standalone (typically 1) and sentinel (minimum 3 required)"
+        },
+        "standalone": {
+            "type": "object",
+            "description": "Standalone mode configuration",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable standalone mode (single or multiple independent instances)"
+                }
+            }
+        },
+        "sentinel": {
+            "type": "object",
+            "description": "Sentinel mode configuration (HA with automatic failover)",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable Sentinel mode for high availability with automatic failover"
+                },
+                "quorum": {
+                    "type": "integer",
+                    "default": 2,
+                    "minimum": 2,
+                    "description": "Quorum for failover decision"
+                },
+                "downAfterMilliseconds": {
+                    "type": "integer",
+                    "default": 30000,
+                    "minimum": 1000,
+                    "description": "Time before instance considered down"
+                },
+                "failoverTimeout": {
+                    "type": "integer",
+                    "default": 180000,
+                    "minimum": 1000,
+                    "description": "Failover timeout in milliseconds"
+                },
+                "parallelSyncs": {
+                    "type": "integer",
+                    "default": 1,
+                    "minimum": 1,
+                    "description": "Number of replicas syncing simultaneously"
+                },
+                "auth": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "password": {
+                            "type": "string",
+                            "default": ""
+                        },
+                        "existingSecret": {
+                            "type": "string",
+                            "default": ""
+                        },
+                        "existingSecretPasswordKey": {
+                            "type": "string",
+                            "default": "sentinel-password"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "default": {}
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "repository": {
+                            "type": "string",
+                            "default": ""
+                        },
+                        "tag": {
+                            "type": "string",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "default": ""
+                        }
+                    }
+                },
+                "port": {
+                    "type": "integer",
+                    "default": 26379,
+                    "minimum": 1,
+                    "maximum": 65535,
+                    "description": "Sentinel service port"
+                },
+                "announce": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                },
+                "customConfig": {
+                    "type": "string",
+                    "default": ""
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "default": []
+                },
+                "affinity": {
+                    "type": "object",
+                    "default": {}
+                },
+                "antiAffinity": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "type": {
+                            "type": "string",
+                            "enum": ["hard", "soft"],
+                            "default": "hard"
+                        },
+                        "topologyKey": {
+                            "type": "string",
+                            "default": "kubernetes.io/hostname"
+                        }
+                    }
+                }
+            }
+        },
+        "replication": {
+            "type": "object",
+            "description": "Replication configuration (for Sentinel mode)",
+            "properties": {
+                "readOnly": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Replicas are read-only"
+                },
+                "minReplicas": {
+                    "type": "object",
+                    "properties": {
+                        "toWrite": {
+                            "type": "integer",
+                            "default": 1,
+                            "minimum": 0
+                        },
+                        "maxLag": {
+                            "type": "integer",
+                            "default": 10,
+                            "minimum": 0,
+                            "description": "Maximum lag in seconds"
+                        }
+                    }
+                },
+                "disklessSync": {
+                    "type": "boolean",
+                    "default": true
+                },
+                "disklessSyncDelay": {
+                    "type": "integer",
+                    "default": 5,
+                    "minimum": 0
+                },
+                "antiAffinity": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "type": {
+                            "type": "string",
+                            "enum": ["hard", "soft"],
+                            "default": "hard"
+                        },
+                        "topologyKey": {
+                            "type": "string",
+                            "default": "kubernetes.io/hostname"
+                        }
+                    }
+                }
+            }
+        },
+        "backup": {
+            "type": "object",
+            "description": "Automated backup configuration",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable automated backups using CronJob"
+                },
+                "schedule": {
+                    "type": "string",
+                    "default": "0 * * * *",
+                    "description": "Backup schedule in cron format"
+                },
+                "successfulJobsHistoryLimit": {
+                    "type": "integer",
+                    "default": 3,
+                    "minimum": 0
+                },
+                "failedJobsHistoryLimit": {
+                    "type": "integer",
+                    "default": 3,
+                    "minimum": 0
+                },
+                "retention": {
+                    "type": "object",
+                    "properties": {
+                        "hourly": {
+                            "type": "integer",
+                            "default": 240,
+                            "minimum": 1,
+                            "description": "Number of hourly backups to keep (default 240 = 10 days)"
+                        }
+                    }
+                },
+                "storage": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": ["s3", "minio", "gcs", "azure"],
+                            "default": "s3",
+                            "description": "Storage backend type"
+                        },
+                        "s3": {
+                            "type": "object",
+                            "properties": {
+                                "bucket": {
+                                    "type": "string",
+                                    "default": "",
+                                    "description": "S3 bucket name"
+                                },
+                                "region": {
+                                    "type": "string",
+                                    "default": "us-east-1",
+                                    "description": "S3 region"
+                                },
+                                "endpoint": {
+                                    "type": "string",
+                                    "default": "",
+                                    "description": "Custom S3 endpoint (for MinIO or S3-compatible storage). When set, MinIO's mc tool will be used instead of AWS CLI"
+                                },
+                                "prefix": {
+                                    "type": "string",
+                                    "default": "backups/",
+                                    "description": "Prefix/path within bucket"
+                                },
+                                "pathStyle": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "description": "Use path-style addressing (required for MinIO)"
+                                },
+                                "existingSecret": {
+                                    "type": "string",
+                                    "default": ""
+                                },
+                                "accessKeyId": {
+                                    "type": "string",
+                                    "default": ""
+                                },
+                                "secretAccessKey": {
+                                    "type": "string",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "gcs": {
+                            "type": "object",
+                            "properties": {
+                                "bucket": {
+                                    "type": "string",
+                                    "default": ""
+                                },
+                                "projectId": {
+                                    "type": "string",
+                                    "default": ""
+                                },
+                                "prefix": {
+                                    "type": "string",
+                                    "default": "backups/"
+                                },
+                                "existingSecret": {
+                                    "type": "string",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "azure": {
+                            "type": "object",
+                            "properties": {
+                                "storageAccount": {
+                                    "type": "string",
+                                    "default": ""
+                                },
+                                "container": {
+                                    "type": "string",
+                                    "default": ""
+                                },
+                                "prefix": {
+                                    "type": "string",
+                                    "default": "backups/"
+                                },
+                                "existingSecret": {
+                                    "type": "string",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                },
+                "compression": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "level": {
+                            "type": "integer",
+                            "default": 6,
+                            "minimum": 1,
+                            "maximum": 9
+                        }
+                    }
+                },
+                "encryption": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "gpgRecipient": {
+                            "type": "string",
+                            "default": ""
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "repository": {
+                            "type": "string",
+                            "default": "amazon/aws-cli"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "default": "latest"
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "default": "IfNotPresent"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "default": []
+                },
+                "affinity": {
+                    "type": "object",
+                    "default": {}
+                },
+                "extraEnv": {
+                    "type": "array",
+                    "default": []
+                },
+                "annotations": {
+                    "type": "object",
+                    "default": {}
+                },
+                "labels": {
+                    "type": "object",
+                    "default": {}
+                }
+            }
         }
-    }
+    },
+    "required": [],
+    "additionalProperties": true
 }

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -1,166 +1,206 @@
-# Number of Valkey pods to run
-replicaCount: 1
+# Number of Valkey replicas (minimum 3 for sentinel mode)
+replicaCount: 3
+
+standalone:
+  enabled: true
+
+sentinel:
+  enabled: false
+
+  # Sentinel port
+  port: 26379
+
+  # Quorum: number of Sentinels that must agree primary is down
+  # Recommendation: (replicas / 2) + 1
+  quorum: 2
+
+  # Time before instance considered down (milliseconds)
+  downAfterMilliseconds: 30000
+
+  # Failover timeout in milliseconds
+  failoverTimeout: 180000
+
+  # Number of replicas syncing simultaneously during failover
+  parallelSyncs: 1
+
+  # Sentinel authentication (recommended for production)
+  auth:
+    enabled: true
+    password: "SuperSecret1"  # Use same password as Valkey for simplicity
+    existingSecret: ""
+    existingSecretPasswordKey: "sentinel-password"
+
+  # Sentinel resources
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  # Sentinel pod anti-affinity (spread across nodes)
+  antiAffinity:
+    enabled: true
+    type: hard  # hard or soft
+    topologyKey: kubernetes.io/hostname
+
+replication:
+  # Replica configuration
+  readOnly: true
+
+  # Write safety: minimum replicas that must be connected
+  # for primary to accept writes
+  minReplicas:
+    toWrite: 1
+    maxLag: 10  # seconds
+
+  # Replication behavior
+  disklessSync: true
+  disklessSyncDelay: 5  # seconds
+
+  # Valkey pod anti-affinity (spread across nodes)
+  antiAffinity:
+    enabled: true
+    type: hard  # hard or soft
+    topologyKey: kubernetes.io/hostname
+
+networkPolicy:
+  enabled: true
+  ingress:
+    # Allow all traffic from same namespace to Valkey and Sentinel ports
+    - from:
+      - podSelector: {}
+      ports:
+      - protocol: TCP
+        port: 6379
+      - protocol: TCP
+        port: 26379
 
 image:
-  # Valkey Docker image to use
   repository: docker.io/valkey/valkey
-  # Image pull policy (Always, IfNotPresent, Never)
   pullPolicy: IfNotPresent
-  # Image tag (leave empty to use .Chart.AppVersion)
-  tag: ""
-
-# List of image pull secrets (for private registries)
-imagePullSecrets: []
-
-# Override the default name or full name of resources
-nameOverride: ""
-fullnameOverride: ""
-
-serviceAccount:
-  # Create a service account for Valkey
-  create: true
-  # Whether to automount the service account token
-  automount: false
-  # Annotations to add to the service account
-  annotations: {}
-  # Name of an existing service account to use (if create: false)
-  name: ""
-
-# Annotations and labels for the pods
-podAnnotations: {}
-podLabels: {}
-
-# Security context for the pod (applies to all containers)
-podSecurityContext:
-  fsGroup: 1000
-  runAsUser: 1000
-  runAsGroup: 1000
-
-# Security context for the Valkey containers
-securityContext:
-  capabilities:
-    drop:
-      - ALL
-  readOnlyRootFilesystem: true
-  runAsNonRoot: true
-  runAsUser: 1000
+  tag: ""  # Uses chart appVersion
 
 service:
-  # Type of Kubernetes service (ClusterIP, NodePort, LoadBalancer)
   type: ClusterIP
-  # Port on which Valkey will be exposed
   port: 6379
-  annotations: {}
-  # NodePort value (if service.type is NodePort)
   nodePort: 0
-
-# Network policy to control traffic to the pods
-# More info: https://kubernetes.io/docs/concepts/services-networking/network-policies/
-networkPolicy: {}
-
-# Resource limits/requests for the main Valkey container
-resources: {}
-  # Example:
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
-# Resource limits/requests for init containers
-initResources: {}
-  # Example:
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
-# Persistent storage configuration
-dataStorage:
-  # Enable persistent volume claim creation
-  enabled: false
-
-  # Use existing PVC by name (skip dynamic provisioning if set)
-  persistentVolumeClaimName: ""
-
-  # Name of the volume (referenced in deployment)
-  volumeName: "valkey-data"
-
-  # Request size (e.g. 5Gi) for dynamically provisioned volume
-  requestedSize: ""
-
-  # Name of the storage class to use
-  className: ""
-
-  # Access modes for the PVC (e.g., ReadWriteOnce, ReadWriteMany)
-  accessModes:
-    - ReadWriteOnce
-
-  # If true, keep the PVC on Helm uninstall
-  keepPvc: false
-
-  # Optional annotations to add to the PVC
   annotations: {}
-
-  # Optional labels to add to the PVC
   labels: {}
 
-# Mount additional secrets into the Valkey container
-extraValkeySecrets: []
-
-# Mount additional configMaps into the Valkey container
-extraValkeyConfigs: []
-
-# Mount extra secrets as volume to init container (deprecated, use extraValkeySecrets)
-extraSecretValkeyConfigs: false
-
-# Mount additional emptyDir or hostPath volumes (advanced use)
-extraStorage: []
-
-# Content for valkey.conf (will be mounted via ConfigMap)
-valkeyConfig: ""
+dataStorage:
+  enabled: true
+  className: ""
+  requestedSize: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  # Keep PVCs on deletion for data safety
+  keepPvc: true
+  # Sentinel storage size
+  sentinelSize: 1Gi
 
 auth:
-  # Enable ACL-based authentication
-  enabled: false
+  enabled: true
+  password: "SuperSecret1"
+  # For production, use existingSecret instead of password
+  existingSecret: ""
+  existingSecretPasswordKey: "password"
 
-  # Default ACL rules (used only if auth.enabled is true)
+  # Default ACL rules (legacy - used only if auth.enabled is true)
   aclConfig: |
     # Users and permissions can be defined here
     # Example:
     # user default off
-    # user default on >defaultpassword ~*  &* +@all 
+    # user default on >defaultpassword ~*  &* +@all
 
-# Node selector for pod assignment
-nodeSelector: {}
-
-# Tolerations for pod assignment to tainted nodes
-tolerations: []
-
-# Affinity rules for pod scheduling
-affinity: {}
-
-# Set Deployment strategy. See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
-deploymentStrategy: RollingUpdate
-
-# See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints
-topologySpreadConstraints: []
-
-# Valkey logging level: debug, verbose, notice, warning
-valkeyLogLevel: "notice"
+# Resources for Valkey data nodes
+resources:
+  limits:
+    cpu: 200m
+    memory: 256Mi
+  requests:
+    cpu: 200m
+    memory: 256Mi
 
 metrics:
-  # Enable Prometheus exporter sidecar
-  enabled: false
+  enabled: true
 
   exporter:
-    # Additional secrets to mount for metrics exporter
-    extraExporterSecrets: []
+    resources:
+      limits:
+        cpu: 50m
+        memory: 64Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
 
-# Environment variables to inject into Valkey container
-env: {}
-  # Example:
-  # LOG_LEVEL: info
+  serviceMonitor:
+    enabled: true
+    interval: 30s
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 2
+  # maxUnavailable: 1
+
+backup:
+  # Enable automated backups
+  enabled: false
+
+  # Hourly backups
+  schedule: "0 * * * *"
+
+  # Retention policy: keep last N backups
+  # With hourly backups, 240 = 10 days of history
+  # Adjust based on your storage capacity
+  retention:
+    hourly: 96  # Keep last 96 backups (3 days with hourly schedule)
+
+  # S3/MinIO storage configuration
+  storage:
+    type: s3  # or "minio" for MinIO
+
+    s3:
+      # Bucket name (required)
+      bucket: "valkey-backups"
+
+      # Region (for AWS S3)
+      region: "us-east-1"
+
+      # MinIO endpoint (leave empty for AWS S3)
+      # Example: "https://minio.example.com" or "http://minio:9000"
+      endpoint: ""
+
+      # Path within bucket
+      prefix: "production/valkey/"
+
+      # Use path-style addressing (required for MinIO)
+      pathStyle: false
+
+      # Credentials via existing Secret (recommended)
+      # Create secret with: kubectl create secret generic s3-backup-creds \
+      #   --from-literal=access-key-id=AKIAIOSFODNN7EXAMPLE \
+      #   --from-literal=secret-access-key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+      existingSecret: "s3-backup-creds"
+
+      # Or specify credentials directly (not recommended for production)
+      # accessKeyId: ""
+      # secretAccessKey: ""
+
+  # Compression (enabled by default)
+  compression:
+    enabled: true
+    level: 6
+
+  # Resources for backup job
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# Add custom valkey.conf directives here
+valkeyConfig: ""


### PR DESCRIPTION
- Enhanced values.schema.json to support standalone and sentinel deployment modes.
- Updated values.yaml to include detailed configurations for sentinel mode, including quorum, failover settings, and authentication.
- Added resource limits and requests for both Valkey and Sentinel components.
- Configured automated backup settings with S3/MinIO support and retention policies.
- Added support for pod disruption budgets and metrics monitoring.
- Added StatefulSet templates for valkey and sentinel when enabling HA sentinel mode