### PR TITLE
fix: use bash instead of sh in init script

### DIFF
--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "valkey.labels" . | nindent 4 }}
 data:
   init.sh: |-
-    #!/bin/sh
+    #!/bin/bash
     set -euo pipefail
 
     # Default config paths


### PR DESCRIPTION
The change from using `sh` instead of `bash` breaks the init pod.
If this change was intentional, it should not be part of a minor update as it can be breaking.

See https://github.com/valkey-io/valkey-helm/issues/58