### PR TITLE
feat: support service application protocol

### DIFF
--- a/valkey/README.md
+++ b/valkey/README.md
@@ -137,6 +137,7 @@ auth:
 | metrics.service.extraLabels | object | `{}` |  |
 | metrics.service.ports.http | int | `9121` |  |
 | metrics.service.type | string | `"ClusterIP"` |  |
+| metrics.service.appProtocol | string | `""` |  |
 | metrics.serviceMonitor.additionalLabels | object | `{}` |  |
 | metrics.serviceMonitor.annotations | object | `{}` |  |
 | metrics.serviceMonitor.enabled | bool | `false` |  |
@@ -170,6 +171,7 @@ auth:
 | service.nodePort | int | `0` |  |
 | service.port | int | `6379` |  |
 | service.type | string | `"ClusterIP"` |  |
+| service.appProtocol | string | `""` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.automount | bool | `false` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/valkey/templates/metrics-svc.yaml
+++ b/valkey/templates/metrics-svc.yaml
@@ -21,6 +21,9 @@ spec:
       port: {{ .Values.metrics.service.ports.http }}
       protocol: TCP
       targetPort: metrics
+      {{- if .Values.metrics.service.appProtocol }}
+      appProtocol: {{ .Values.metrics.service.appProtocol }}
+      {{- end }}
   selector:
     {{- include "valkey.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/valkey/templates/service.yaml
+++ b/valkey/templates/service.yaml
@@ -21,5 +21,8 @@ spec:
       {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
+      {{- if .Values.service.appProtocol }}
+      appProtocol: {{ .Values.service.appProtocol }}
+      {{- end }}
   selector:
     {{- include "valkey.selectorLabels" . | nindent 4 }}

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -191,6 +191,9 @@
                         },
                         "extraLabels": {
                             "type": "object"
+                        },
+                        "appProtocol": {
+                            "type": "string"
                         }
                     }
                 },
@@ -380,6 +383,9 @@
                     "type": "integer"
                 },
                 "clusterIP": {
+                    "type": "string"
+                },
+                "appProtocol": {
                     "type": "string"
                 }
             }

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -69,6 +69,8 @@ service:
   nodePort: 0
   # ClusterIP value
   clusterIP: ""
+  # Application protocol
+  appProtocol: ""
 
 # Network policy to control traffic to the pods
 # More info: https://kubernetes.io/docs/concepts/services-networking/network-policies/
@@ -268,6 +270,8 @@ metrics:
     # Optional labels for the metrics exporter service
     extraLabels: {}
     # ServiceMonitor configuration for Prometheus Operator
+    # Application protocol
+    appProtocol: ""
   serviceMonitor:
     # Enable ServiceMonitor resource for scraping service metrics
     enabled: false


### PR DESCRIPTION
This change adds support for `service.appProtocol` and
`metrics.service.appProtocol` which allow users to specify the
application protocol for the service port. This is useful for certain
scenarios where the application protocol needs to be explicitly defined,
such as when using Istio.

Link: https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol
