### PR TITLE
fix: use valkey.image helper in test pods

### DIFF
--- a/valkey/templates/tests/auth.yaml
+++ b/valkey/templates/tests/auth.yaml
@@ -21,7 +21,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: test-auth
-      image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+      image: {{ include "valkey.image" . | quote }}
       command:
         - sh
         - -c
@@ -97,7 +97,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: test-auth
-      image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+      image: {{ include "valkey.image" . | quote }}
       command:
         - sh
         - -c


### PR DESCRIPTION
Fixes #129 