### PR TITLE
fix: use image.pullPolicy for main container

### DIFF
--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -89,6 +89,7 @@ spec:
       containers:
         - name: {{ include "valkey.fullname" . }}
           image: {{ include "valkey.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: [ "valkey-server" ]
           args: [ "/data/conf/valkey.conf" ]
           securityContext:
@@ -213,7 +214,7 @@ spec:
           secret:
             secretName: {{ required "An existing secret is required to enable TLS" .Values.tls.existingSecret }}
             defaultMode: 0400
-        {{- end }}        
+        {{- end }}
         {{- range .Values.extraValkeyConfigs }}
         - name: {{ .name }}-valkey
           configMap:

--- a/valkey/tests/deployment_test.yaml
+++ b/valkey/tests/deployment_test.yaml
@@ -143,3 +143,15 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: custom-sa
+
+  - it: should use image pull policy for containers and initContainers
+    set:
+      image.pullPolicy: Always
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+      - equal:
+          path: spec.template.spec.initContainers[0].imagePullPolicy
+          value: Always

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -257,16 +257,16 @@ metrics:
   # Service configuration for the metrics exporter
   service:
     # Enable a separate service for the metrics exporter
-    enabled: true  
+    enabled: true
     # Service type (ClusterIP, NodePort, LoadBalancer)
-    type: ClusterIP  
+    type: ClusterIP
     # Port on which the metrics exporter service will be exposed
     ports:
-      http: 9121  
+      http: 9121
     # Optional annotations for the metrics exporter service
-    annotations: {}  
+    annotations: {}
     # Optional labels for the metrics exporter service
-    extraLabels: {}  
+    extraLabels: {}
     # ServiceMonitor configuration for Prometheus Operator
   serviceMonitor:
     # Enable ServiceMonitor resource for scraping service metrics


### PR DESCRIPTION
Hello there! 👋 

Thanks for providing this chart!

Just a minor fix, the `image.pullPolicy` parameter is only used in `initContainer`, not in the main `container`.

Added a unit test to make sure the fix is correct.