### PR TITLE
fix: pass REDIS_PASSWORD to metrics exporter when auth is enabled

### DIFF
--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -193,6 +193,20 @@ spec:
           env:
             - name: REDIS_ALIAS
               value: {{ include "valkey.fullname" . }}
+            {{- if .Values.auth.enabled }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.auth.usersExistingSecret }}
+                  {{- $defaultUser := index .Values.auth.aclUsers "default" | default dict }}
+                  {{- $passwordKey := $defaultUser.passwordKey | default "default" }}
+                  name: {{ .Values.auth.usersExistingSecret }}
+                  key: {{ $passwordKey }}
+                  {{- else }}
+                  name: {{ include "valkey.fullname" . }}-auth
+                  key: default-password
+                  {{- end }}
+            {{- end }}
             {{- range $key, $val := .Values.metrics.exporter.extraEnvs }}
             - name: {{ $key }}
               value: "{{ $val }}"

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -207,6 +207,20 @@ spec:
           env:
             - name: REDIS_ALIAS
               value: {{ include "valkey.fullname" . }}
+            {{- if .Values.auth.enabled }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.auth.usersExistingSecret }}
+                  {{- $defaultUser := index .Values.auth.aclUsers "default" | default dict }}
+                  {{- $passwordKey := $defaultUser.passwordKey | default "default" }}
+                  name: {{ .Values.auth.usersExistingSecret }}
+                  key: {{ $passwordKey }}
+                  {{- else }}
+                  name: {{ include "valkey.fullname" . }}-auth
+                  key: default-password
+                  {{- end }}
+            {{- end }}
             {{- range $key, $val := .Values.metrics.exporter.extraEnvs }}
             - name: {{ $key }}
               value: "{{ $val }}"

--- a/valkey/tests/deployment_test.yaml
+++ b/valkey/tests/deployment_test.yaml
@@ -322,3 +322,80 @@ tests:
             name: extra-config
             mountPath: /extra-config
             readOnly: true
+
+  - it: should not have REDIS_PASSWORD env in metrics exporter when auth is disabled
+    set:
+      auth.enabled: false
+      metrics.enabled: true
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - notContains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: REDIS_PASSWORD
+
+  - it: should set REDIS_PASSWORD from generated secret in metrics exporter when auth is enabled
+    set:
+      auth.enabled: true
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          password: "default-password"
+      metrics.enabled: true
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-valkey-auth
+                key: default-password
+
+  - it: should set REDIS_PASSWORD from existing secret in metrics exporter when usersExistingSecret is set
+    set:
+      auth.enabled: true
+      auth.usersExistingSecret: "my-custom-secret"
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+      metrics.enabled: true
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-custom-secret
+                key: default
+
+  - it: should set REDIS_PASSWORD using custom passwordKey in metrics exporter when usersExistingSecret is set
+    set:
+      auth.enabled: true
+      auth.usersExistingSecret: "my-custom-secret"
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          passwordKey: "my-password-key"
+      metrics.enabled: true
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-custom-secret
+                key: my-password-key

--- a/valkey/tests/statefulset_test.yaml
+++ b/valkey/tests/statefulset_test.yaml
@@ -254,3 +254,88 @@ tests:
       - equal:
           path: spec.persistentVolumeClaimRetentionPolicy.whenScaled
           value: Delete
+
+  - it: should not have REDIS_PASSWORD env in metrics exporter when auth is disabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      auth.enabled: false
+      metrics.enabled: true
+    template: templates/statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - notContains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: REDIS_PASSWORD
+
+  - it: should set REDIS_PASSWORD from generated secret in metrics exporter when auth is enabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      auth.enabled: true
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          password: "default-password"
+      metrics.enabled: true
+    template: templates/statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-valkey-auth
+                key: default-password
+
+  - it: should set REDIS_PASSWORD from existing secret in metrics exporter when usersExistingSecret is set
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      auth.enabled: true
+      auth.usersExistingSecret: "my-custom-secret"
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+      metrics.enabled: true
+    template: templates/statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-custom-secret
+                key: default
+
+  - it: should set REDIS_PASSWORD using custom passwordKey in metrics exporter when usersExistingSecret is set
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      auth.enabled: true
+      auth.usersExistingSecret: "my-custom-secret"
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          passwordKey: "my-password-key"
+      metrics.enabled: true
+    template: templates/statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-custom-secret
+                key: my-password-key


### PR DESCRIPTION
Passes the `REDIS_PASSWORD` env to the metrics exporter container when auth is enabled. This resolves #135 