### PR TITLE
Fix replica auth to honor passwordKey

### DIFF
--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -186,7 +186,9 @@ data:
       {{- if .Values.auth.enabled }}
       # Get the password for the replication user
       {{- $replUsername := .Values.replica.replicationUser }}
-      REPL_PASSWORD=$(get_user_password "{{ $replUsername }}") || exit 1
+      {{- $replUser := index .Values.auth.aclUsers $replUsername }}
+      {{- $replPasswordKey := $replUser.passwordKey | default $replUsername }}
+      REPL_PASSWORD=$(get_user_password "{{ $replUsername }}" "{{ $replPasswordKey }}") || exit 1
 
       # Write masterauth configuration
       echo "masterauth $REPL_PASSWORD" >>"$VALKEY_CONFIG"

--- a/valkey/tests/init_config_test.yaml
+++ b/valkey/tests/init_config_test.yaml
@@ -103,6 +103,41 @@ tests:
           path: data["init.sh"]
           pattern: "/valkey-auth-secret/aclConfig"
 
+  - it: should use passwordKey for replica authentication when configured
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      replica.replicationUser: "default"
+      auth.enabled: true
+      auth.usersExistingSecret: "my-secret"
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          passwordKey: "valkey-password"
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'REPL_PASSWORD=\$\(get_user_password "default" "valkey-password"\)'
+
+  - it: should default to username for replica authentication when passwordKey not configured
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      replica.replicationUser: "default"
+      auth.enabled: true
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          password: "default-password"
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'REPL_PASSWORD=\$\(get_user_password "default" "default"\)'
+
   - it: should have correct metadata
     asserts:
       - isKind:


### PR DESCRIPTION
## Summary

When `auth.enabled` is true and a custom `passwordKey` is specified in `aclUsers` configuration, replicas failed to authenticate because they were looking for a password key matching the username instead of the configured `passwordKey`.

This fix ensures replica authentication uses the same `passwordKey` logic as ACL user generation, making both code paths consistent.

## Problem

Replicas enter crashloop backoff when `passwordKey` differs from the username (e.g., `passwordKey: "valkey-password"` for user `"default"`).

The issue occurs because:
- ACL generation correctly uses the configured `passwordKey`
- Replica authentication ignores `passwordKey` and always uses the username as the key

## Solution

Updated the replica authentication code in `init_config.yaml` to:
1. Look up the replication user from `auth.aclUsers`
2. Get the configured `passwordKey` (or default to username if not specified)
3. Pass both username and passwordKey to `get_user_password()`, consistent with ACL generation

## Test plan

- [x] All existing tests pass (83 tests)
- [x] New tests added to cover the bug scenario
- [ ] Deploy with replicas enabled and custom passwordKey (e.g., `passwordKey: "valkey-password"` for user `"default"`)
- [ ] Verify both master and replicas start successfully
- [ ] Verify replica authentication works correctly