### PR TITLE
feat: Add loadBalancerSourceRanges support

### DIFF
--- a/valkey/templates/service-read.yaml
+++ b/valkey/templates/service-read.yaml
@@ -18,6 +18,9 @@ spec:
   {{- if .Values.replica.service.loadBalancerClass }}
   loadBalancerClass: {{ .Values.replica.service.loadBalancerClass }}
   {{- end }}
+  {{- if .Values.replica.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ .Values.replica.service.loadBalancerSourceRanges }}
+  {{- end }}
   ports:
     - name: tcp
       port: {{ .Values.replica.service.port }}

--- a/valkey/templates/service.yaml
+++ b/valkey/templates/service.yaml
@@ -17,6 +17,9 @@ spec:
   {{- if .Values.service.loadBalancerClass }}
   loadBalancerClass: {{ .Values.service.loadBalancerClass }}
   {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ .Values.service.loadBalancerSourceRanges }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: tcp

--- a/valkey/tests/service_read_test.yaml
+++ b/valkey/tests/service_read_test.yaml
@@ -78,6 +78,17 @@ tests:
           of: Service
       - notExists:
           path: spec.loadBalancerClass
+  - it: should be able to set loadBalancerSourceRanges
+    set:
+      replica.enabled: true
+      replica.service.loadBalancerSourceRanges: ["10.0.0.1"]
+    template: templates/service-read.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.loadBalancerSourceRanges
+          value: ["10.0.0.1"]
   - it: should have correct selector labels
     set:
       replica.enabled: true

--- a/valkey/tests/service_test.yaml
+++ b/valkey/tests/service_test.yaml
@@ -68,6 +68,16 @@ tests:
           of: Service
       - notExists:
           path: spec.loadBalancerClass
+  - it: should be able to set loadBalancerSourceRanges
+    set:
+      service.loadBalancerSourceRanges: ["10.0.0.1"]
+    template: templates/service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.loadBalancerSourceRanges
+          value: ["10.0.0.1"]
   - it: should have correct selector labels
     template: templates/service.yaml
     asserts:

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -46,6 +46,9 @@
                 "enabled": {
                     "type": "boolean"
                 },
+                "hostPath": {
+                    "type": "string"
+                },
                 "keepPvc": {
                     "type": "boolean"
                 },
@@ -62,9 +65,6 @@
                     "type": "string"
                 },
                 "volumeName": {
-                    "type": "string"
-                },
-                "hostPath": {
                     "type": "string"
                 }
             }
@@ -85,16 +85,16 @@
         "extraSecretValkeyConfigs": {
             "type": "boolean"
         },
-        "extraVolumes": {
+        "extraValkeyConfigs": {
+            "type": "array"
+        },
+        "extraValkeySecrets": {
             "type": "array"
         },
         "extraVolumeMounts": {
             "type": "array"
         },
-        "extraValkeyConfigs": {
-            "type": "array"
-        },
-        "extraValkeySecrets": {
+        "extraVolumes": {
             "type": "array"
         },
         "fullnameOverride": {
@@ -347,6 +347,14 @@
                 },
                 "runAsUser": {
                     "type": "integer"
+                },
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },
@@ -386,17 +394,7 @@
                     }
                 },
                 "persistentVolumeClaimRetentionPolicy": {
-                    "type": "object",
-                    "properties": {
-                        "whenDeleted": {
-                            "type": "string",
-                            "enum": ["Delete", "Retain"]
-                        },
-                        "whenScaled": {
-                            "type": "string",
-                            "enum": ["Delete", "Retain"]
-                        }
-                    }
+                    "type": "object"
                 },
                 "replicas": {
                     "type": "integer"
@@ -422,6 +420,9 @@
                         "loadBalancerClass": {
                             "type": "string"
                         },
+                        "loadBalancerSourceRanges": {
+                            "type": "array"
+                        },
                         "nodePort": {
                             "type": "integer"
                         },
@@ -441,6 +442,9 @@
         "securityContext": {
             "type": "object",
             "properties": {
+                "allowPrivilegeEscalation": {
+                    "type": "boolean"
+                },
                 "capabilities": {
                     "type": "object",
                     "properties": {
@@ -477,6 +481,9 @@
                 },
                 "loadBalancerClass": {
                     "type": "string"
+                },
+                "loadBalancerSourceRanges": {
+                    "type": "array"
                 },
                 "nodePort": {
                     "type": "integer"

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -74,6 +74,10 @@ service:
   clusterIP: ""
   # Class of a load balancer implementation
   loadBalancerClass: ""
+  # If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer
+  # will be restricted to the specified client IPs.
+  # This field will be ignored if the cloud-provider does not support the feature.
+  loadBalancerSourceRanges: []
   # Application protocol
   appProtocol: ""
 
@@ -234,6 +238,10 @@ replica:
     appProtocol: ""
     # Class of a load balancer implementation
     loadBalancerClass: ""
+    # If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer
+    # will be restricted to the specified client IPs.
+    # This field will be ignored if the cloud-provider does not support the feature.
+    loadBalancerSourceRanges: []
 
   # Persistence configuration (required for replicas)
   persistence:


### PR DESCRIPTION
This PR adds the `loadBalancerSourceRanges` support to the services created by the chart to allow protecting those services by allowing specific IP ranges to connect.