### PR TITLE
Fix yaml parse errors

### DIFF
--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -27,15 +27,15 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-      {{- with .Values.podAnnotations }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
         checksum/initconfig: {{ include (print $.Template.BasePath "/init_config.yaml") . | sha256sum | trunc 32 }}
         {{- if .Values.valkeyConfig }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 32 }}
         {{- end }}
     spec:
-      {{- (include "valkey.imagePullSecrets" .) | nindent 6 -}}
+      {{- include "valkey.imagePullSecrets" . | nindent 6 }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
       serviceAccountName: {{ include "valkey.serviceAccountName" . }}
       {{- if .Values.priorityClassName }}


### PR DESCRIPTION
Fixes the following issues introduced in commit [bf8926e](https://github.com/valkey-io/valkey-helm/commit/bf8926e5832517fa2dd2f27476e742535e9a645c#diff-53978c02729a6ff1724874a6cc2ae8efa376f156133ae33f9609275d09c77610):

1. **Annotations block**: Fixed 'mapping values are not allowed in this context' error
   - Previously: 'annotations:' keyword was always present but could be empty
   - Now: Proper structure with annotations always present as a mapping key
   - Contains both podAnnotations (if provided) and checksum annotations

2. **ImagePullSecrets formatting**: Removed trailing '-' in nindent
   - Previously: {{- (include \"valkey.imagePullSecrets\" .) | nindent 6 -}}
   - Now: {{- include \"valkey.imagePullSecrets\" . | nindent 6 }}
   - The trailing '-' caused whitespace handling issues with the include output

