### PR TITLE
Add `clusterIP` service option

### DIFF
--- a/valkey/templates/service.yaml
+++ b/valkey/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: tcp

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -338,6 +338,9 @@
                 },
                 "nodePort": {
                     "type": "integer"
+                },
+                "clusterIP": {
+                    "type": "string"
                 }
             }
         },

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -59,6 +59,8 @@ service:
   annotations: {}
   # NodePort value (if service.type is NodePort)
   nodePort: 0
+  # ClusterIP value
+  clusterIP: ""
 
 # Network policy to control traffic to the pods
 # More info: https://kubernetes.io/docs/concepts/services-networking/network-policies/


### PR DESCRIPTION
Small PR to add a `service.clusterIP` option to allow manually specifying the IP address of the service.
