### PR TITLE
feat: make tls config more flexible

### DIFF
--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -115,14 +115,14 @@ spec:
           startupProbe:
             exec:
               {{- if .Values.tls.enabled }}
-              command: [ "sh", "-c", "valkey-cli --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
+              command: [ "sh", "-c", "valkey-cli --cacert {{ .Values.tls.caPublicKey }} --tls ping" ]
               {{- else }}
               command: [ "sh", "-c", "valkey-cli ping" ]
               {{- end }}
           livenessProbe:
             exec:
               {{- if .Values.tls.enabled }}
-              command: [ "sh", "-c", "valkey-cli --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
+              command: [ "sh", "-c", "valkey-cli --cacert {{ .Values.tls.caPublicKey }} --tls ping" ]
               {{- else }}
               command: [ "sh", "-c", "valkey-cli ping" ]
               {{- end }}

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -75,11 +75,11 @@ data:
     log "Generating base valkey.conf"
     {
 {{- if .Values.tls.enabled }}
-      echo "tls-cert-file /tls/{{ .Values.tls.serverPublicKey }}"
-      echo "tls-key-file /tls/{{ .Values.tls.serverKey }}"
-      echo "tls-ca-cert-file /tls/{{ .Values.tls.caPublicKey }}"
+      echo "tls-cert-file {{ .Values.tls.serverPublicKey }}"
+      echo "tls-key-file {{ .Values.tls.serverKey }}"
+      echo "tls-ca-cert-file {{ .Values.tls.caPublicKey }}"
       {{- if .Values.tls.dhParamKey }}
-      echo "tls-dh-params-file /tls/{{ .Values.tls.dhParamKey }}"
+      echo "tls-dh-params-file {{ .Values.tls.dhParamKey }}"
       {{- end }}
       {{- if not .Values.tls.requireClientCertificate }}
       echo "tls-auth-clients no"
@@ -228,4 +228,3 @@ data:
       log "Appending files in /extravalkeyconfigs/"
       cat /extravalkeyconfigs/* >>"$VALKEY_CONFIG"
     fi
-

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -128,14 +128,14 @@ spec:
           startupProbe:
             exec:
               {{- if .Values.tls.enabled }}
-              command: [ "sh", "-c", "valkey-cli --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
+              command: [ "sh", "-c", "valkey-cli --cacert {{ .Values.tls.caPublicKey }} --tls ping" ]
               {{- else }}
               command: [ "sh", "-c", "valkey-cli ping" ]
               {{- end }}
           livenessProbe:
             exec:
               {{- if .Values.tls.enabled }}
-              command: [ "sh", "-c", "valkey-cli --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
+              command: [ "sh", "-c", "valkey-cli --cacert {{ .Values.tls.caPublicKey }} --tls ping" ]
               {{- else }}
               command: [ "sh", "-c", "valkey-cli ping" ]
               {{- end }}
@@ -144,7 +144,7 @@ spec:
           volumeMounts:
             - name: valkey-data
               mountPath: /data
-            {{- if .Values.tls.enabled }}
+            {{- if .Values.tls.existingSecret }}
             - name: {{ include "valkey.fullname" . }}-tls
               mountPath: /tls
             {{- end }}
@@ -226,10 +226,10 @@ spec:
             secretName: {{ .name }}
             defaultMode: {{ .defaultMode | default 0440 }}
         {{- end }}
-        {{- if .Values.tls.enabled }}
+        {{- if .Values.tls.existingSecret }}
         - name: {{ include "valkey.fullname" . }}-tls
           secret:
-            secretName: {{ required "An existing secret is required to enable TLS" .Values.tls.existingSecret }}
+            secretName: {{ .Values.tls.existingSecret }}
             defaultMode: 0400
         {{- end }}
         {{- range .Values.extraValkeyConfigs }}

--- a/valkey/templates/tests/auth.yaml
+++ b/valkey/templates/tests/auth.yaml
@@ -35,7 +35,7 @@ spec:
 
           {{- if .Values.tls.enabled }}
           # TLS flags
-          TLS_FLAGS="--tls --cacert /tls/{{ .Values.tls.caPublicKey }}"
+          TLS_FLAGS="--tls --cacert {{ .Values.tls.caPublicKey }}"
           {{- else }}
           TLS_FLAGS=""
           {{- end }}
@@ -107,7 +107,7 @@ spec:
 
           {{- if .Values.tls.enabled }}
           # TLS flags
-          TLS_FLAGS="--tls --cacert /tls/{{ .Values.tls.caPublicKey }}"
+          TLS_FLAGS="--tls --cacert {{ .Values.tls.caPublicKey }}"
           {{- else }}
           TLS_FLAGS=""
           {{- end }}

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -248,11 +248,11 @@ tls:
   # Name of the Secret containing TLS keys (required)
   existingSecret: ""
   # Secret key name containing server public certificate
-  serverPublicKey: server.crt
+  serverPublicKey: /tls/server.crt
   # Secret key name containing server private key
-  serverKey: server.key
+  serverKey: /tls/server.key
   # Secret key name containing Certificate Authority public certificate
-  caPublicKey: ca.crt
+  caPublicKey: /tls/ca.crt
   # Secret key name containing DH parameters (optional)
   dhParamKey: ""
   # Require that clients authenticate with a certificate


### PR DESCRIPTION
## Description

- TLS configuration was forced to use existing secret, making it impossible to use custom mounts
- This PR makes it possible to mount use `tls.serverPublicKey` and alike to point to custom files