### PR TITLE
Update init container name to use fullname template

### DIFF
--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -39,7 +39,7 @@ spec:
       securityContext:
       {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
-        - name: {{ .Chart.Name }}-init
+        - name: {{ include "valkey.fullname" . }}-init
           image: {{ include "valkey.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.securityContext }}


### PR DESCRIPTION
In the current state of the helm chart if we incluse it with an alias like `valkey_cache` the generated template are not correct.

This change is to use the same basename as the main container for the init.