### PR TITLE
Fix: Add missing value for extra volume mounts in StatefulSet

### DIFF
--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -99,6 +99,9 @@ spec:
               readOnly: true
             {{- end }}
             {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.initResources }}
           resources:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
The extraVolumeMount value is set in the [deploy_valkey.yaml](https://github.com/valkey-io/valkey-helm/blob/main/valkey/templates/deploy_valkey.yaml#L86-L88) but missing in the statefulset