### PR TITLE
Mitigating differences in deployed manifest.

### DIFF
--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -24,7 +24,9 @@ spec:
     matchLabels:
       {{- include "valkey.selectorLabels" . | nindent 6 }}
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1	
+    kind: PersistentVolumeClaim
+    metadata:
       name: valkey-data
     spec:
       accessModes: {{ toYaml .Values.replica.persistence.accessModes | nindent 8 }}


### PR DESCRIPTION
When the chart is deployed K8s will fill in missing pieces. CD tools like ArgoCD will see the difference and flag the deployment as out-of-sync. This PR mitigates that problem for the statefulset.

<img width="488" height="219" alt="image" src="https://github.com/user-attachments/assets/b4692bc8-dd5a-491a-b9a3-e3dc0363c83a" />
