### PR TITLE
fix/workaround: allow external/alternative CAs for the client commands when using TLS.

### DIFF
--- a/valkey/templates/_helpers.tpl
+++ b/valkey/templates/_helpers.tpl
@@ -188,3 +188,13 @@ Validate replica authentication configuration
 {{- end }}
 {{- end -}}
 
+{{/*
+Which caFile to use
+*/}}
+{{- define "valkey.caFile" -}}
+{{- if .Values.tls.alternativeClientCa }}
+{{- .Values.tls.alternativeClientCa }}
+{{- else }}
+{{- printf "/tls/%s" .Values.tls.caPublicKey }}
+{{- end }}
+{{- end -}}

--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -119,14 +119,14 @@ spec:
           startupProbe:
             exec:
               {{- if .Values.tls.enabled }}
-              command: [ "sh", "-c", "valkey-cli --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
+              command: [ "sh", "-c", "valkey-cli --cacert {{ include "valkey.caFile" . }} --tls ping" ]
               {{- else }}
               command: [ "sh", "-c", "valkey-cli ping" ]
               {{- end }}
           livenessProbe:
             exec:
               {{- if .Values.tls.enabled }}
-              command: [ "sh", "-c", "valkey-cli --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
+              command: [ "sh", "-c", "valkey-cli --cacert {{ include "valkey.caFile" . }} --tls ping" ]
               {{- else }}
               command: [ "sh", "-c", "valkey-cli ping" ]
               {{- end }}

--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -115,14 +115,14 @@ spec:
           startupProbe:
             exec:
               {{- if .Values.tls.enabled }}
-              command: [ "sh", "-c", "valkey-cli --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
+              command: [ "sh", "-c", "valkey-cli --cacert {{ include "valkey.caFile" . }} --tls ping" ]
               {{- else }}
               command: [ "sh", "-c", "valkey-cli ping" ]
               {{- end }}
           livenessProbe:
             exec:
               {{- if .Values.tls.enabled }}
-              command: [ "sh", "-c", "valkey-cli --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
+              command: [ "sh", "-c", "valkey-cli --cacert {{ include "valkey.caFile" . }} --tls ping" ]
               {{- else }}
               command: [ "sh", "-c", "valkey-cli ping" ]
               {{- end }}

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -136,14 +136,14 @@ spec:
           startupProbe:
             exec:
               {{- if .Values.tls.enabled }}
-              command: [ "sh", "-c", "valkey-cli --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
+              command: [ "sh", "-c", "valkey-cli --cacert {{ include "valkey.caFile" . }} --tls ping" ]
               {{- else }}
               command: [ "sh", "-c", "valkey-cli ping" ]
               {{- end }}
           livenessProbe:
             exec:
               {{- if .Values.tls.enabled }}
-              command: [ "sh", "-c", "valkey-cli --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
+              command: [ "sh", "-c", "valkey-cli --cacert {{ include "valkey.caFile" . }} --tls ping" ]
               {{- else }}
               command: [ "sh", "-c", "valkey-cli ping" ]
               {{- end }}

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -132,14 +132,14 @@ spec:
           startupProbe:
             exec:
               {{- if .Values.tls.enabled }}
-              command: [ "sh", "-c", "valkey-cli --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
+              command: [ "sh", "-c", "valkey-cli --cacert {{ include "valkey.caFile" . }} --tls ping" ]
               {{- else }}
               command: [ "sh", "-c", "valkey-cli ping" ]
               {{- end }}
           livenessProbe:
             exec:
               {{- if .Values.tls.enabled }}
-              command: [ "sh", "-c", "valkey-cli --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
+              command: [ "sh", "-c", "valkey-cli --cacert {{ include "valkey.caFile" . }} --tls ping" ]
               {{- else }}
               command: [ "sh", "-c", "valkey-cli ping" ]
               {{- end }}

--- a/valkey/templates/tests/auth.yaml
+++ b/valkey/templates/tests/auth.yaml
@@ -35,7 +35,7 @@ spec:
 
           {{- if .Values.tls.enabled }}
           # TLS flags
-          TLS_FLAGS="--tls --cacert /tls/{{ .Values.tls.caPublicKey }}"
+          TLS_FLAGS="--tls --cacert {{ include "valkey.caFile" . }}"
           {{- else }}
           TLS_FLAGS=""
           {{- end }}
@@ -107,7 +107,7 @@ spec:
 
           {{- if .Values.tls.enabled }}
           # TLS flags
-          TLS_FLAGS="--tls --cacert /tls/{{ .Values.tls.caPublicKey }}"
+          TLS_FLAGS="--tls --cacert {{ include "valkey.caFile" . }}"
           {{- else }}
           TLS_FLAGS=""
           {{- end }}

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -519,6 +519,9 @@
                 "caPublicKey": {
                     "type": "string"
                 },
+                "alternativeClientCa": {
+                    "type": "string"
+                },
                 "dhParamKey": {
                     "type": "string"
                 },

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -275,6 +275,9 @@ tls:
   serverKey: server.key
   # Secret key name containing Certificate Authority public certificate
   caPublicKey: ca.crt
+  # in case the caPublicKey does not work for the client (e.g. valkey-cli), you can set an alternative CA cert as an absolute path here. 
+  # Useful e.g. for trust-manager in combination with cert-manager-generated ACME certs.
+  alternativeClientCa: ""
   # Secret key name containing DH parameters (optional)
   dhParamKey: ""
   # Require that clients authenticate with a certificate

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -269,6 +269,9 @@ tls:
   serverKey: server.key
   # Secret key name containing Certificate Authority public certificate
   caPublicKey: ca.crt
+  # in case the caPublicKey does not work for the client (e.g. valkey-cli), you can set an alternative CA cert as an absolute path here. 
+  # Useful e.g. for trust-manager in combination with cert-manager-generated ACME certs.
+  alternativeClientCa: ""
   # Secret key name containing DH parameters (optional)
   dhParamKey: ""
   # Require that clients authenticate with a certificate


### PR DESCRIPTION
Recently, I ran into a problem with TLS certs:

I'm using a TLS Cert by cert-manager using ACME. In the secret generated with cert-manager, there is no separate CA available (see the topics on ca.crt in https://cert-manager.io/docs/usage/certificate/#target-secret).

Therefore, I needed a separate way of using another CA for the `valkey-cli` client (mainly for probes).

**This PR adds a value that allows the client to use any other ca.**

In my case the cacerts provided by trust-manager into a config map and mounted using the `extraValkeyConfigs`.

Using the `fullchain` aka `tls.crt`, which is provided to the server as ca file from the TLS-secret, does not work:
```
I have no name!@valkey-76d9f8db58-fp6bh:/data$ valkey-cli --tls --cacert /tls/tls.crt
Could not connect to Valkey at 127.0.0.1:6379: SSL_connect failed: certificate verify failed
not connected> 
I have no name!@valkey-76d9f8db58-fp6bh:/data$ valkey-cli --tls --cacert /cacert/trust-bundle.pem 
127.0.0.1:6379> 
```

Given the above example, setting `tls.alternativeClientCa: "/cacert/valkey-trust-bundle.crt"` should make it work also for the probes. 

`/cacert/` is the mount of trust-manager, which creates a configmap with all CAs necessary, e.g. using the following bundle:

```
apiVersion: trust.cert-manager.io/v1alpha1
kind: Bundle
metadata:
  name: valkey-trust-bundle
spec:
  sources:
  - useDefaultCAs: true
  target:
    configMap:
      key: "trust-bundle.pem"
```

Please let me know in case there is a better way solving this.
Thanks!