### PR TITLE
feat: add commonLabels support to add labels to all resources

### DIFF
--- a/valkey/README.md
+++ b/valkey/README.md
@@ -92,6 +92,7 @@ A Helm chart for Kubernetes
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
+| commonLabels | object | `{}` |  |
 | podSecurityContext.fsGroup | int | `1000` |  |
 | podSecurityContext.runAsGroup | int | `1000` |  |
 | podSecurityContext.runAsUser | int | `1000` |  |

--- a/valkey/templates/_helpers.tpl
+++ b/valkey/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "valkey.chart" . }}
 app.kubernetes.io/version: {{ mustRegexReplaceAllLiteral "@sha.*" .Values.image.tag "" | default .Chart.AppVersion | trunc 63 | trimSuffix "-" | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{- toYaml . | nindent 0 }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -18,6 +18,9 @@ spec:
     metadata:
       labels:
         {{- include "valkey.selectorLabels" . | nindent 8 }}
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -276,6 +276,9 @@
         "podLabels": {
             "type": "object"
         },
+        "commonLabels": {
+            "type": "object"
+        },
         "podSecurityContext": {
             "type": "object",
             "properties": {

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -30,6 +30,9 @@ serviceAccount:
 podAnnotations: {}
 podLabels: {}
 
+# Common labels to add to all resources (Deployment, Service, ConfigMap, etc.)
+commonLabels: {}
+
 # Security context for the pod (applies to all containers)
 podSecurityContext:
   fsGroup: 1000


### PR DESCRIPTION
Fixes #73

Added commonLabels field in values.yaml that applies labels to all  Kubernetes resources (Deployment, Service, ConfigMap, PVC, etc.) through the valkey.labels helper template. Updated pod template to include both commonLabels and podLabels. Updated README documentation as well