### PR TITLE
fix: render auth checksum as annotation

### DIFF
--- a/valkey/templates/_helpers.tpl
+++ b/valkey/templates/_helpers.tpl
@@ -188,3 +188,11 @@ Validate replica authentication configuration
 {{- end }}
 {{- end -}}
 
+{{- define "valkey.renderAuthSecret" -}}
+{{- $hasInlinePass := eq (include "valkey.hasInlinePasswords" .) "true" -}}
+{{- if and .Values.auth.enabled (or $hasInlinePass .Values.auth.aclConfig) -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}

--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -30,9 +30,12 @@ spec:
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        checksum/initconfig: {{ include (print $.Template.BasePath "/init_config.yaml") . | sha256sum | trunc 32 }}
+        checksum/initconfig: {{ include (print $.Template.BasePath "/init_config.yaml") . | sha256sum | trunc 32 | quote }}
         {{- if .Values.valkeyConfig }}
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 32 }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 32 | quote }}
+        {{- end }}
+        {{- if (include "valkey.renderAuthSecret" .) | eq "true" }}
+        checksum/auth-secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum | trunc 32 | quote }}
         {{- end }}
     spec:
       {{- include "valkey.imagePullSecrets" . | nindent 6 }}

--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -80,7 +80,7 @@ spec:
               mountPath: /valkey-users-secret
               readOnly: true
             {{- end }}
-            {{- if or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig }}
+            {{- if (include "valkey.renderAuthSecret" .) | eq "true" }}
             - name: valkey-auth-secret
               mountPath: /valkey-auth-secret
               readOnly: true
@@ -249,7 +249,7 @@ spec:
             secretName: {{ .Values.auth.usersExistingSecret }}
             defaultMode: 0400
         {{- end }}
-        {{- if or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig }}
+        {{- if (include "valkey.renderAuthSecret" .) | eq "true" }}
         - name: valkey-auth-secret
           secret:
             secretName: {{ include "valkey.fullname" . }}-auth

--- a/valkey/templates/secret.yaml
+++ b/valkey/templates/secret.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.auth.enabled }}
-{{- if or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig }}
+{{- if (include "valkey.renderAuthSecret" .) | eq "true" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -16,5 +15,4 @@ data:
   {{- if .Values.auth.aclConfig }}
   aclConfig: {{ .Values.auth.aclConfig | b64enc }}
   {{- end }}
-{{- end }}
 {{- end }}

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -45,7 +45,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 32 | quote }}
         {{- end }}
         {{- if (include "valkey.renderAuthSecret" .) | eq "true" }}
-        checksum/auth-secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum | trunc 32 }}
+        checksum/auth-secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum | trunc 32 | quote }}
         {{- end }}
     spec:
       {{- (include "valkey.imagePullSecrets" .) | nindent 6 }}
@@ -92,7 +92,7 @@ spec:
               mountPath: /valkey-users-secret
               readOnly: true
             {{- end }}
-            {{- if or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig }}
+            {{- if (include "valkey.renderAuthSecret" .) | eq "true" }}
             - name: valkey-auth-secret
               mountPath: /valkey-auth-secret
               readOnly: true
@@ -259,7 +259,7 @@ spec:
             secretName: {{ .Values.auth.usersExistingSecret }}
             defaultMode: 0400
         {{- end }}
-        {{- if or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig }}
+        {{- if (include "valkey.renderAuthSecret" .) | eq "true" }}
         - name: valkey-auth-secret
           secret:
             secretName: {{ include "valkey.fullname" . }}-auth

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -44,6 +44,9 @@ spec:
         {{- if .Values.valkeyConfig }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 32 | quote }}
         {{- end }}
+        {{- if (include "valkey.renderAuthSecret" .) | eq "true" }}
+        checksum/auth-secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum | trunc 32 }}
+        {{- end }}
     spec:
       {{- (include "valkey.imagePullSecrets" .) | nindent 6 }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automount }}

--- a/valkey/tests/auth_validation_test.yaml
+++ b/valkey/tests/auth_validation_test.yaml
@@ -3,6 +3,7 @@ templates:
   - templates/deploy_valkey.yaml
   - templates/statefulset.yaml
   - templates/init_config.yaml
+  - templates/secret.yaml
 tests:
   - it: should fail when auth enabled but no method configured
     set:

--- a/valkey/tests/deployment_test.yaml
+++ b/valkey/tests/deployment_test.yaml
@@ -2,6 +2,7 @@ suite: deployment configuration
 templates:
   - templates/deploy_valkey.yaml
   - templates/init_config.yaml
+  - templates/secret.yaml
 tests:
   - it: should not have auth volumes when auth disabled
     set:
@@ -322,3 +323,16 @@ tests:
             name: extra-config
             mountPath: /extra-config
             readOnly: true
+  - it: adds auth secret annotations
+    set:
+      auth:
+        enabled: true
+        aclConfig: "acl config"
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - exists:
+          path: spec.template.metadata.annotations
+      - exists:
+          path: spec.template.metadata.annotations["checksum/auth-secret"]

--- a/valkey/tests/statefulset_test.yaml
+++ b/valkey/tests/statefulset_test.yaml
@@ -2,6 +2,7 @@ suite: statefulset configuration
 templates:
   - templates/statefulset.yaml
   - templates/init_config.yaml
+  - templates/secret.yaml
 tests:
   - it: should fail when replica enabled but no size provided
     set:
@@ -236,3 +237,24 @@ tests:
             name: extra-config
             mountPath: /extra-config
             readOnly: true
+  - it: adds auth secret annotations
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      auth:
+        enabled: true
+        aclUsers:
+          default:
+            permissions: "default perm"
+            password: "default pass"
+          replica:
+            permissions: "replica perm"    
+            password: "replica pass"
+    template: templates/statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - exists:
+          path: spec.template.metadata.annotations
+      - exists:
+          path: spec.template.metadata.annotations["checksum/auth-secret"]


### PR DESCRIPTION
Currently changes to the auth secret do not result in a fresh rollout of the Valkey Pods.

We can fix this by rendering an annotation with the secret checksum to the Deployment/StatefulSet similar to what is already being done for ConfigMaps.

This is a common pattern in Helm: https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments