### PR TITLE
fix: rename VALKEY_LOGLEVEL env var to VALKEY_LOG_LEVEL

### DIFF
--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -110,7 +110,7 @@ spec:
             - name: {{ $key }}
               value: "{{ $val }}"
             {{- end }}
-            - name: VALKEY_LOGLEVEL
+            - name: VALKEY_LOG_LEVEL
               value: "{{ .Values.valkeyLogLevel }}"
           ports:
             - name: tcp

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -127,7 +127,7 @@ spec:
             - name: {{ $key }}
               value: "{{ $val }}"
             {{- end }}
-            - name: VALKEY_LOGLEVEL
+            - name: VALKEY_LOG_LEVEL
               value: "{{ .Values.valkeyLogLevel }}"
           ports:
             - name: tcp


### PR DESCRIPTION
## Summary

The `valkeyLogLevel` helm value sets the environment variable `VALKEY_LOGLEVEL` in both the Deployment and StatefulSet templates. However, the Valkey entrypoint script reads `VALKEY_LOG_LEVEL` (with an underscore between LOG and LEVEL). This means setting `valkeyLogLevel` in values.yaml has no effect on the running container's log level.

## Changes

Renamed the environment variable from `VALKEY_LOGLEVEL` to `VALKEY_LOG_LEVEL` in:
- `valkey/templates/deploy_valkey.yaml` (standalone mode)
- `valkey/templates/statefulset.yaml` (replica mode)

No changes to `values.yaml` needed. The helm value name `valkeyLogLevel` remains the same.

## Testing

Set `valkeyLogLevel: debug` in values.yaml and confirmed the running container picks up the debug log level.

Fixes #1302
