### PR TITLE
chore: do not use sh to execute valkey-cli in probes

### DIFF
--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -119,16 +119,16 @@ spec:
           startupProbe:
             exec:
               {{- if .Values.tls.enabled }}
-              command: [ "sh", "-c", "valkey-cli --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
+              command: [ "valkey-cli", "--cacert", "/tls/{{ .Values.tls.caPublicKey }}", "--tls", "ping" ]
               {{- else }}
-              command: [ "sh", "-c", "valkey-cli ping" ]
+              command: [ "valkey-cli", "ping" ]
               {{- end }}
           livenessProbe:
             exec:
               {{- if .Values.tls.enabled }}
-              command: [ "sh", "-c", "valkey-cli --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
+              command: [ "valkey-cli", "--cacert", "/tls/{{ .Values.tls.caPublicKey }}", "--tls", "ping" ]
               {{- else }}
-              command: [ "sh", "-c", "valkey-cli ping" ]
+              command: [ "valkey-cli", "ping" ]
               {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -136,16 +136,16 @@ spec:
           startupProbe:
             exec:
               {{- if .Values.tls.enabled }}
-              command: [ "sh", "-c", "valkey-cli --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
+              command: [ "valkey-cli", "--cacert", "/tls/{{ .Values.tls.caPublicKey }}", "--tls", "ping" ]
               {{- else }}
-              command: [ "sh", "-c", "valkey-cli ping" ]
+              command: [ "valkey-cli", "ping" ]
               {{- end }}
           livenessProbe:
             exec:
               {{- if .Values.tls.enabled }}
-              command: [ "sh", "-c", "valkey-cli --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
+              command: [ "valkey-cli", "--cacert", "/tls/{{ .Values.tls.caPublicKey }}", "--tls", "ping" ]
               {{- else }}
-              command: [ "sh", "-c", "valkey-cli ping" ]
+              command: [ "valkey-cli", "ping" ]
               {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
this enables the usage of if the distroless image, which does not include sh.

[Markus Sattler](mailto:markus.satter@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH

[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)