### PR TITLE
feat: add support for loadBalancerClass

### DIFF
--- a/valkey/templates/service.yaml
+++ b/valkey/templates/service.yaml
@@ -13,6 +13,9 @@ spec:
   {{- if .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
+  {{- if .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.service.loadBalancerClass }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: tcp

--- a/valkey/tests/service_test.yaml
+++ b/valkey/tests/service_test.yaml
@@ -1,0 +1,21 @@
+suite: service configuration
+templates:
+  - templates/service.yaml
+tests:
+  - it: should be able to set custom loadBalancerClass
+    set:
+      service.loadBalancerClass: "custom-lb-class"
+    template: templates/service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.loadBalancerClass
+          value: "custom-lb-class"
+  - it: shouldn't have loadBalancerClass by default
+    template: templates/service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - notExists:
+          path: spec.loadBalancerClass

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -69,6 +69,8 @@ service:
   nodePort: 0
   # ClusterIP value
   clusterIP: ""
+  # Class of a load balancer implementation
+  loadBalancerClass: ""
   # Application protocol
   appProtocol: ""
 


### PR DESCRIPTION
Allow setting loadBalancerClass for the service. It can be helpful for exposing it via tailscale for example.