### PR TITLE
add: restart sts when valkeyConfig is changed

### DIFF
--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -41,6 +41,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
         checksum/initconfig: {{ include (print $.Template.BasePath "/init_config.yaml") . | sha256sum | trunc 32 | quote }}
+        {{- if .Values.valkeyConfig }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 32 | quote }}
+        {{- end }}
     spec:
       {{- (include "valkey.imagePullSecrets" .) | nindent 6 }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automount }}


### PR DESCRIPTION
Hello,

I don't know if this is intentional but there is no checksum on valkeyconfig changes 
So a modification does not launch a restart of the STS.

Proposing to add a chechsum for sts like in deployment mode.

Thanks.