### PR TITLE
Fix pipefail crash and dash related potential issues.

### DIFF
--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -9,10 +9,6 @@ data:
     #!/bin/sh
     set -eu
 
-    if set -o pipefail 2>/dev/null; then
-      set -o pipefail
-    fi
-
     # Default config paths
     VALKEY_CONFIG=${VALKEY_CONFIG_PATH:-/data/conf/valkey.conf}
 


### PR DESCRIPTION
Fixes https://github.com/valkey-io/valkey/issues/2845

- The chart currently uses #!/bin/sh but also uses bash-only pipefail.
- Debian-based images often link /bin/sh to dash, causing Illegal option -o pipefail.
- This change makes the script portable under POSIX sh by:
   - removing -o pipefail
   - avoiding local so dash doesn’t error.