### PR TITLE
feat: adds support to configure persistentVolumeClaimRetentionPolicy

### DIFF
--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -12,6 +12,10 @@ spec:
   serviceName: {{ include "valkey.fullname" . }}-headless
   replicas: {{ add (int .Values.replica.replicas) 1 }}
   podManagementPolicy: OrderedReady
+  {{- if .Values.replica.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml .Values.replica.persistentVolumeClaimRetentionPolicy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "valkey.selectorLabels" . | nindent 6 }}

--- a/valkey/tests/statefulset_test.yaml
+++ b/valkey/tests/statefulset_test.yaml
@@ -236,3 +236,21 @@ tests:
             name: extra-config
             mountPath: /extra-config
             readOnly: true
+
+  - it: should include persistentVolumeClaimRetentionPolicy when configured
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      replica.persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Delete
+    template: templates/statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenDeleted
+          value: Retain
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenScaled
+          value: Delete

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -385,6 +385,19 @@
                         }
                     }
                 },
+                "persistentVolumeClaimRetentionPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "whenDeleted": {
+                            "type": "string",
+                            "enum": ["Delete", "Retain"]
+                        },
+                        "whenScaled": {
+                            "type": "string",
+                            "enum": ["Delete", "Retain"]
+                        }
+                    }
+                },
                 "replicas": {
                     "type": "integer"
                 },

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -245,6 +245,11 @@ replica:
     accessModes:
       - ReadWriteOnce
 
+  # PersistentVolumeClaim retention policy for StatefulSet
+  # Controls when PVCs are deleted (requires Kubernetes 1.23+)
+  # More info: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+  persistentVolumeClaimRetentionPolicy: {}
+
 tls:
   # Enable TLS
   enabled: false


### PR DESCRIPTION
Fixes #114 


The PR adds `persistentVolumeClaimRetentionPolicy` to the StatefulSet. The changes are thoroughly tested as well. The default behaviour currently set in `values.yaml` is that the PVCs are deleted when a `helm uninstall` operation is done (in other words, chart deleted completely). In the event of scaling down, the PVCs are retained. 