### PR TITLE
Add helm value extraEnvFromSecrets to metrics exporter in order to re…

### DIFF
--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -197,6 +197,13 @@ spec:
             - name: {{ $key }}
               value: "{{ $val }}"
             {{- end }}
+          {{- with .Values.metrics.exporter.extraEnvFromSecrets }}
+          envFrom:
+            {{- range . }}
+            - secretRef:
+                name: {{ .name }}
+            {{- end }}
+          {{- end }}
         {{- end }}
       volumes:
         - name: scripts

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -328,6 +328,9 @@ metrics:
     extraEnvs: {}
     # Example:
     # LOG_LEVEL: info
+    extraEnvFromSecrets: []
+    # Example:
+    #  - name: my-secret
     securityContext: {}
       # Example:
       # runAsNonRoot: true


### PR DESCRIPTION
…ad the contents of a secret as environment variable in metrics exporter container

e.g. if the secret contains the contents like 
```
REDIS_USER: default
REDIS_PASSWORD: asdfgh
```

these will be available in a secure way for the redis exporter