### PR TITLE
chore: add readinessProbe for main valkey container

### DIFF
--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -122,6 +122,13 @@ spec:
               {{- else }}
               command: [ "sh", "-c", "valkey-cli ping" ]
               {{- end }}
+          readinessProbe:
+            exec:
+              {{- if .Values.tls.enabled }}
+              command: [ "sh", "-c", "valkey-cli --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
+              {{- else }}
+              command: [ "sh", "-c", "valkey-cli ping" ]
+              {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
Adds a readinessProbe, mirroring the existing livenessProbe logic.

If you have another `command` which would make more sense for a readiness probe, feel free to suggest!