### PR TITLE
Add loadBalancerIP option

### DIFF
--- a/valkey/README.md
+++ b/valkey/README.md
@@ -319,6 +319,7 @@ tls:
 | replica.service.annotations | object | `{}` |  |
 | replica.service.nodePort | int | `0` |  |
 | replica.service.clusterIP | string | `""` |  |
+| replica.service.loadBalancerIP | string | `""` |  |
 | replica.service.appProtocol | string | `""` |  |
 | replica.service.loadBalancerClass | string | `""` |  |
 | replica.persistence. |  | `""` |  |

--- a/valkey/templates/service-read.yaml
+++ b/valkey/templates/service-read.yaml
@@ -15,6 +15,9 @@ spec:
   {{- if .Values.replica.service.clusterIP }}
   clusterIP: {{ .Values.replica.service.clusterIP }}
   {{- end }}
+  {{- if .Values.replica.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.replica.service.loadBalancerIP }}
+  {{- end }}
   {{- if .Values.replica.service.loadBalancerClass }}
   loadBalancerClass: {{ .Values.replica.service.loadBalancerClass }}
   {{- end }}

--- a/valkey/templates/service.yaml
+++ b/valkey/templates/service.yaml
@@ -14,6 +14,9 @@ spec:
   {{- if .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   {{- if .Values.service.loadBalancerClass }}
   loadBalancerClass: {{ .Values.service.loadBalancerClass }}
   {{- end }}

--- a/valkey/tests/service_read_test.yaml
+++ b/valkey/tests/service_read_test.yaml
@@ -23,6 +23,17 @@ tests:
       - equal:
           path: spec.clusterIP
           value: "10.0.0.2"
+  - it: should be able to set custom loadBalancerIP
+    set:
+      replica.enabled: true
+      replica.service.loadBalancerIP: "10.0.0.5"
+    template: templates/service-read.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.loadBalancerIP
+          value: "10.0.0.5"
   - it: should have correct default ports
     set:
       replica.enabled: true

--- a/valkey/tests/service_test.yaml
+++ b/valkey/tests/service_test.yaml
@@ -20,6 +20,16 @@ tests:
       - equal:
           path: spec.clusterIP
           value: "10.0.0.1"
+  - it: should be able to set custom loadBalancerIP
+    set:
+      service.loadBalancerIP: "10.0.0.2"
+    template: templates/service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.loadBalancerIP
+          value: "10.0.0.2"
   - it: should have correct default ports
     template: templates/service.yaml
     asserts:

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -403,6 +403,9 @@
                         "clusterIP": {
                             "type": "string"
                         },
+                        "loadBalancerIP": {
+                            "type": "string"
+                        },
                         "enabled": {
                             "type": "boolean"
                         },
@@ -460,6 +463,9 @@
                     "type": "string"
                 },
                 "clusterIP": {
+                    "type": "string"
+                },
+                "loadBalancerIP": {
                     "type": "string"
                 },
                 "loadBalancerClass": {

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -69,6 +69,8 @@ service:
   nodePort: 0
   # ClusterIP value
   clusterIP: ""
+  # LoadBalancerIP value
+  loadBalancerIP: ""
   # Class of a load balancer implementation
   loadBalancerClass: ""
   # Application protocol
@@ -227,6 +229,8 @@ replica:
     nodePort: 0
     # ClusterIP value
     clusterIP: ""
+    # LoadBalancerIP value
+    loadBalancerIP: ""
     # Application protocol
     appProtocol: ""
     # Class of a load balancer implementation


### PR DESCRIPTION
This is a deprecated field but also the only way to set an IP for an internal LB with GKE.