### PR TITLE
feat: add Sentinel and Cluster mode support

### DIFF
--- a/valkey/templates/NOTES.txt
+++ b/valkey/templates/NOTES.txt
@@ -10,7 +10,42 @@ Namespace:    {{ .Release.Namespace }}
 Chart:        {{ .Chart.Name }} {{ .Chart.Version }}
 App version:  {{ .Chart.AppVersion }}
 
-{{- if .Values.replica.enabled }}
+{{- if .Values.cluster.enabled }}
+================================================================================
+🔗 CLUSTER MODE (Sharding + HA)
+================================================================================
+
+Your Valkey deployment is running in CLUSTER mode:
+- Masters (shards): {{ .Values.cluster.masters }}
+- Replicas per master: {{ .Values.cluster.replicasPerMaster }}
+- Total nodes: {{ mul (int .Values.cluster.masters) (add1 (int .Values.cluster.replicasPerMaster)) }}
+
+Client Service: {{ include "valkey.cluster.fullname" . }}
+  Type: {{ .Values.cluster.service.type }}
+  Port: {{ .Values.cluster.service.port }}
+
+Headless Service (internal): {{ include "valkey.cluster.headlessServiceName" . }}
+
+IMPORTANT: Use the -c flag for cluster-aware clients:
+
+1) In-cluster access:
+   $ valkey-cli -c -h {{ include "valkey.cluster.fullname" . }} -p {{ .Values.cluster.service.port }}{{ if .Values.tls.enabled }} --tls{{- end }}{{ if .Values.auth.enabled }} --user <user> -a <password>{{ end }} SET key value
+
+2) Local access via kubectl port-forward:
+   $ kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "valkey.cluster.fullname" . }} 6379:{{ .Values.cluster.service.port }}
+   $ valkey-cli -c -h 127.0.0.1 -p 6379{{ if .Values.tls.enabled }} --tls{{- end }}{{ if .Values.auth.enabled }} --user <user> -a <password>{{ end }} SET key value
+
+Direct Pod Access:
+{{- $totalNodes := mul (int .Values.cluster.masters) (add1 (int .Values.cluster.replicasPerMaster)) }}
+{{- range $i := until (int $totalNodes) }}
+  {{ include "valkey.cluster.fullname" $ }}-{{ $i }}.{{ include "valkey.cluster.headlessServiceName" $ }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}
+{{- end }}
+
+Cluster Status:
+  $ valkey-cli -c -h {{ include "valkey.cluster.fullname" . }} -p {{ .Values.cluster.service.port }}{{ if .Values.tls.enabled }} --tls{{- end }}{{ if .Values.auth.enabled }} --user <user> -a <password>{{ end }} CLUSTER INFO
+  $ valkey-cli -c -h {{ include "valkey.cluster.fullname" . }} -p {{ .Values.cluster.service.port }}{{ if .Values.tls.enabled }} --tls{{- end }}{{ if .Values.auth.enabled }} --user <user> -a <password>{{ end }} CLUSTER NODES
+
+{{- else if .Values.replica.enabled }}
 ================================================================================
 🔄 REPLICATION MODE
 ================================================================================
@@ -116,13 +151,25 @@ Port:         {{ .Values.service.port }}
 {{ end }}
 
 ✅ Quick test
+{{- if .Values.cluster.enabled }}
+$ valkey-cli -c -h {{ include "valkey.cluster.fullname" . }} -p {{ .Values.cluster.service.port }}{{ if .Values.tls.enabled }} --tls{{- end }}{{ if .Values.auth.enabled }} --user <user> -a <password>{{ end }}
+{{- else }}
 $ valkey-cli -h {{ include "valkey.fullname" . }} -p {{ .Values.service.port }}{{ if .Values.tls.enabled }} --tls{{- end }}{{ if .Values.auth.enabled }} --user <user> -a <password>{{ end }}
+{{- end }}
 valkey> SET foo bar
 valkey> GET foo
 "bar"
 
 💾 Persistence
-{{- if .Values.replica.enabled }}
+{{- if .Values.cluster.enabled }}
+- Persistence is ENABLED (required for cluster mode). Each node has its own volume.
+- Size: {{ .Values.cluster.persistence.size }}
+{{- if .Values.cluster.persistence.storageClass }}
+- Storage class: {{ .Values.cluster.persistence.storageClass }}
+{{- end }}
+- To see PVCs:
+  $ kubectl -n {{ .Release.Namespace }} get pvc -l app.kubernetes.io/instance={{ .Release.Name }}
+{{- else if .Values.replica.enabled }}
 - Persistence is ENABLED (required for replication mode). Each instance has its own volume.
 - Size: {{ .Values.replica.persistence.size }}
 {{- if .Values.replica.persistence.storageClass }}

--- a/valkey/templates/NOTES.txt
+++ b/valkey/templates/NOTES.txt
@@ -19,6 +19,23 @@ Your Valkey deployment is running in REPLICATION mode:
 - 1 Master  ({{ include "valkey.fullname" . }}-0)
 - {{ .Values.replica.replicas }} Replica(s)
 
+{{- if .Values.sentinel.enabled }}
+
+🛡️ SENTINEL MODE (High Availability)
+
+  Sentinel instances: {{ .Values.sentinel.replicas }}
+  Sentinel service:   {{ include "valkey.sentinel.fullname" . }}:{{ .Values.sentinel.service.port }}
+  Master group name:  {{ .Values.sentinel.masterGroupName }}
+  Quorum:             {{ .Values.sentinel.quorum }}
+
+  Automatic failover is ENABLED. The master pod may change during failover.
+  The primary service ({{ include "valkey.fullname" . }}) automatically routes to the current master.
+
+  For Sentinel-aware clients:
+    sentinel_hosts = ["{{ include "valkey.sentinel.fullname" . }}:{{ .Values.sentinel.service.port }}"]
+    master_name = "{{ .Values.sentinel.masterGroupName }}"
+{{- end }}
+
 {{- if .Values.replica.service.enabled }}
 
 READ Operations (Load-balanced across all pods):

--- a/valkey/templates/_helpers.tpl
+++ b/valkey/templates/_helpers.tpl
@@ -188,3 +188,57 @@ Validate replica authentication configuration
 {{- end }}
 {{- end -}}
 
+{{/*
+Sentinel full name
+*/}}
+{{- define "valkey.sentinel.fullname" -}}
+{{ include "valkey.fullname" . }}-sentinel
+{{- end -}}
+
+{{/*
+Sentinel headless service name
+*/}}
+{{- define "valkey.sentinel.headlessServiceName" -}}
+{{ include "valkey.fullname" . }}-sentinel-headless
+{{- end -}}
+
+{{/*
+Sentinel labels
+*/}}
+{{- define "valkey.sentinel.labels" -}}
+{{ include "valkey.labels" . }}
+app.kubernetes.io/component: sentinel
+{{- end -}}
+
+{{/*
+Sentinel selector labels
+*/}}
+{{- define "valkey.sentinel.selectorLabels" -}}
+{{ include "valkey.selectorLabels" . }}
+app.kubernetes.io/component: sentinel
+{{- end -}}
+
+{{/*
+Returns the role labeler container image
+*/}}
+{{- define "valkey.roleLabeler.image" -}}
+{{- include "common.image" (dict "image" (dict "registry" .Values.sentinel.roleLabeler.image.registry "repository" .Values.sentinel.roleLabeler.image.repository "tag" .Values.sentinel.roleLabeler.image.tag) "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Validate sentinel configuration
+*/}}
+{{- define "valkey.validateSentinelConfig" -}}
+{{- if .Values.sentinel.enabled }}
+  {{- if not .Values.replica.enabled }}
+    {{- fail "Sentinel mode requires replication to be enabled. Please set replica.enabled=true" }}
+  {{- end }}
+  {{- if lt (int .Values.sentinel.replicas) 3 }}
+    {{- fail "Sentinel requires at least 3 replicas for proper quorum. Please set sentinel.replicas >= 3" }}
+  {{- end }}
+  {{- if gt (int .Values.sentinel.quorum) (int .Values.sentinel.replicas) }}
+    {{- fail (printf "Sentinel quorum (%d) cannot be greater than the number of Sentinel replicas (%d)" (int .Values.sentinel.quorum) (int .Values.sentinel.replicas)) }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+

--- a/valkey/templates/_helpers.tpl
+++ b/valkey/templates/_helpers.tpl
@@ -226,6 +226,53 @@ Returns the role labeler container image
 {{- end -}}
 
 {{/*
+Cluster full name
+*/}}
+{{- define "valkey.cluster.fullname" -}}
+{{ include "valkey.fullname" . }}-cluster
+{{- end -}}
+
+{{/*
+Cluster headless service name
+*/}}
+{{- define "valkey.cluster.headlessServiceName" -}}
+{{ include "valkey.fullname" . }}-cluster-headless
+{{- end -}}
+
+{{/*
+Cluster labels
+*/}}
+{{- define "valkey.cluster.labels" -}}
+{{ include "valkey.labels" . }}
+app.kubernetes.io/component: cluster
+{{- end -}}
+
+{{/*
+Cluster selector labels
+*/}}
+{{- define "valkey.cluster.selectorLabels" -}}
+{{ include "valkey.selectorLabels" . }}
+app.kubernetes.io/component: cluster
+{{- end -}}
+
+{{/*
+Validate cluster configuration
+*/}}
+{{- define "valkey.validateClusterConfig" -}}
+{{- if .Values.cluster.enabled }}
+  {{- if .Values.replica.enabled }}
+    {{- fail "cluster.enabled and replica.enabled are mutually exclusive. Please enable only one deployment mode." }}
+  {{- end }}
+  {{- if lt (int .Values.cluster.masters) 3 }}
+    {{- fail "Cluster mode requires at least 3 master nodes. Please set cluster.masters >= 3" }}
+  {{- end }}
+  {{- if not .Values.cluster.persistence.size }}
+    {{- fail "Cluster mode requires persistent storage. Please set cluster.persistence.size (e.g., '5Gi')" }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Validate sentinel configuration
 */}}
 {{- define "valkey.validateSentinelConfig" -}}

--- a/valkey/templates/cluster-configmap.yaml
+++ b/valkey/templates/cluster-configmap.yaml
@@ -1,0 +1,260 @@
+{{- if .Values.cluster.enabled }}
+{{- include "valkey.validateClusterConfig" . }}
+{{- include "valkey.validateAuthConfig" . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "valkey.cluster.fullname" . }}-scripts
+  labels:
+    {{- include "valkey.cluster.labels" . | nindent 4 }}
+data:
+  cluster-init.sh: |-
+    #!/bin/sh
+    set -eu
+
+    VALKEY_CONFIG="/data/conf/valkey.conf"
+    DATA_DIR="/data/conf"
+    LOGFILE="/data/init.log"
+
+    log() {
+      echo "$(date) $1" | tee -a "$LOGFILE" >&2
+    }
+
+    rm -f "$LOGFILE"
+    mkdir -p "$DATA_DIR"
+    rm -f "$VALKEY_CONFIG"
+
+    {{- if .Values.auth.enabled }}
+    # Function to get password for a user
+    get_user_password() {
+      username="$1"
+      password_key="${2:-$username}"
+      password=""
+
+      {{- if .Values.auth.usersExistingSecret }}
+      if [ -f "/valkey-users-secret/$password_key" ]; then
+        password=$(cat "/valkey-users-secret/$password_key")
+        log "Using password from existing secret for user $username"
+      elif [ -f "/valkey-auth-secret/${username}-password" ]; then
+        password=$(cat "/valkey-auth-secret/${username}-password")
+        log "Using inline password for user $username"
+      else
+        log "ERROR: No password found for user $username"
+        return 1
+      fi
+      {{- else }}
+      if [ -f "/valkey-auth-secret/${username}-password" ]; then
+        password=$(cat "/valkey-auth-secret/${username}-password")
+        log "Using inline password for user $username"
+      else
+        log "ERROR: No password found for user $username"
+        return 1
+      fi
+      {{- end }}
+
+      echo "$password"
+    }
+    {{- end }}
+
+    # Base valkey.conf
+    log "Generating base valkey.conf"
+    {
+{{- if .Values.tls.enabled }}
+      echo "tls-cert-file /tls/{{ .Values.tls.serverPublicKey }}"
+      echo "tls-key-file /tls/{{ .Values.tls.serverKey }}"
+      echo "tls-ca-cert-file /tls/{{ .Values.tls.caPublicKey }}"
+      {{- if .Values.tls.dhParamKey }}
+      echo "tls-dh-params-file /tls/{{ .Values.tls.dhParamKey }}"
+      {{- end }}
+      {{- if not .Values.tls.requireClientCertificate }}
+      echo "tls-auth-clients no"
+      {{- end }}
+      echo "port 0"
+      echo "tls-port {{ .Values.cluster.service.port }}"
+      echo "tls-replication yes"
+{{- else }}
+      echo "port {{ .Values.cluster.service.port }}"
+{{- end }}
+      echo "protected-mode no"
+      echo "bind * -::*"
+      echo "dir /data"
+      echo ""
+      echo "# Cluster configuration"
+      echo "cluster-enabled yes"
+      echo "cluster-config-file /data/nodes.conf"
+      echo "cluster-node-timeout {{ .Values.cluster.nodeTimeout }}"
+    } >>"$VALKEY_CONFIG"
+
+    # Announce this node's hostname for cluster communication
+    HEADLESS_SVC="{{ include "valkey.cluster.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+    MY_FQDN="${HOSTNAME}.${HEADLESS_SVC}"
+    {
+      echo ""
+      echo "# Cluster announce"
+      echo "cluster-announce-hostname ${MY_FQDN}"
+      echo "cluster-preferred-endpoint-type hostname"
+    } >>"$VALKEY_CONFIG"
+
+    {{- if .Values.auth.enabled }}
+    # Create secure directory for ACL file
+    log "Creating /etc/valkey directory for ACL file"
+    mkdir -p /etc/valkey
+
+    echo "aclfile /etc/valkey/users.acl" >>"$VALKEY_CONFIG"
+
+    log "Preparing ACL file at /etc/valkey/users.acl"
+    if [ -f /etc/valkey/users.acl ]; then
+      chmod 0600 /etc/valkey/users.acl
+      rm -f /etc/valkey/users.acl
+    fi
+
+    touch /etc/valkey/users.acl
+    chmod 0600 /etc/valkey/users.acl
+
+    {{- if .Values.auth.aclUsers }}
+    log "Generating ACL entries for users"
+    {{- range $username, $user := .Values.auth.aclUsers }}
+    {{- $passwordKey := $user.passwordKey | default $username }}
+
+    PASSWORD=$(get_user_password "{{ $username }}" "{{ $passwordKey }}") || exit 1
+    PASSHASH=$(echo -n "$PASSWORD" | sha256sum | cut -f 1 -d " ")
+    echo "user {{ $username }} on #$PASSHASH {{ $user.permissions }}" >> /etc/valkey/users.acl
+    {{- end }}
+    {{- end }}
+
+    {{- if .Values.auth.aclConfig }}
+    log "Appending custom ACL configuration"
+    if [ -f /valkey-auth-secret/aclConfig ]; then
+      cat /valkey-auth-secret/aclConfig >> /etc/valkey/users.acl
+    fi
+    {{- end }}
+
+    chmod 0400 /etc/valkey/users.acl
+    log "ACL file created with 0400 permissions"
+    {{- end }}
+
+    # Append extra configs if present
+    {{- if .Values.valkeyConfig }}
+    if [ -f /usr/local/etc/valkey/valkey.conf ]; then
+      log "Appending /usr/local/etc/valkey/valkey.conf"
+      cat /usr/local/etc/valkey/valkey.conf >>"$VALKEY_CONFIG"
+    fi
+    {{- end }}
+
+    {{- if .Values.cluster.extraConfig }}
+    # Append extra cluster configuration
+    cat >> "$VALKEY_CONFIG" << 'EXTRACONF'
+
+    {{ .Values.cluster.extraConfig }}
+    EXTRACONF
+    {{- end }}
+
+    log "Cluster node configuration generated successfully"
+
+  cluster-bootstrap.sh: |-
+    #!/bin/sh
+    set -eu
+
+    LOGFILE="/data/bootstrap.log"
+    DATA_PORT="{{ .Values.cluster.service.port }}"
+    HEADLESS_SVC="{{ include "valkey.cluster.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+    TOTAL_NODES={{ mul (int .Values.cluster.masters) (add1 (int .Values.cluster.replicasPerMaster)) }}
+    REPLICAS_PER_MASTER={{ int .Values.cluster.replicasPerMaster }}
+
+    log() {
+      echo "$(date) $1" | tee -a "$LOGFILE" >&2
+    }
+
+    rm -f "$LOGFILE"
+
+    {{- if .Values.tls.enabled }}
+    CLI_TLS_FLAGS="--tls --cacert /tls/{{ .Values.tls.caPublicKey }} --cert /tls/{{ .Values.tls.serverPublicKey }} --key /tls/{{ .Values.tls.serverKey }}"
+    {{- else }}
+    CLI_TLS_FLAGS=""
+    {{- end }}
+
+    {{- if .Values.auth.enabled }}
+    {{- $defaultUser := index .Values.auth.aclUsers "default" | default dict }}
+    {{- $defaultPasswordKey := $defaultUser.passwordKey | default "default" }}
+    AUTH_PASSWORD=""
+    {{- if .Values.auth.usersExistingSecret }}
+    if [ -f "/valkey-users-secret/{{ $defaultPasswordKey }}" ]; then
+      AUTH_PASSWORD=$(cat "/valkey-users-secret/{{ $defaultPasswordKey }}")
+    elif [ -f "/valkey-auth-secret/default-password" ]; then
+      AUTH_PASSWORD=$(cat "/valkey-auth-secret/default-password")
+    fi
+    {{- else }}
+    if [ -f "/valkey-auth-secret/default-password" ]; then
+      AUTH_PASSWORD=$(cat "/valkey-auth-secret/default-password")
+    fi
+    {{- end }}
+    CLI_AUTH_FLAGS="-a $AUTH_PASSWORD --no-auth-warning"
+    {{- else }}
+    CLI_AUTH_FLAGS=""
+    {{- end }}
+
+    # Wait for local node to be ready
+    log "Waiting for local Valkey node to respond..."
+    until valkey-cli -p "$DATA_PORT" $CLI_TLS_FLAGS $CLI_AUTH_FLAGS PING 2>/dev/null | grep -q PONG; do
+      sleep 1
+    done
+    log "Local node is ready"
+
+    # Check if cluster is already formed
+    CLUSTER_STATE=$(valkey-cli -p "$DATA_PORT" $CLI_TLS_FLAGS $CLI_AUTH_FLAGS CLUSTER INFO 2>/dev/null | grep cluster_state | tr -d '\r' || echo "")
+    if echo "$CLUSTER_STATE" | grep -q "cluster_state:ok"; then
+      log "Cluster is already formed, sleeping"
+      exec sleep infinity
+    fi
+
+    # Only pod-0 orchestrates cluster creation
+    POD_INDEX=${POD_INDEX:-0}
+    if [ "$POD_INDEX" != "0" ]; then
+      log "Not pod-0 (index=$POD_INDEX), waiting for cluster to be formed..."
+      while true; do
+        CLUSTER_STATE=$(valkey-cli -p "$DATA_PORT" $CLI_TLS_FLAGS $CLI_AUTH_FLAGS CLUSTER INFO 2>/dev/null | grep cluster_state | tr -d '\r' || echo "")
+        if echo "$CLUSTER_STATE" | grep -q "cluster_state:ok"; then
+          log "Cluster is now formed, sleeping"
+          exec sleep infinity
+        fi
+        sleep 2
+      done
+    fi
+
+    # Pod-0: wait for all nodes to be reachable
+    log "Pod-0: Waiting for all $TOTAL_NODES nodes to be reachable..."
+    NODE_ADDRS=""
+    i=0
+    while [ $i -lt $TOTAL_NODES ]; do
+      NODE_HOST="{{ include "valkey.cluster.fullname" . }}-${i}.${HEADLESS_SVC}"
+      log "Waiting for node ${NODE_HOST}:${DATA_PORT}..."
+      until valkey-cli -h "$NODE_HOST" -p "$DATA_PORT" $CLI_TLS_FLAGS $CLI_AUTH_FLAGS PING 2>/dev/null | grep -q PONG; do
+        sleep 2
+      done
+      log "Node ${NODE_HOST} is ready"
+      NODE_ADDRS="${NODE_ADDRS} ${NODE_HOST}:${DATA_PORT}"
+      i=$((i + 1))
+    done
+
+    log "All nodes ready. Creating cluster..."
+    log "Nodes:${NODE_ADDRS}"
+    log "Replicas per master: ${REPLICAS_PER_MASTER}"
+
+    # Create the cluster
+    valkey-cli --cluster create ${NODE_ADDRS} \
+      --cluster-replicas ${REPLICAS_PER_MASTER} \
+      --cluster-yes \
+      $CLI_TLS_FLAGS $CLI_AUTH_FLAGS
+
+    log "Cluster creation complete"
+
+    # Verify cluster state
+    CLUSTER_STATE=$(valkey-cli -p "$DATA_PORT" $CLI_TLS_FLAGS $CLI_AUTH_FLAGS CLUSTER INFO 2>/dev/null | grep cluster_state | tr -d '\r' || echo "")
+    if echo "$CLUSTER_STATE" | grep -q "cluster_state:ok"; then
+      log "Cluster verified: state is OK, sleeping"
+      exec sleep infinity
+    else
+      log "WARNING: Cluster state is not OK after creation: $CLUSTER_STATE"
+      exit 1
+    fi
+{{- end }}

--- a/valkey/templates/cluster-headless.yaml
+++ b/valkey/templates/cluster-headless.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.cluster.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "valkey.cluster.headlessServiceName" . }}
+  labels:
+    {{- include "valkey.cluster.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: {{ .Values.cluster.service.port }}
+      targetPort: tcp
+      protocol: TCP
+      name: tcp
+    - port: {{ add (int .Values.cluster.service.port) 10000 }}
+      targetPort: cluster-bus
+      protocol: TCP
+      name: cluster-bus
+  selector:
+    {{- include "valkey.cluster.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/valkey/templates/cluster-pdb.yaml
+++ b/valkey/templates/cluster-pdb.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.cluster.enabled .Values.cluster.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "valkey.cluster.fullname" . }}
+  labels:
+    {{- include "valkey.cluster.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.cluster.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.cluster.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.cluster.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.cluster.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "valkey.cluster.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/valkey/templates/cluster-service.yaml
+++ b/valkey/templates/cluster-service.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.cluster.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "valkey.cluster.fullname" . }}
+  labels:
+    {{- include "valkey.cluster.labels" . | nindent 4 }}
+  {{- with .Values.cluster.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.cluster.service.type }}
+  {{- if .Values.cluster.service.clusterIP }}
+  clusterIP: {{ .Values.cluster.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.cluster.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.cluster.service.loadBalancerClass }}
+  {{- end }}
+  {{- if .Values.cluster.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ .Values.cluster.service.loadBalancerSourceRanges }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.cluster.service.port }}
+      targetPort: tcp
+      protocol: TCP
+      name: tcp
+      {{- if and (eq .Values.cluster.service.type "NodePort") .Values.cluster.service.nodePort }}
+      nodePort: {{ .Values.cluster.service.nodePort }}
+      {{- end }}
+      {{- if .Values.cluster.service.appProtocol }}
+      appProtocol: {{ .Values.cluster.service.appProtocol }}
+      {{- end }}
+  selector:
+    {{- include "valkey.cluster.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/valkey/templates/cluster-statefulset.yaml
+++ b/valkey/templates/cluster-statefulset.yaml
@@ -1,0 +1,464 @@
+{{- if .Values.cluster.enabled }}
+{{- include "valkey.validateClusterConfig" . }}
+{{- include "valkey.validateAuthConfig" . }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "valkey.cluster.fullname" . }}
+  labels:
+    {{- include "valkey.cluster.labels" . | nindent 4 }}
+  {{- with .Values.cluster.workloadAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  serviceName: {{ include "valkey.cluster.headlessServiceName" . }}
+  replicas: {{ mul (int .Values.cluster.masters) (add1 (int .Values.cluster.replicasPerMaster)) }}
+  podManagementPolicy: Parallel
+  {{- if .Values.cluster.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml .Values.cluster.persistentVolumeClaimRetentionPolicy | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "valkey.cluster.selectorLabels" . | nindent 6 }}
+  volumeClaimTemplates:
+  - metadata:
+      name: valkey-data
+    spec:
+      accessModes: {{ toYaml .Values.cluster.persistence.accessModes | nindent 8 }}
+      {{- if .Values.cluster.persistence.storageClass }}
+      storageClassName: {{ .Values.cluster.persistence.storageClass | quote }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.cluster.persistence.size | quote }}
+  template:
+    metadata:
+      labels:
+        {{- include "valkey.cluster.selectorLabels" . | nindent 8 }}
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.cluster.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+      {{- with .Values.cluster.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+        checksum/cluster-scripts: {{ include (print $.Template.BasePath "/cluster-configmap.yaml") . | sha256sum | trunc 32 | quote }}
+        {{- if .Values.valkeyConfig }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 32 | quote }}
+        {{- end }}
+    spec:
+      {{- (include "valkey.imagePullSecrets" .) | nindent 6 }}
+      {{- if .Values.cluster.roleLabeler.enabled }}
+      automountServiceAccountToken: true
+      {{- else }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      {{- end }}
+      serviceAccountName: {{ include "valkey.serviceAccountName" . }}
+      {{- if .Values.cluster.priorityClassName }}
+      priorityClassName: {{ .Values.cluster.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.cluster.podSecurityContext }}
+      securityContext:
+        {{- toYaml .Values.cluster.podSecurityContext | nindent 8 }}
+      {{- else }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
+      initContainers:
+        - name: cluster-init
+          image: {{ include "valkey.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.cluster.securityContext }}
+          securityContext:
+            {{- toYaml .Values.cluster.securityContext | nindent 12 }}
+          {{- else }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
+          command: [ "/scripts/cluster-init.sh" ]
+          volumeMounts:
+            - name: valkey-data
+              mountPath: /data
+            - name: cluster-scripts
+              mountPath: /scripts
+            {{- if .Values.tls.enabled }}
+            - name: {{ include "valkey.fullname" . }}-tls
+              mountPath: /tls
+            {{- end }}
+            {{- if .Values.valkeyConfig }}
+            - name: valkey-config
+              mountPath: /usr/local/etc/valkey/valkey.conf
+              subPath: valkey.conf
+            {{- end }}
+            {{- if .Values.auth.enabled }}
+            - name: valkey-acl
+              mountPath: /etc/valkey
+            {{- if .Values.auth.usersExistingSecret }}
+            - name: valkey-users-secret
+              mountPath: /valkey-users-secret
+              readOnly: true
+            {{- end }}
+            {{- if or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig }}
+            - name: valkey-auth-secret
+              mountPath: /valkey-auth-secret
+              readOnly: true
+            {{- end }}
+            {{- end }}
+          {{- with .Values.initResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.extraInitContainers }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: valkey
+          image: {{ include "valkey.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: [ "valkey-server" ]
+          args: [ "/data/conf/valkey.conf" ]
+          {{- if .Values.cluster.securityContext }}
+          securityContext:
+            {{- toYaml .Values.cluster.securityContext | nindent 12 }}
+          {{- else }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
+          env:
+            - name: POD_INDEX
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+            {{- range $key, $val := .Values.env }}
+            - name: {{ $key }}
+              value: "{{ $val }}"
+            {{- end }}
+            - name: VALKEY_LOGLEVEL
+              value: "{{ .Values.valkeyLogLevel }}"
+          ports:
+            - name: tcp
+              containerPort: {{ .Values.cluster.service.port }}
+              protocol: TCP
+            - name: cluster-bus
+              containerPort: {{ add (int .Values.cluster.service.port) 10000 }}
+              protocol: TCP
+          {{- $cliFlags := printf "-p %s" (toString .Values.cluster.service.port) }}
+          {{- if .Values.tls.enabled }}
+          {{- $cliFlags = printf "%s --cacert /tls/%s --tls" $cliFlags .Values.tls.caPublicKey }}
+          {{- end }}
+          {{- $authCmd := "" }}
+          {{- if .Values.auth.enabled }}
+            {{- if .Values.auth.usersExistingSecret }}
+              {{- $defaultUser := index .Values.auth.aclUsers "default" | default dict }}
+              {{- $defaultPasswordKey := $defaultUser.passwordKey | default "default" }}
+              {{- $authCmd = printf "AUTH_PASS=$(cat /valkey-users-secret/%s 2>/dev/null || cat /valkey-auth-secret/default-password); " $defaultPasswordKey }}
+            {{- else }}
+              {{- $authCmd = "AUTH_PASS=$(cat /valkey-auth-secret/default-password); " }}
+            {{- end }}
+            {{- $cliFlags = printf "%s -a $AUTH_PASS --no-auth-warning" $cliFlags }}
+          {{- end }}
+          startupProbe:
+            exec:
+              command: [ "sh", "-c", "{{ $authCmd }}valkey-cli {{ $cliFlags }} ping" ]
+          livenessProbe:
+            exec:
+              command: [ "sh", "-c", "{{ $authCmd }}valkey-cli {{ $cliFlags }} ping" ]
+          readinessProbe:
+            exec:
+              command: [ "sh", "-c", "{{ $authCmd }}valkey-cli {{ $cliFlags }} cluster info | grep -q cluster_state:ok" ]
+          {{- with (.Values.cluster.resources | default .Values.resources) }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: valkey-data
+              mountPath: /data
+            {{- if .Values.tls.enabled }}
+            - name: {{ include "valkey.fullname" . }}-tls
+              mountPath: /tls
+            {{- end }}
+            {{- if .Values.auth.enabled }}
+            - name: valkey-acl
+              mountPath: /etc/valkey
+            {{- if .Values.auth.usersExistingSecret }}
+            - name: valkey-users-secret
+              mountPath: /valkey-users-secret
+              readOnly: true
+            {{- end }}
+            {{- if or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig }}
+            - name: valkey-auth-secret
+              mountPath: /valkey-auth-secret
+              readOnly: true
+            {{- end }}
+            {{- end }}
+            {{- range $secret := .Values.extraValkeySecrets }}
+            - name: {{ $secret.name }}-valkey
+              mountPath: {{ $secret.mountPath }}
+            {{- end }}
+            {{- range $config := .Values.extraValkeyConfigs }}
+            - name: {{ $config.name }}-valkey
+              mountPath: {{ $config.mountPath }}
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        - name: cluster-bootstrap
+          image: {{ include "valkey.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.cluster.securityContext }}
+          securityContext:
+            {{- toYaml .Values.cluster.securityContext | nindent 12 }}
+          {{- else }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
+          command: [ "/scripts/cluster-bootstrap.sh" ]
+          env:
+            - name: POD_INDEX
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+          volumeMounts:
+            - name: valkey-data
+              mountPath: /data
+            - name: cluster-scripts
+              mountPath: /scripts
+            {{- if .Values.tls.enabled }}
+            - name: {{ include "valkey.fullname" . }}-tls
+              mountPath: /tls
+            {{- end }}
+            {{- if .Values.auth.enabled }}
+            {{- if .Values.auth.usersExistingSecret }}
+            - name: valkey-users-secret
+              mountPath: /valkey-users-secret
+              readOnly: true
+            {{- end }}
+            {{- if or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig }}
+            - name: valkey-auth-secret
+              mountPath: /valkey-auth-secret
+              readOnly: true
+            {{- end }}
+            {{- end }}
+          {{- with .Values.initResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          image: {{ include "valkey.metrics.exporter.image" . }}
+          imagePullPolicy: {{ .Values.metrics.exporter.image.pullPolicy | quote }}
+          {{- with .Values.metrics.exporter.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.metrics.exporter.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.metrics.exporter.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.metrics.exporter.port }}
+          startupProbe:
+            tcpSocket:
+              port: metrics
+          livenessProbe:
+            tcpSocket:
+              port: metrics
+          readinessProbe:
+            httpGet:
+              path: /
+              port: metrics
+          {{- with .Values.metrics.exporter.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.metrics.exporter.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: REDIS_ALIAS
+              value: {{ include "valkey.fullname" . }}
+            {{- if .Values.auth.enabled }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.auth.usersExistingSecret }}
+                  {{- $defaultUser := index .Values.auth.aclUsers "default" | default dict }}
+                  {{- $passwordKey := $defaultUser.passwordKey | default "default" }}
+                  name: {{ .Values.auth.usersExistingSecret }}
+                  key: {{ $passwordKey }}
+                  {{- else }}
+                  name: {{ include "valkey.fullname" . }}-auth
+                  key: default-password
+                  {{- end }}
+            {{- end }}
+            {{- range $key, $val := .Values.metrics.exporter.extraEnvs }}
+            - name: {{ $key }}
+              value: "{{ $val }}"
+            {{- end }}
+        {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.cluster.roleLabeler.enabled }}
+        - name: role-checker
+          image: {{ include "valkey.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 1000
+          command: [ "/scripts/role-checker.sh" ]
+          volumeMounts:
+            - name: role-labeler-scripts
+              mountPath: /scripts
+            - name: role-shared
+              mountPath: /role
+            {{- if .Values.auth.enabled }}
+            {{- if .Values.auth.usersExistingSecret }}
+            - name: valkey-users-secret
+              mountPath: /valkey-users-secret
+              readOnly: true
+            {{- end }}
+            {{- if or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig }}
+            - name: valkey-auth-secret
+              mountPath: /valkey-auth-secret
+              readOnly: true
+            {{- end }}
+            {{- end }}
+            {{- if .Values.tls.enabled }}
+            - name: {{ include "valkey.fullname" . }}-tls
+              mountPath: /tls
+            {{- end }}
+          {{- with .Values.cluster.roleLabeler.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        - name: role-labeler
+          image: {{ include "valkey.roleLabeler.image" . }}
+          imagePullPolicy: {{ .Values.cluster.roleLabeler.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          command: [ "/scripts/role-labeler.sh" ]
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: role-labeler-scripts
+              mountPath: /scripts
+            - name: role-shared
+              mountPath: /role
+          {{- with .Values.cluster.roleLabeler.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
+      volumes:
+        - name: cluster-scripts
+          configMap:
+            name: {{ include "valkey.cluster.fullname" . }}-scripts
+            defaultMode: 0555
+        {{- if .Values.cluster.roleLabeler.enabled }}
+        - name: role-labeler-scripts
+          configMap:
+            name: {{ include "valkey.fullname" . }}-role-labeler
+            defaultMode: 0555
+        - name: role-shared
+          emptyDir:
+            medium: Memory
+        {{- end }}
+        {{- if .Values.auth.enabled }}
+        - name: valkey-acl
+          emptyDir:
+            medium: Memory
+        {{- end }}
+        {{- if .Values.valkeyConfig }}
+        - name: valkey-config
+          configMap:
+            name: {{ include "valkey.fullname" . }}-config
+        {{- end }}
+        {{- range .Values.extraValkeySecrets }}
+        - name: {{ .name }}-valkey
+          secret:
+            secretName: {{ .name }}
+            defaultMode: {{ .defaultMode | default 0440 }}
+        {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: {{ include "valkey.fullname" . }}-tls
+          secret:
+            secretName: {{ required "An existing secret is required to enable TLS" .Values.tls.existingSecret }}
+            defaultMode: 0400
+        {{- end }}
+        {{- range .Values.extraValkeyConfigs }}
+        - name: {{ .name }}-valkey
+          configMap:
+            name: {{ .name }}
+            defaultMode: {{ .defaultMode | default 0440 }}
+        {{- end }}
+        {{- if .Values.metrics.enabled }}
+        {{- range .Values.metrics.exporter.extraExporterSecrets }}
+        - name: {{ .name }}-exporter
+          secret:
+            secretName: {{ .name }}
+            defaultMode: {{ .defaultMode | default 0440 }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.auth.enabled }}
+        {{- if .Values.auth.usersExistingSecret }}
+        - name: valkey-users-secret
+          secret:
+            secretName: {{ .Values.auth.usersExistingSecret }}
+            defaultMode: 0400
+        {{- end }}
+        {{- if or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig }}
+        - name: valkey-auth-secret
+          secret:
+            secretName: {{ include "valkey.fullname" . }}-auth
+            defaultMode: 0400
+        {{- end }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with (.Values.cluster.nodeSelector | default .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cluster.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cluster.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.cluster.tolerations | default .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.replica.enabled }}
+{{- if and (not .Values.replica.enabled) (not .Values.cluster.enabled) }}
 {{- $fullname := include "valkey.fullname" . }}
 {{- $storage := .Values.dataStorage }}
 {{- $createPVC := and $storage.enabled (not (empty $storage.requestedSize)) (empty $storage.persistentVolumeClaimName) }}

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.cluster.enabled }}
 {{- include "valkey.validateSentinelConfig" . }}
 apiVersion: v1
 kind: ConfigMap
@@ -280,4 +281,4 @@ data:
       log "Appending files in /extravalkeyconfigs/"
       cat /extravalkeyconfigs/* >>"$VALKEY_CONFIG"
     fi
-
+{{- end }}

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -1,3 +1,4 @@
+{{- include "valkey.validateSentinelConfig" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -150,27 +151,78 @@ data:
     # Use POD_INDEX from Kubernetes metadata
     POD_INDEX=${POD_INDEX:-0}
     IS_MASTER=false
+    MASTER_HOST=""
+    MASTER_PORT="{{ .Values.service.port }}"
+    MY_FQDN="{{ include "valkey.fullname" . }}-$POD_INDEX.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
 
-    # Check if this is pod-0 (master)
+    {{- if .Values.sentinel.enabled }}
+    # Sentinel mode: query Sentinel for current master
+    SENTINEL_HOST="{{ include "valkey.sentinel.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+    SENTINEL_PORT="{{ .Values.sentinel.port }}"
+    MASTER_GROUP="{{ .Values.sentinel.masterGroupName }}"
+
+    log "Querying Sentinel at ${SENTINEL_HOST}:${SENTINEL_PORT} for master of group ${MASTER_GROUP}..."
+
+    {{- if .Values.tls.enabled }}
+    MASTER_INFO=$(valkey-cli -h "$SENTINEL_HOST" -p "$SENTINEL_PORT" --tls --cacert /tls/{{ .Values.tls.caPublicKey }} \
+      SENTINEL get-master-addr-by-name "$MASTER_GROUP" 2>/dev/null || echo "")
+    {{- else }}
+    MASTER_INFO=$(valkey-cli -h "$SENTINEL_HOST" -p "$SENTINEL_PORT" \
+      SENTINEL get-master-addr-by-name "$MASTER_GROUP" 2>/dev/null || echo "")
+    {{- end }}
+
+    if [ -n "$MASTER_INFO" ]; then
+      SENTINEL_MASTER_HOST=$(echo "$MASTER_INFO" | head -1)
+      SENTINEL_MASTER_PORT=$(echo "$MASTER_INFO" | sed -n '2p')
+
+      log "Sentinel reports master at ${SENTINEL_MASTER_HOST}:${SENTINEL_MASTER_PORT}"
+
+      # Resolve my hostname IP for comparison
+      MY_IP=$(getent hosts "$MY_FQDN" 2>/dev/null | awk '{print $1}' | head -1 || echo "")
+      MASTER_IP=$(getent hosts "$SENTINEL_MASTER_HOST" 2>/dev/null | awk '{print $1}' | head -1 || echo "$SENTINEL_MASTER_HOST")
+
+      if [ "$MY_IP" = "$MASTER_IP" ] || [ "$MY_FQDN" = "$SENTINEL_MASTER_HOST" ]; then
+        IS_MASTER=true
+        log "This pod is the current master (confirmed by Sentinel)"
+      else
+        IS_MASTER=false
+        MASTER_HOST="$SENTINEL_MASTER_HOST"
+        MASTER_PORT="${SENTINEL_MASTER_PORT:-{{ .Values.service.port }}}"
+        log "This pod is a replica, master is at ${MASTER_HOST}:${MASTER_PORT}"
+      fi
+    else
+      # Bootstrap fallback: Sentinel not available yet
+      log "Sentinel not available, falling back to bootstrap mode"
+      if [ "$POD_INDEX" = "0" ]; then
+        IS_MASTER=true
+        log "This pod (index $POD_INDEX) is configured as MASTER (bootstrap)"
+      else
+        IS_MASTER=false
+        MASTER_HOST="{{ include "valkey.fullname" . }}-0.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+        log "This pod (index $POD_INDEX) is configured as REPLICA (bootstrap), master at $MASTER_HOST"
+      fi
+    fi
+    {{- else }}
+    # Static master assignment: pod-0 is always master
     if [ "$POD_INDEX" = "0" ]; then
       IS_MASTER=true
       log "This pod (index $POD_INDEX) is configured as MASTER"
     else
+      IS_MASTER=false
+      MASTER_HOST="{{ include "valkey.fullname" . }}-0.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
       log "This pod (index $POD_INDEX) is configured as REPLICA"
     fi
+    {{- end }}
 
     # Configure replica settings
     if [ "$IS_MASTER" = "false" ]; then
-      MASTER_HOST="{{ include "valkey.fullname" . }}-0.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
-      MASTER_PORT="{{ .Values.service.port }}"
-
       log "Configuring replica to follow master at $MASTER_HOST:$MASTER_PORT"
 
       {
         echo ""
         echo "# Replica Configuration"
         echo "replicaof $MASTER_HOST $MASTER_PORT"
-        echo "replica-announce-ip {{ include "valkey.fullname" . }}-$POD_INDEX.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+        echo "replica-announce-ip $MY_FQDN"
         {{- if .Values.replica.disklessSync }}
         echo ""
         echo "# Diskless replication"

--- a/valkey/templates/pvc.yaml
+++ b/valkey/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.dataStorage.enabled (not .Values.replica.enabled) (not (empty .Values.dataStorage.requestedSize)) (empty .Values.dataStorage.persistentVolumeClaimName) }}
+{{- if and .Values.dataStorage.enabled (not .Values.replica.enabled) (not .Values.cluster.enabled) (not (empty .Values.dataStorage.requestedSize)) (empty .Values.dataStorage.persistentVolumeClaimName) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/valkey/templates/role-labeler-configmap.yaml
+++ b/valkey/templates/role-labeler-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.replica.enabled .Values.sentinel.enabled .Values.sentinel.roleLabeler.enabled }}
+{{- if or (and .Values.replica.enabled .Values.sentinel.enabled .Values.sentinel.roleLabeler.enabled) (and .Values.cluster.enabled .Values.cluster.roleLabeler.enabled) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,11 +10,33 @@ data:
     #!/bin/sh
     set -eu
 
+    {{- if .Values.cluster.enabled }}
+    POLL_INTERVAL={{ .Values.cluster.roleLabeler.pollIntervalSeconds }}
+    VALKEY_PORT="{{ .Values.cluster.service.port }}"
+    {{- else }}
     POLL_INTERVAL={{ .Values.sentinel.roleLabeler.pollIntervalSeconds }}
     VALKEY_PORT="{{ .Values.service.port }}"
+    {{- end }}
     ROLE_FILE="/role/current-role"
 
     {{- if .Values.auth.enabled }}
+    {{- if .Values.cluster.enabled }}
+    {{- $defaultUser := index .Values.auth.aclUsers "default" | default dict }}
+    {{- $defaultPasswordKey := $defaultUser.passwordKey | default "default" }}
+    AUTH_PASSWORD=""
+    {{- if .Values.auth.usersExistingSecret }}
+    if [ -f "/valkey-users-secret/{{ $defaultPasswordKey }}" ]; then
+      AUTH_PASSWORD=$(cat "/valkey-users-secret/{{ $defaultPasswordKey }}")
+    elif [ -f "/valkey-auth-secret/default-password" ]; then
+      AUTH_PASSWORD=$(cat "/valkey-auth-secret/default-password")
+    fi
+    {{- else }}
+    if [ -f "/valkey-auth-secret/default-password" ]; then
+      AUTH_PASSWORD=$(cat "/valkey-auth-secret/default-password")
+    fi
+    {{- end }}
+    CLI_AUTH="-a ${AUTH_PASSWORD} --no-auth-warning"
+    {{- else }}
     {{- $replUsername := .Values.replica.replicationUser }}
     {{- $replUser := index .Values.auth.aclUsers $replUsername }}
     {{- $replPasswordKey := $replUser.passwordKey | default $replUsername }}
@@ -31,6 +53,7 @@ data:
     fi
     {{- end }}
     CLI_AUTH="--user {{ $replUsername }} -a ${AUTH_PASSWORD} --no-auth-warning"
+    {{- end }}
     {{- else }}
     CLI_AUTH=""
     {{- end }}
@@ -57,7 +80,11 @@ data:
     #!/bin/sh
     set -eu
 
+    {{- if .Values.cluster.enabled }}
+    POLL_INTERVAL={{ .Values.cluster.roleLabeler.pollIntervalSeconds }}
+    {{- else }}
     POLL_INTERVAL={{ .Values.sentinel.roleLabeler.pollIntervalSeconds }}
+    {{- end }}
     KUBE_API="https://kubernetes.default.svc"
     TOKEN_FILE="/var/run/secrets/kubernetes.io/serviceaccount/token"
     CA_FILE="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"

--- a/valkey/templates/role-labeler-configmap.yaml
+++ b/valkey/templates/role-labeler-configmap.yaml
@@ -1,0 +1,96 @@
+{{- if and .Values.replica.enabled .Values.sentinel.enabled .Values.sentinel.roleLabeler.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "valkey.fullname" . }}-role-labeler
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+data:
+  role-checker.sh: |-
+    #!/bin/sh
+    set -eu
+
+    POLL_INTERVAL={{ .Values.sentinel.roleLabeler.pollIntervalSeconds }}
+    VALKEY_PORT="{{ .Values.service.port }}"
+    ROLE_FILE="/role/current-role"
+
+    {{- if .Values.auth.enabled }}
+    {{- $replUsername := .Values.replica.replicationUser }}
+    {{- $replUser := index .Values.auth.aclUsers $replUsername }}
+    {{- $replPasswordKey := $replUser.passwordKey | default $replUsername }}
+    AUTH_PASSWORD=""
+    {{- if .Values.auth.usersExistingSecret }}
+    if [ -f "/valkey-users-secret/{{ $replPasswordKey }}" ]; then
+      AUTH_PASSWORD=$(cat "/valkey-users-secret/{{ $replPasswordKey }}")
+    elif [ -f "/valkey-auth-secret/{{ $replUsername }}-password" ]; then
+      AUTH_PASSWORD=$(cat "/valkey-auth-secret/{{ $replUsername }}-password")
+    fi
+    {{- else }}
+    if [ -f "/valkey-auth-secret/{{ $replUsername }}-password" ]; then
+      AUTH_PASSWORD=$(cat "/valkey-auth-secret/{{ $replUsername }}-password")
+    fi
+    {{- end }}
+    CLI_AUTH="--user {{ $replUsername }} -a ${AUTH_PASSWORD} --no-auth-warning"
+    {{- else }}
+    CLI_AUTH=""
+    {{- end }}
+
+    {{- if .Values.tls.enabled }}
+    CLI_TLS="--tls --cacert /tls/{{ .Values.tls.caPublicKey }}"
+    {{- else }}
+    CLI_TLS=""
+    {{- end }}
+
+    while true; do
+      ROLE_OUTPUT=$(valkey-cli -h 127.0.0.1 -p "$VALKEY_PORT" $CLI_TLS $CLI_AUTH ROLE 2>/dev/null || echo "")
+      ROLE=$(echo "$ROLE_OUTPUT" | head -1)
+
+      case "$ROLE" in
+        master) echo "master" > "$ROLE_FILE" ;;
+        slave)  echo "replica" > "$ROLE_FILE" ;;
+      esac
+
+      sleep "$POLL_INTERVAL"
+    done
+
+  role-labeler.sh: |-
+    #!/bin/sh
+    set -eu
+
+    POLL_INTERVAL={{ .Values.sentinel.roleLabeler.pollIntervalSeconds }}
+    KUBE_API="https://kubernetes.default.svc"
+    TOKEN_FILE="/var/run/secrets/kubernetes.io/serviceaccount/token"
+    CA_FILE="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    ROLE_FILE="/role/current-role"
+    CURRENT_LABEL=""
+
+    patch_label() {
+      ROLE="$1"
+      TOKEN=$(cat "$TOKEN_FILE")
+      PAYLOAD="{\"metadata\":{\"labels\":{\"valkey-role\":\"${ROLE}\"}}}"
+
+      curl -s -o /dev/null \
+        --cacert "$CA_FILE" \
+        -H "Authorization: Bearer ${TOKEN}" \
+        -H "Content-Type: application/strategic-merge-patch+json" \
+        -X PATCH \
+        -d "$PAYLOAD" \
+        "${KUBE_API}/api/v1/namespaces/${POD_NAMESPACE}/pods/${POD_NAME}" 2>/dev/null || true
+    }
+
+    # Wait for the role file to appear
+    while [ ! -f "$ROLE_FILE" ]; do
+      sleep 1
+    done
+
+    while true; do
+      NEW_LABEL=$(cat "$ROLE_FILE" 2>/dev/null || echo "")
+
+      if [ -n "$NEW_LABEL" ] && [ "$NEW_LABEL" != "$CURRENT_LABEL" ]; then
+        patch_label "$NEW_LABEL"
+        CURRENT_LABEL="$NEW_LABEL"
+      fi
+
+      sleep "$POLL_INTERVAL"
+    done
+{{- end }}

--- a/valkey/templates/sentinel-configmap.yaml
+++ b/valkey/templates/sentinel-configmap.yaml
@@ -1,0 +1,142 @@
+{{- if and .Values.replica.enabled .Values.sentinel.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "valkey.sentinel.fullname" . }}-scripts
+  labels:
+    {{- include "valkey.sentinel.labels" . | nindent 4 }}
+data:
+  sentinel-init.sh: |-
+    #!/bin/sh
+    set -eu
+
+    SENTINEL_CONFIG="/data/conf/sentinel.conf"
+    DATA_DIR="/data/conf"
+    LOGFILE="/data/sentinel-init.log"
+
+    log() {
+      echo "$(date) $1" | tee -a "$LOGFILE" >&2
+    }
+
+    rm -f "$LOGFILE"
+    mkdir -p "$DATA_DIR"
+    rm -f "$SENTINEL_CONFIG"
+
+    MASTER_GROUP="{{ .Values.sentinel.masterGroupName }}"
+    HEADLESS_SVC="{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+    DATA_PORT="{{ .Values.service.port }}"
+    SENTINEL_PORT="{{ .Values.sentinel.port }}"
+    TOTAL_DATA_PODS={{ add (int .Values.replica.replicas) 1 }}
+
+    {{- if .Values.auth.enabled }}
+    # Read the default user password for Sentinel to authenticate to data pods
+    {{- $replUsername := .Values.replica.replicationUser }}
+    {{- $replUser := index .Values.auth.aclUsers $replUsername }}
+    {{- $replPasswordKey := $replUser.passwordKey | default $replUsername }}
+    AUTH_PASSWORD=""
+    {{- if .Values.auth.usersExistingSecret }}
+    if [ -f "/valkey-users-secret/{{ $replPasswordKey }}" ]; then
+      AUTH_PASSWORD=$(cat "/valkey-users-secret/{{ $replPasswordKey }}")
+    elif [ -f "/valkey-auth-secret/{{ $replUsername }}-password" ]; then
+      AUTH_PASSWORD=$(cat "/valkey-auth-secret/{{ $replUsername }}-password")
+    fi
+    {{- else }}
+    if [ -f "/valkey-auth-secret/{{ $replUsername }}-password" ]; then
+      AUTH_PASSWORD=$(cat "/valkey-auth-secret/{{ $replUsername }}-password")
+    fi
+    {{- end }}
+
+    CLI_AUTH_FLAGS="--user {{ $replUsername }} -a $AUTH_PASSWORD --no-auth-warning"
+    {{- else }}
+    CLI_AUTH_FLAGS=""
+    {{- end }}
+
+    {{- if .Values.tls.enabled }}
+    CLI_TLS_FLAGS="--tls --cacert /tls/{{ .Values.tls.caPublicKey }}"
+    {{- else }}
+    CLI_TLS_FLAGS=""
+    {{- end }}
+
+    # Discover current master by querying data pods
+    MASTER_HOST=""
+    MASTER_FOUND=false
+    log "Attempting to discover current master from data pods..."
+
+    i=0
+    while [ $i -lt $TOTAL_DATA_PODS ]; do
+      POD_HOST="{{ include "valkey.fullname" . }}-${i}.${HEADLESS_SVC}"
+      log "Probing ${POD_HOST}:${DATA_PORT}..."
+
+      {{- if .Values.tls.enabled }}
+      ROLE_OUTPUT=$(valkey-cli -h "$POD_HOST" -p "$DATA_PORT" $CLI_TLS_FLAGS $CLI_AUTH_FLAGS ROLE 2>/dev/null || echo "")
+      {{- else }}
+      ROLE_OUTPUT=$(valkey-cli -h "$POD_HOST" -p "$DATA_PORT" $CLI_AUTH_FLAGS ROLE 2>/dev/null || echo "")
+      {{- end }}
+
+      if echo "$ROLE_OUTPUT" | head -1 | grep -q "master"; then
+        MASTER_HOST="$POD_HOST"
+        MASTER_FOUND=true
+        log "Found master at ${MASTER_HOST}"
+        break
+      fi
+      i=$((i + 1))
+    done
+
+    if [ "$MASTER_FOUND" = "false" ]; then
+      # Bootstrap: no master found, default to pod-0
+      MASTER_HOST="{{ include "valkey.fullname" . }}-0.${HEADLESS_SVC}"
+      log "No master found, defaulting to ${MASTER_HOST} (bootstrap)"
+    fi
+
+    # Determine this Sentinel's announce address
+    SENTINEL_HEADLESS="{{ include "valkey.sentinel.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+    MY_ANNOUNCE="${HOSTNAME}.${SENTINEL_HEADLESS}"
+
+    log "Generating sentinel.conf"
+    {
+    {{- if .Values.tls.enabled }}
+      echo "port 0"
+      echo "tls-port {{ .Values.sentinel.port }}"
+      echo "tls-cert-file /tls/{{ .Values.tls.serverPublicKey }}"
+      echo "tls-key-file /tls/{{ .Values.tls.serverKey }}"
+      echo "tls-ca-cert-file /tls/{{ .Values.tls.caPublicKey }}"
+      {{- if .Values.tls.dhParamKey }}
+      echo "tls-dh-params-file /tls/{{ .Values.tls.dhParamKey }}"
+      {{- end }}
+      echo "tls-replication yes"
+      {{- if not .Values.tls.requireClientCertificate }}
+      echo "tls-auth-clients no"
+      {{- end }}
+    {{- else }}
+      echo "port {{ .Values.sentinel.port }}"
+    {{- end }}
+
+      echo ""
+      echo "dir /data"
+      echo "sentinel resolve-hostnames yes"
+      echo "sentinel announce-hostnames yes"
+      echo "sentinel announce-ip ${MY_ANNOUNCE}"
+      echo "sentinel announce-port {{ .Values.sentinel.port }}"
+      echo ""
+      echo "sentinel monitor ${MASTER_GROUP} ${MASTER_HOST} ${DATA_PORT} {{ .Values.sentinel.quorum }}"
+      echo "sentinel down-after-milliseconds ${MASTER_GROUP} {{ .Values.sentinel.downAfterMilliseconds }}"
+      echo "sentinel failover-timeout ${MASTER_GROUP} {{ .Values.sentinel.failoverTimeout }}"
+      echo "sentinel parallel-syncs ${MASTER_GROUP} {{ .Values.sentinel.parallelSyncs }}"
+
+    {{- if .Values.auth.enabled }}
+      echo ""
+      echo "sentinel auth-user ${MASTER_GROUP} {{ .Values.replica.replicationUser }}"
+      echo "sentinel auth-pass ${MASTER_GROUP} ${AUTH_PASSWORD}"
+    {{- end }}
+    } > "$SENTINEL_CONFIG"
+
+    {{- if .Values.sentinel.extraConfig }}
+    # Append extra Sentinel configuration
+    cat >> "$SENTINEL_CONFIG" << 'EXTRACONF'
+
+    {{ .Values.sentinel.extraConfig }}
+    EXTRACONF
+    {{- end }}
+
+    log "Sentinel configuration generated successfully"
+{{- end }}

--- a/valkey/templates/sentinel-headless.yaml
+++ b/valkey/templates/sentinel-headless.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.replica.enabled .Values.sentinel.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "valkey.sentinel.headlessServiceName" . }}
+  labels:
+    {{- include "valkey.sentinel.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp-sentinel
+      port: {{ .Values.sentinel.port }}
+      targetPort: tcp-sentinel
+      protocol: TCP
+  selector:
+    {{- include "valkey.sentinel.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/valkey/templates/sentinel-pdb.yaml
+++ b/valkey/templates/sentinel-pdb.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.replica.enabled .Values.sentinel.enabled .Values.sentinel.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "valkey.sentinel.fullname" . }}
+  labels:
+    {{- include "valkey.sentinel.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.sentinel.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.sentinel.podDisruptionBudget.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ .Values.sentinel.podDisruptionBudget.maxUnavailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "valkey.sentinel.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/valkey/templates/sentinel-rbac.yaml
+++ b/valkey/templates/sentinel-rbac.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.replica.enabled .Values.sentinel.enabled .Values.sentinel.roleLabeler.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "valkey.fullname" . }}-role-labeler
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "valkey.fullname" . }}-role-labeler
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "valkey.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "valkey.fullname" . }}-role-labeler
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/valkey/templates/sentinel-rbac.yaml
+++ b/valkey/templates/sentinel-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.replica.enabled .Values.sentinel.enabled .Values.sentinel.roleLabeler.enabled }}
+{{- if or (and .Values.replica.enabled .Values.sentinel.enabled .Values.sentinel.roleLabeler.enabled) (and .Values.cluster.enabled .Values.cluster.roleLabeler.enabled) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/valkey/templates/sentinel-service.yaml
+++ b/valkey/templates/sentinel-service.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.replica.enabled .Values.sentinel.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "valkey.sentinel.fullname" . }}
+  labels:
+    {{- include "valkey.sentinel.labels" . | nindent 4 }}
+  {{- with .Values.sentinel.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.sentinel.service.type }}
+  {{- if .Values.sentinel.service.clusterIP }}
+  clusterIP: {{ .Values.sentinel.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.sentinel.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.sentinel.service.loadBalancerClass }}
+  {{- end }}
+  {{- if .Values.sentinel.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ .Values.sentinel.service.loadBalancerSourceRanges }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.sentinel.service.port }}
+      targetPort: tcp-sentinel
+      protocol: TCP
+      name: tcp-sentinel
+      {{- if and (eq .Values.sentinel.service.type "NodePort") .Values.sentinel.service.nodePort }}
+      nodePort: {{ .Values.sentinel.service.nodePort }}
+      {{- end }}
+      {{- if .Values.sentinel.service.appProtocol }}
+      appProtocol: {{ .Values.sentinel.service.appProtocol }}
+      {{- end }}
+  selector:
+    {{- include "valkey.sentinel.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/valkey/templates/sentinel-statefulset.yaml
+++ b/valkey/templates/sentinel-statefulset.yaml
@@ -1,0 +1,188 @@
+{{- if and .Values.replica.enabled .Values.sentinel.enabled }}
+{{- include "valkey.validateSentinelConfig" . }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "valkey.sentinel.fullname" . }}
+  labels:
+    {{- include "valkey.sentinel.labels" . | nindent 4 }}
+  {{- with .Values.sentinel.workloadAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  serviceName: {{ include "valkey.sentinel.headlessServiceName" . }}
+  replicas: {{ .Values.sentinel.replicas }}
+  selector:
+    matchLabels:
+      {{- include "valkey.sentinel.selectorLabels" . | nindent 6 }}
+  {{- if .Values.sentinel.persistence.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: sentinel-data
+    spec:
+      accessModes: {{ toYaml .Values.sentinel.persistence.accessModes | nindent 8 }}
+      {{- if .Values.sentinel.persistence.storageClass }}
+      storageClassName: {{ .Values.sentinel.persistence.storageClass | quote }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.sentinel.persistence.size | quote }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "valkey.sentinel.selectorLabels" . | nindent 8 }}
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.sentinel.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+      {{- with .Values.sentinel.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+        checksum/sentinel-scripts: {{ include (print $.Template.BasePath "/sentinel-configmap.yaml") . | sha256sum | trunc 32 | quote }}
+    spec:
+      {{- (include "valkey.imagePullSecrets" .) | nindent 6 }}
+      automountServiceAccountToken: false
+      serviceAccountName: {{ include "valkey.serviceAccountName" . }}
+      {{- if .Values.sentinel.priorityClassName }}
+      priorityClassName: {{ .Values.sentinel.priorityClassName | quote }}
+      {{- end }}
+      {{- with .Values.sentinel.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if not .Values.sentinel.podSecurityContext }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
+      initContainers:
+        - name: sentinel-init
+          image: {{ include "valkey.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.sentinel.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if not .Values.sentinel.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
+          command: [ "/scripts/sentinel-init.sh" ]
+          volumeMounts:
+            - name: sentinel-data
+              mountPath: /data
+            - name: sentinel-scripts
+              mountPath: /scripts
+            {{- if .Values.tls.enabled }}
+            - name: {{ include "valkey.fullname" . }}-tls
+              mountPath: /tls
+            {{- end }}
+            {{- if .Values.auth.enabled }}
+            {{- if .Values.auth.usersExistingSecret }}
+            - name: valkey-users-secret
+              mountPath: /valkey-users-secret
+              readOnly: true
+            {{- end }}
+            {{- if or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig }}
+            - name: valkey-auth-secret
+              mountPath: /valkey-auth-secret
+              readOnly: true
+            {{- end }}
+            {{- end }}
+          {{- with .Values.initResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      containers:
+        - name: sentinel
+          image: {{ include "valkey.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.sentinel.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if not .Values.sentinel.securityContext }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
+          command: [ "valkey-server" ]
+          args: [ "/data/conf/sentinel.conf", "--sentinel" ]
+          ports:
+            - name: tcp-sentinel
+              containerPort: {{ .Values.sentinel.port }}
+              protocol: TCP
+          startupProbe:
+            exec:
+              {{- if .Values.tls.enabled }}
+              command: [ "sh", "-c", "valkey-cli -p {{ .Values.sentinel.port }} --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
+              {{- else }}
+              command: [ "sh", "-c", "valkey-cli -p {{ .Values.sentinel.port }} ping" ]
+              {{- end }}
+          livenessProbe:
+            exec:
+              {{- if .Values.tls.enabled }}
+              command: [ "sh", "-c", "valkey-cli -p {{ .Values.sentinel.port }} --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
+              {{- else }}
+              command: [ "sh", "-c", "valkey-cli -p {{ .Values.sentinel.port }} ping" ]
+              {{- end }}
+          {{- with .Values.sentinel.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: sentinel-data
+              mountPath: /data
+            {{- if .Values.tls.enabled }}
+            - name: {{ include "valkey.fullname" . }}-tls
+              mountPath: /tls
+            {{- end }}
+      volumes:
+        - name: sentinel-scripts
+          configMap:
+            name: {{ include "valkey.sentinel.fullname" . }}-scripts
+            defaultMode: 0555
+        {{- if not .Values.sentinel.persistence.enabled }}
+        - name: sentinel-data
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: {{ include "valkey.fullname" . }}-tls
+          secret:
+            secretName: {{ required "An existing secret is required to enable TLS" .Values.tls.existingSecret }}
+            defaultMode: 0400
+        {{- end }}
+        {{- if .Values.auth.enabled }}
+        {{- if .Values.auth.usersExistingSecret }}
+        - name: valkey-users-secret
+          secret:
+            secretName: {{ .Values.auth.usersExistingSecret }}
+            defaultMode: 0400
+        {{- end }}
+        {{- if or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig }}
+        - name: valkey-auth-secret
+          secret:
+            secretName: {{ include "valkey.fullname" . }}-auth
+            defaultMode: 0400
+        {{- end }}
+        {{- end }}
+      {{- with (.Values.sentinel.nodeSelector | default .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sentinel.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sentinel.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.sentinel.tolerations | default .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/valkey/templates/service.yaml
+++ b/valkey/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.cluster.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -40,3 +41,4 @@ spec:
     statefulset.kubernetes.io/pod-name: {{ include "valkey.fullname" . }}-0
     {{- end }}
     {{- end }}
+{{- end }}

--- a/valkey/templates/service.yaml
+++ b/valkey/templates/service.yaml
@@ -34,5 +34,9 @@ spec:
   selector:
     {{- include "valkey.selectorLabels" . | nindent 4 }}
     {{- if .Values.replica.enabled }}
+    {{- if .Values.sentinel.enabled }}
+    valkey-role: master
+    {{- else }}
     statefulset.kubernetes.io/pod-name: {{ include "valkey.fullname" . }}-0
+    {{- end }}
     {{- end }}

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -54,7 +54,11 @@ spec:
         {{- end }}
     spec:
       {{- (include "valkey.imagePullSecrets" .) | nindent 6 }}
+      {{- if and .Values.sentinel.enabled .Values.sentinel.roleLabeler.enabled }}
+      automountServiceAccountToken: true
+      {{- else }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      {{- end }}
       serviceAccountName: {{ include "valkey.serviceAccountName" . }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
@@ -233,11 +237,88 @@ spec:
         {{- with .Values.extraContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if and .Values.sentinel.enabled .Values.sentinel.roleLabeler.enabled }}
+        - name: role-checker
+          image: {{ include "valkey.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 1000
+          command: [ "/scripts/role-checker.sh" ]
+          volumeMounts:
+            - name: role-labeler-scripts
+              mountPath: /scripts
+            - name: role-shared
+              mountPath: /role
+            {{- if .Values.auth.enabled }}
+            {{- if .Values.auth.usersExistingSecret }}
+            - name: valkey-users-secret
+              mountPath: /valkey-users-secret
+              readOnly: true
+            {{- end }}
+            {{- if or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig }}
+            - name: valkey-auth-secret
+              mountPath: /valkey-auth-secret
+              readOnly: true
+            {{- end }}
+            {{- end }}
+            {{- if .Values.tls.enabled }}
+            - name: {{ include "valkey.fullname" . }}-tls
+              mountPath: /tls
+            {{- end }}
+          {{- with .Values.sentinel.roleLabeler.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        - name: role-labeler
+          image: {{ include "valkey.roleLabeler.image" . }}
+          imagePullPolicy: {{ .Values.sentinel.roleLabeler.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          command: [ "/scripts/role-labeler.sh" ]
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: role-labeler-scripts
+              mountPath: /scripts
+            - name: role-shared
+              mountPath: /role
+          {{- with .Values.sentinel.roleLabeler.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
       volumes:
         - name: scripts
           configMap:
             name: {{ include "valkey.fullname" . }}-init-scripts
             defaultMode: 0555
+        {{- if and .Values.sentinel.enabled .Values.sentinel.roleLabeler.enabled }}
+        - name: role-labeler-scripts
+          configMap:
+            name: {{ include "valkey.fullname" . }}-role-labeler
+            defaultMode: 0555
+        - name: role-shared
+          emptyDir:
+            medium: Memory
+        {{- end }}
         {{- if .Values.auth.enabled }}
         - name: valkey-acl
           emptyDir:

--- a/valkey/tests/cluster_init_config_test.yaml
+++ b/valkey/tests/cluster_init_config_test.yaml
@@ -1,0 +1,141 @@
+suite: cluster init config
+templates:
+  - templates/cluster-configmap.yaml
+tests:
+  - it: should not render when cluster disabled
+    set:
+      cluster.enabled: false
+    template: templates/cluster-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render configmap with cluster scripts
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+    template: templates/cluster-configmap.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - exists:
+          path: data["cluster-init.sh"]
+      - exists:
+          path: data["cluster-bootstrap.sh"]
+
+  - it: should contain cluster-enabled in init script
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+    template: templates/cluster-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["cluster-init.sh"]
+          pattern: "cluster-enabled yes"
+
+  - it: should contain cluster-config-file in init script
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+    template: templates/cluster-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["cluster-init.sh"]
+          pattern: "cluster-config-file"
+
+  - it: should contain cluster-node-timeout in init script
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+      cluster.nodeTimeout: 10000
+    template: templates/cluster-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["cluster-init.sh"]
+          pattern: "cluster-node-timeout 10000"
+
+  - it: should contain TLS cluster replication when TLS enabled
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+      tls.enabled: true
+      tls.existingSecret: "tls-secret"
+    template: templates/cluster-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["cluster-init.sh"]
+          pattern: "tls-replication yes"
+
+  - it: should contain port 0 and tls-port when TLS enabled
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+      tls.enabled: true
+      tls.existingSecret: "tls-secret"
+    template: templates/cluster-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["cluster-init.sh"]
+          pattern: "port 0"
+      - matchRegex:
+          path: data["cluster-init.sh"]
+          pattern: "tls-port 6379"
+
+  - it: should contain auth setup when auth enabled
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+      auth.enabled: true
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          password: "testpass"
+    template: templates/cluster-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["cluster-init.sh"]
+          pattern: "aclfile"
+
+  - it: should contain cluster-announce-hostname in init script
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+    template: templates/cluster-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["cluster-init.sh"]
+          pattern: "cluster-announce-hostname"
+
+  - it: bootstrap script should contain cluster create command
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+    template: templates/cluster-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["cluster-bootstrap.sh"]
+          pattern: "valkey-cli --cluster create"
+
+  - it: bootstrap script should use TLS flags when TLS enabled
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+      tls.enabled: true
+      tls.existingSecret: "tls-secret"
+    template: templates/cluster-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["cluster-bootstrap.sh"]
+          pattern: "--tls --cacert"
+
+  - it: bootstrap script should calculate correct total nodes
+    set:
+      cluster.enabled: true
+      cluster.masters: 5
+      cluster.replicasPerMaster: 2
+      cluster.persistence.size: "5Gi"
+    template: templates/cluster-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["cluster-bootstrap.sh"]
+          pattern: "TOTAL_NODES=15"

--- a/valkey/tests/cluster_service_test.yaml
+++ b/valkey/tests/cluster_service_test.yaml
@@ -1,0 +1,121 @@
+suite: cluster service configuration
+templates:
+  - templates/cluster-headless.yaml
+  - templates/cluster-service.yaml
+  - templates/cluster-configmap.yaml
+tests:
+  # Headless service
+  - it: should not render headless service when cluster disabled
+    set:
+      cluster.enabled: false
+    template: templates/cluster-headless.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render headless service with correct properties
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+    template: templates/cluster-headless.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.clusterIP
+          value: None
+      - equal:
+          path: spec.publishNotReadyAddresses
+          value: true
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-cluster-headless
+
+  - it: should have two ports on headless service
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+    template: templates/cluster-headless.yaml
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: tcp
+            port: 6379
+            targetPort: tcp
+            protocol: TCP
+      - contains:
+          path: spec.ports
+          content:
+            name: cluster-bus
+            port: 16379
+            targetPort: cluster-bus
+            protocol: TCP
+
+  # Client service
+  - it: should not render client service when cluster disabled
+    set:
+      cluster.enabled: false
+    template: templates/cluster-service.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render client service with single port
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+    template: templates/cluster-service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-cluster
+      - lengthEqual:
+          path: spec.ports
+          count: 1
+      - contains:
+          path: spec.ports
+          content:
+            name: tcp
+            port: 6379
+            targetPort: tcp
+            protocol: TCP
+
+  - it: should apply service annotations
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+      cluster.service.annotations:
+        service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    template: templates/cluster-service.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-type"]
+          value: nlb
+
+  - it: should configure NodePort when set
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+      cluster.service.type: NodePort
+      cluster.service.nodePort: 30379
+    template: templates/cluster-service.yaml
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 30379
+
+  - it: should use cluster selector labels
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+    template: templates/cluster-service.yaml
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: cluster

--- a/valkey/tests/cluster_statefulset_test.yaml
+++ b/valkey/tests/cluster_statefulset_test.yaml
@@ -1,0 +1,323 @@
+suite: cluster statefulset configuration
+templates:
+  - templates/cluster-statefulset.yaml
+  - templates/cluster-configmap.yaml
+tests:
+  # Validation tests
+  - it: should not render when cluster is disabled
+    set:
+      cluster.enabled: false
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should fail when cluster and replica are both enabled
+    set:
+      cluster.enabled: true
+      replica.enabled: true
+      cluster.persistence.size: "5Gi"
+      replica.persistence.size: "5Gi"
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "mutually exclusive"
+
+  - it: should fail when cluster has less than 3 masters
+    set:
+      cluster.enabled: true
+      cluster.masters: 2
+      cluster.persistence.size: "5Gi"
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "minimum"
+
+  - it: should fail when cluster has no persistence size
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: ""
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "persistent storage"
+
+  # Basic rendering
+  - it: should render cluster statefulset with defaults
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: spec.replicas
+          value: 6
+      - equal:
+          path: spec.podManagementPolicy
+          value: Parallel
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-cluster
+
+  - it: should calculate correct pod count for 3 masters 0 replicas
+    set:
+      cluster.enabled: true
+      cluster.masters: 3
+      cluster.replicasPerMaster: 0
+      cluster.persistence.size: "5Gi"
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: should calculate correct pod count for 6 masters 2 replicas
+    set:
+      cluster.enabled: true
+      cluster.masters: 6
+      cluster.replicasPerMaster: 2
+      cluster.persistence.size: "5Gi"
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 18
+
+  # Ports
+  - it: should expose both tcp and cluster-bus ports
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: tcp
+            containerPort: 6379
+            protocol: TCP
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: cluster-bus
+            containerPort: 16379
+            protocol: TCP
+
+  # Bootstrap sidecar
+  - it: should have cluster-bootstrap sidecar
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: cluster-bootstrap
+          any: true
+
+  # Readiness probe checks cluster state
+  - it: should have readiness probe checking cluster state
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command
+          content: "sh"
+          any: true
+
+  # TLS
+  - it: should mount TLS volume when TLS enabled
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+      tls.enabled: true
+      tls.existingSecret: "my-tls-secret"
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: RELEASE-NAME-valkey-tls
+            secret:
+              secretName: my-tls-secret
+              defaultMode: 256
+
+  - it: should use TLS in probes when TLS enabled
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+      tls.enabled: true
+      tls.existingSecret: "my-tls-secret"
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.exec.command
+          value: ["sh", "-c", "valkey-cli -p 6379 --cacert /tls/ca.crt --tls ping"]
+
+  # Auth
+  - it: should mount auth secrets when auth enabled
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+      auth.enabled: true
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          password: "testpass"
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: valkey-acl
+            emptyDir:
+              medium: Memory
+
+  # Storage
+  - it: should configure volumeClaimTemplates
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "10Gi"
+      cluster.persistence.storageClass: "fast-ssd"
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: "10Gi"
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.storageClassName
+          value: "fast-ssd"
+
+  # ServiceName
+  - it: should reference headless service
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.serviceName
+          value: RELEASE-NAME-valkey-cluster-headless
+
+  # Image pull policy
+  - it: should use configured pull policy
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+      image.pullPolicy: Always
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].imagePullPolicy
+          value: Always
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+
+  # Workload annotations
+  - it: should apply workload annotations
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+      cluster.workloadAnnotations:
+        custom/annotation: "value"
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["custom/annotation"]
+          value: "value"
+
+  # Pod labels
+  - it: should apply pod labels
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+      cluster.podLabels:
+        custom-label: "value"
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.custom-label
+          value: "value"
+
+  # Metrics sidecar
+  - it: should include metrics sidecar when enabled
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+      metrics.enabled: true
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: metrics
+          any: true
+
+  # Role labeler sidecars
+  - it: should have role-checker and role-labeler sidecars by default
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: role-checker
+          any: true
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: role-labeler
+          any: true
+
+  - it: should not have role labeler sidecars when disabled
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+      cluster.roleLabeler.enabled: false
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers
+          content:
+            name: role-checker
+          any: true
+      - notContains:
+          path: spec.template.spec.containers
+          content:
+            name: role-labeler
+          any: true
+
+  - it: should enable automountServiceAccountToken when role labeler is enabled
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: true
+
+  # PVC retention policy
+  - it: should set persistentVolumeClaimRetentionPolicy when configured
+    set:
+      cluster.enabled: true
+      cluster.persistence.size: "5Gi"
+      cluster.persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Delete
+        whenScaled: Retain
+    template: templates/cluster-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenDeleted
+          value: Delete
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenScaled
+          value: Retain

--- a/valkey/tests/sentinel_init_config_test.yaml
+++ b/valkey/tests/sentinel_init_config_test.yaml
@@ -1,0 +1,55 @@
+suite: sentinel init config
+templates:
+  - templates/init_config.yaml
+tests:
+  - it: should contain sentinel query logic when sentinel enabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: "SENTINEL get-master-addr-by-name"
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: "SENTINEL_HOST="
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: "Bootstrap fallback"
+
+  - it: should not contain sentinel query when sentinel disabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: false
+    asserts:
+      - notMatchRegex:
+          path: data["init.sh"]
+          pattern: "SENTINEL get-master-addr-by-name"
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: "This pod.*is configured as MASTER"
+
+  - it: should use sentinel master group name
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+      sentinel.masterGroupName: "custom-master"
+    asserts:
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: "MASTER_GROUP=\"custom-master\""
+
+  - it: should include TLS flags in sentinel query when TLS enabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+      tls.enabled: true
+      tls.existingSecret: my-tls-secret
+    asserts:
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: "--tls --cacert /tls/ca.crt"

--- a/valkey/tests/sentinel_pdb_test.yaml
+++ b/valkey/tests/sentinel_pdb_test.yaml
@@ -1,0 +1,66 @@
+suite: sentinel pdb configuration
+templates:
+  - templates/sentinel-pdb.yaml
+  - templates/init_config.yaml
+tests:
+  - it: should not render when sentinel disabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: false
+    template: templates/sentinel-pdb.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when pdb disabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+      sentinel.podDisruptionBudget.enabled: false
+    template: templates/sentinel-pdb.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render with default maxUnavailable
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+    template: templates/sentinel-pdb.yaml
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-sentinel
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+
+  - it: should use minAvailable when set
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+      sentinel.podDisruptionBudget.minAvailable: 2
+    template: templates/sentinel-pdb.yaml
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+      - notExists:
+          path: spec.maxUnavailable
+
+  - it: should select sentinel pods
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+    template: templates/sentinel-pdb.yaml
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: sentinel

--- a/valkey/tests/sentinel_rbac_test.yaml
+++ b/valkey/tests/sentinel_rbac_test.yaml
@@ -1,0 +1,75 @@
+suite: sentinel rbac configuration
+templates:
+  - templates/sentinel-rbac.yaml
+  - templates/init_config.yaml
+tests:
+  - it: should not render when sentinel disabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: false
+    template: templates/sentinel-rbac.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when role labeler disabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+      sentinel.roleLabeler.enabled: false
+    template: templates/sentinel-rbac.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render Role and RoleBinding when sentinel enabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+    template: templates/sentinel-rbac.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should create role with pod get and patch permissions
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+    template: templates/sentinel-rbac.yaml
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-role-labeler
+      - equal:
+          path: rules[0].resources
+          value: ["pods"]
+      - equal:
+          path: rules[0].verbs
+          value: ["get", "patch"]
+
+  - it: should bind role to service account
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+    template: templates/sentinel-rbac.yaml
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - equal:
+          path: subjects[0].name
+          value: RELEASE-NAME-valkey
+      - equal:
+          path: roleRef.name
+          value: RELEASE-NAME-valkey-role-labeler

--- a/valkey/tests/sentinel_service_routing_test.yaml
+++ b/valkey/tests/sentinel_service_routing_test.yaml
@@ -1,0 +1,38 @@
+suite: sentinel service routing
+templates:
+  - templates/service.yaml
+  - templates/init_config.yaml
+tests:
+  - it: should use pod-name selector when sentinel disabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: false
+    template: templates/service.yaml
+    asserts:
+      - equal:
+          path: spec.selector["statefulset.kubernetes.io/pod-name"]
+          value: RELEASE-NAME-valkey-0
+
+  - it: should use valkey-role label when sentinel enabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+    template: templates/service.yaml
+    asserts:
+      - equal:
+          path: spec.selector["valkey-role"]
+          value: master
+      - notExists:
+          path: spec.selector["statefulset.kubernetes.io/pod-name"]
+
+  - it: should not have any extra selector in standalone mode
+    set:
+      replica.enabled: false
+    template: templates/service.yaml
+    asserts:
+      - notExists:
+          path: spec.selector["valkey-role"]
+      - notExists:
+          path: spec.selector["statefulset.kubernetes.io/pod-name"]

--- a/valkey/tests/sentinel_service_test.yaml
+++ b/valkey/tests/sentinel_service_test.yaml
@@ -1,0 +1,110 @@
+suite: sentinel service configuration
+templates:
+  - templates/sentinel-service.yaml
+  - templates/sentinel-headless.yaml
+  - templates/init_config.yaml
+tests:
+  - it: should not render sentinel service when disabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: false
+    template: templates/sentinel-service.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render sentinel headless service when disabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: false
+    template: templates/sentinel-headless.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render sentinel service when enabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+    template: templates/sentinel-service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-sentinel
+      - equal:
+          path: spec.ports[0].port
+          value: 26379
+      - equal:
+          path: spec.ports[0].name
+          value: tcp-sentinel
+
+  - it: should render sentinel headless service when enabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+    template: templates/sentinel-headless.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-sentinel-headless
+      - equal:
+          path: spec.clusterIP
+          value: None
+      - equal:
+          path: spec.publishNotReadyAddresses
+          value: true
+
+  - it: should have sentinel component label on services
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+    template: templates/sentinel-service.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: sentinel
+
+  - it: should use custom sentinel service port
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+      sentinel.service.port: 36379
+    template: templates/sentinel-service.yaml
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 36379
+
+  - it: should apply sentinel service annotations
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+      sentinel.service.annotations:
+        prometheus.io/scrape: "true"
+    template: templates/sentinel-service.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+
+  - it: should select sentinel pods
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+    template: templates/sentinel-service.yaml
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: sentinel

--- a/valkey/tests/sentinel_statefulset_test.yaml
+++ b/valkey/tests/sentinel_statefulset_test.yaml
@@ -1,0 +1,261 @@
+suite: sentinel statefulset configuration
+templates:
+  - templates/sentinel-statefulset.yaml
+  - templates/sentinel-configmap.yaml
+  - templates/init_config.yaml
+tests:
+  - it: should not render when sentinel is disabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: false
+    template: templates/sentinel-statefulset.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when replica is disabled
+    set:
+      replica.enabled: false
+      sentinel.enabled: false
+    template: templates/sentinel-statefulset.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should fail when sentinel enabled but replica disabled
+    set:
+      replica.enabled: false
+      sentinel.enabled: true
+    template: templates/init_config.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "Sentinel mode requires replication to be enabled.*"
+
+  - it: should fail when sentinel replicas less than 3
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+      sentinel.replicas: 1
+    template: templates/sentinel-statefulset.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: ".*"
+
+  - it: should fail when quorum greater than replicas
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+      sentinel.replicas: 3
+      sentinel.quorum: 5
+    template: templates/sentinel-statefulset.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "Sentinel quorum.*cannot be greater than.*"
+
+  - it: should render sentinel statefulset when enabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+    template: templates/sentinel-statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-sentinel
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: should use custom replica count
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+      sentinel.replicas: 5
+    template: templates/sentinel-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 5
+
+  - it: should use sentinel headless service name
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+    template: templates/sentinel-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.serviceName
+          value: RELEASE-NAME-valkey-sentinel-headless
+
+  - it: should have sentinel component label
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+    template: templates/sentinel-statefulset.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: sentinel
+
+  - it: should run sentinel command
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+    template: templates/sentinel-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value: ["valkey-server"]
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value: ["/data/conf/sentinel.conf", "--sentinel"]
+
+  - it: should expose sentinel port
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+    template: templates/sentinel-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 26379
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].name
+          value: tcp-sentinel
+
+  - it: should use emptyDir when persistence disabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+      sentinel.persistence.enabled: false
+    template: templates/sentinel-statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: sentinel-data
+            emptyDir: {}
+
+  - it: should use volumeClaimTemplate when persistence enabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+      sentinel.persistence.enabled: true
+      sentinel.persistence.size: "200Mi"
+    template: templates/sentinel-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.name
+          value: sentinel-data
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: "200Mi"
+
+  - it: should apply custom resources to sentinel container
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+      sentinel.resources:
+        limits:
+          cpu: 200m
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+    template: templates/sentinel-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 200m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 128Mi
+
+  - it: should apply sentinel workload annotations
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+      sentinel.workloadAnnotations:
+        custom.annotation: "test-value"
+    template: templates/sentinel-statefulset.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["custom.annotation"]
+          value: "test-value"
+
+  - it: should apply sentinel pod annotations
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+      sentinel.podAnnotations:
+        prometheus.io/scrape: "true"
+    template: templates/sentinel-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+
+  - it: should apply sentinel node selector
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+      sentinel.nodeSelector:
+        disktype: ssd
+    template: templates/sentinel-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.disktype
+          value: ssd
+
+  - it: should mount TLS volumes when TLS enabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+      tls.enabled: true
+      tls.existingSecret: my-tls-secret
+    template: templates/sentinel-statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: RELEASE-NAME-valkey-tls
+            secret:
+              secretName: my-tls-secret
+              defaultMode: 256
+
+  - it: should mount auth secrets when auth enabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      sentinel.enabled: true
+      auth.enabled: true
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          password: "secretpass"
+    template: templates/sentinel-statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: valkey-auth-secret
+            secret:
+              secretName: RELEASE-NAME-valkey-auth
+              defaultMode: 256

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -22,6 +22,181 @@
                 }
             }
         },
+        "cluster": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "masters": {
+                    "type": "integer",
+                    "minimum": 3
+                },
+                "replicasPerMaster": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "nodeTimeout": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "size": {
+                            "type": "string"
+                        },
+                        "storageClass": {
+                            "type": "string"
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "persistentVolumeClaimRetentionPolicy": {
+                    "type": "object"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "nodePort": {
+                            "type": "integer"
+                        },
+                        "clusterIP": {
+                            "type": "string"
+                        },
+                        "appProtocol": {
+                            "type": "string"
+                        },
+                        "loadBalancerClass": {
+                            "type": "string"
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "podDisruptionBudget": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "minAvailable": {
+                            "oneOf": [
+                                {
+                                    "type": "integer",
+                                    "minimum": 0
+                                },
+                                {
+                                    "type": "string",
+                                    "pattern": "^[0-9]+%$"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "maxUnavailable": {
+                            "oneOf": [
+                                {
+                                    "type": "integer",
+                                    "minimum": 0
+                                },
+                                {
+                                    "type": "string",
+                                    "pattern": "^[0-9]+%$"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "securityContext": {
+                    "type": "object"
+                },
+                "podSecurityContext": {
+                    "type": "object"
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podLabels": {
+                    "type": "object"
+                },
+                "workloadAnnotations": {
+                    "type": "object"
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "tolerations": {
+                    "type": "array"
+                },
+                "affinity": {
+                    "type": "object"
+                },
+                "topologySpreadConstraints": {
+                    "type": "array"
+                },
+                "priorityClassName": {
+                    "type": "string"
+                },
+                "extraConfig": {
+                    "type": "string"
+                },
+                "roleLabeler": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "pollIntervalSeconds": {
+                            "type": "integer",
+                            "minimum": 1
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                },
+                                "pullPolicy": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+        },
         "clusterDomain": {
             "type": "string"
         },

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -439,6 +439,192 @@
         "resources": {
             "type": "object"
         },
+        "sentinel": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "replicas": {
+                    "type": "integer",
+                    "minimum": 3
+                },
+                "port": {
+                    "type": "integer"
+                },
+                "masterGroupName": {
+                    "type": "string"
+                },
+                "quorum": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "downAfterMilliseconds": {
+                    "type": "integer"
+                },
+                "failoverTimeout": {
+                    "type": "integer"
+                },
+                "parallelSyncs": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "securityContext": {
+                    "type": "object"
+                },
+                "podSecurityContext": {
+                    "type": "object"
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podLabels": {
+                    "type": "object"
+                },
+                "workloadAnnotations": {
+                    "type": "object"
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "tolerations": {
+                    "type": "array"
+                },
+                "affinity": {
+                    "type": "object"
+                },
+                "topologySpreadConstraints": {
+                    "type": "array"
+                },
+                "priorityClassName": {
+                    "type": "string"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "nodePort": {
+                            "type": "integer"
+                        },
+                        "clusterIP": {
+                            "type": "string"
+                        },
+                        "appProtocol": {
+                            "type": "string"
+                        },
+                        "loadBalancerClass": {
+                            "type": "string"
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "podDisruptionBudget": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "minAvailable": {
+                            "oneOf": [
+                                {
+                                    "type": "integer",
+                                    "minimum": 0
+                                },
+                                {
+                                    "type": "string",
+                                    "pattern": "^[0-9]+%$"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "maxUnavailable": {
+                            "oneOf": [
+                                {
+                                    "type": "integer",
+                                    "minimum": 0
+                                },
+                                {
+                                    "type": "string",
+                                    "pattern": "^[0-9]+%$"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "size": {
+                            "type": "string"
+                        },
+                        "storageClass": {
+                            "type": "string"
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "extraConfig": {
+                    "type": "string"
+                },
+                "roleLabeler": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "pollIntervalSeconds": {
+                            "type": "integer",
+                            "minimum": 1
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                },
+                                "pullPolicy": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+        },
         "securityContext": {
             "type": "object",
             "properties": {

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -264,6 +264,107 @@ replica:
   # More info: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
   persistentVolumeClaimRetentionPolicy: {}
 
+# Sentinel configuration for automatic failover (requires replica.enabled: true)
+sentinel:
+  # Enable Sentinel for high availability with automatic failover
+  enabled: false
+
+  # Number of Sentinel instances (must be odd, minimum 3 for proper quorum)
+  replicas: 3
+
+  # Sentinel port
+  port: 26379
+
+  # Name of the master group as monitored by Sentinel
+  masterGroupName: "mymaster"
+
+  # Number of Sentinels that must agree a master is down before failover
+  quorum: 2
+
+  # Milliseconds before Sentinel considers a master down
+  downAfterMilliseconds: 5000
+
+  # Milliseconds before a failover times out
+  failoverTimeout: 60000
+
+  # Number of replicas that can be reconfigured simultaneously during failover
+  parallelSyncs: 1
+
+  # Resource limits/requests for Sentinel containers
+  resources: {}
+
+  # Security context for Sentinel containers
+  securityContext: {}
+
+  # Pod-level security context for Sentinel pods
+  podSecurityContext: {}
+
+  # Annotations and labels for Sentinel pods
+  podAnnotations: {}
+  podLabels: {}
+
+  # Annotations for the Sentinel StatefulSet resource
+  workloadAnnotations: {}
+
+  # Node selector for Sentinel pod assignment
+  nodeSelector: {}
+
+  # Tolerations for Sentinel pod assignment
+  tolerations: []
+
+  # Affinity rules for Sentinel pod scheduling
+  affinity: {}
+
+  # Topology spread constraints for Sentinel pods
+  topologySpreadConstraints: []
+
+  # Priority class name for Sentinel pods
+  priorityClassName: ""
+
+  # Service configuration for Sentinel
+  service:
+    type: ClusterIP
+    port: 26379
+    annotations: {}
+    nodePort: 0
+    clusterIP: ""
+    appProtocol: ""
+    loadBalancerClass: ""
+    loadBalancerSourceRanges: []
+
+  # PodDisruptionBudget for Sentinel
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: null
+    maxUnavailable: 1
+
+  # Persistence for Sentinel (to survive restarts and remember state)
+  persistence:
+    enabled: false
+    size: "100Mi"
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+
+  # Extra Sentinel configuration directives appended to sentinel.conf
+  extraConfig: ""
+
+  # Role labeler sidecar configuration
+  # The role labeler runs on each data pod and updates pod labels (valkey-role: master/replica)
+  # so the primary service can route to the current master without Sentinel-aware clients
+  roleLabeler:
+    enabled: true
+    # How often to check the role (seconds)
+    pollIntervalSeconds: 5
+    # Image for the role labeler sidecar (needs curl for K8s API calls)
+    image:
+      registry: "docker.io"
+      repository: curlimages/curl
+      tag: "8.13.0"
+      pullPolicy: IfNotPresent
+    # Resource limits/requests for the role labeler sidecar
+    resources: {}
+
 tls:
   # Enable TLS
   enabled: false

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -365,6 +365,101 @@ sentinel:
     # Resource limits/requests for the role labeler sidecar
     resources: {}
 
+# Cluster mode configuration for sharding with optional per-shard replication
+# Mutually exclusive with replica.enabled — cannot use both at the same time
+cluster:
+  # Enable Valkey Cluster (sharding + optional HA)
+  enabled: false
+
+  # Number of master (shard) nodes (minimum 3 for cluster quorum)
+  masters: 3
+
+  # Number of replica nodes per master (0 = sharding only, no HA)
+  replicasPerMaster: 1
+
+  # Cluster node timeout in milliseconds (how long before a node is considered failing)
+  nodeTimeout: 5000
+
+  # Persistence configuration (required for cluster mode)
+  persistence:
+    # Size of the PVC for each node (required when cluster.enabled is true)
+    size: ""
+    # Storage class name (empty = use default storage class)
+    storageClass: ""
+    # Access modes for the PVC
+    accessModes:
+      - ReadWriteOnce
+
+  # PersistentVolumeClaim retention policy for StatefulSet
+  persistentVolumeClaimRetentionPolicy: {}
+
+  # Service configuration for cluster client access
+  service:
+    type: ClusterIP
+    port: 6379
+    annotations: {}
+    nodePort: 0
+    clusterIP: ""
+    appProtocol: ""
+    loadBalancerClass: ""
+    loadBalancerSourceRanges: []
+
+  # PodDisruptionBudget for cluster nodes
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: null
+    maxUnavailable: 1
+
+  # Resource limits/requests for cluster node containers
+  resources: {}
+
+  # Security context for cluster node containers
+  securityContext: {}
+
+  # Pod-level security context for cluster pods
+  podSecurityContext: {}
+
+  # Annotations and labels for cluster pods
+  podAnnotations: {}
+  podLabels: {}
+
+  # Annotations for the cluster StatefulSet resource
+  workloadAnnotations: {}
+
+  # Node selector for cluster pod assignment
+  nodeSelector: {}
+
+  # Tolerations for cluster pod assignment
+  tolerations: []
+
+  # Affinity rules for cluster pod scheduling
+  affinity: {}
+
+  # Topology spread constraints for cluster pods
+  topologySpreadConstraints: []
+
+  # Priority class name for cluster pods
+  priorityClassName: ""
+
+  # Extra Valkey configuration directives appended to valkey.conf
+  extraConfig: ""
+
+  # Role labeler sidecar configuration
+  # Labels each pod with valkey-role: master or valkey-role: replica
+  # Useful for observability, monitoring dashboards, and PDB awareness
+  roleLabeler:
+    enabled: true
+    # How often to check the role (seconds)
+    pollIntervalSeconds: 5
+    # Image for the role labeler sidecar (needs curl for K8s API calls)
+    image:
+      registry: "docker.io"
+      repository: curlimages/curl
+      tag: "8.13.0"
+      pullPolicy: IfNotPresent
+    # Resource limits/requests for the role labeler sidecar
+    resources: {}
+
 tls:
   # Enable TLS
   enabled: false


### PR DESCRIPTION
## Summary

- **Sentinel mode** (`sentinel.enabled: true`): High availability with automatic failover via Sentinel, role-labeler sidecar for dynamic master routing, and configurable quorum/replicas.
- **Cluster mode** (`cluster.enabled: true`): Sharded deployment with configurable masters and replicas-per-master, bootstrap sidecar for automatic cluster formation, and cluster-bus port handling.

Both modes support:
- ACL-based authentication with multi-user support
- TLS encryption (data port + replication/cluster-bus)
- PodDisruptionBudgets
- Metrics exporter sidecar
- Role labeler sidecar for pod labels (`valkey-role: master/slave`)

### Key files added
- `sentinel-*.yaml` — Sentinel StatefulSet, services, RBAC, PDB, ConfigMap
- `cluster-*.yaml` — Cluster StatefulSet, headless/client services, PDB, ConfigMap
- `role-labeler-configmap.yaml` — Shared role labeler for both modes

### Validation
- 203 helm-unittest tests (all passing)
- Tested full upgrade path on live EKS cluster:
  - **Cluster**: basic → auth → auth+TLS (all clean rolling updates)
  - **Sentinel**: basic → auth → auth+TLS (all clean rolling updates)

### Note
> This is a large feature PR. I understand it may take time to review and stabilize. My intention is to put this out for anyone willing to try it out and provide feedback — not to rush it into a release.

## Test plan
- [ ] `just validate` (lint + unit tests)
- [ ] Deploy cluster mode: basic, then upgrade to auth, then TLS
- [ ] Deploy sentinel mode: basic, then upgrade to auth, then TLS
- [ ] Verify cluster formation with `CLUSTER INFO`
- [ ] Verify sentinel failover with `SENTINEL master mymaster`
