### PR TITLE
fix: strip enabled key from securityContext before rendering

### DIFF
--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -46,14 +46,14 @@ spec:
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       initContainers:
         - name: {{ include "valkey.fullname" . }}-init
           image: {{ include "valkey.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- omit . "enabled" | toYaml | nindent 12 }}
           {{- end }}
           command: [ "/scripts/init.sh" ]
           volumeMounts:
@@ -104,7 +104,7 @@ spec:
           command: [ "valkey-server" ]
           args: [ "/data/conf/valkey.conf" ]
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- omit .Values.securityContext "enabled" | toYaml | nindent 12 }}
           env:
             {{- range $key, $val := .Values.env }}
             - name: {{ $key }}
@@ -163,7 +163,7 @@ spec:
           imagePullPolicy: {{ .Values.metrics.exporter.image.pullPolicy | quote }}
           {{- with .Values.metrics.exporter.securityContext }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- omit . "enabled" | toYaml | nindent 12 }}
           {{- end }}
           {{- with .Values.metrics.exporter.command }}
           command:

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -60,14 +60,14 @@ spec:
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
       securityContext:
-      {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       initContainers:
         - name: {{ include "valkey.fullname" . }}-init
           image: {{ include "valkey.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- omit . "enabled" | toYaml | nindent 12 }}
           {{- end }}
           command: [ "/scripts/init.sh" ]
           env:
@@ -117,7 +117,7 @@ spec:
           command: [ "valkey-server" ]
           args: [ "/data/conf/valkey.conf" ]
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- omit .Values.securityContext "enabled" | toYaml | nindent 12 }}
           env:
             - name: POD_INDEX
               valueFrom:
@@ -177,7 +177,7 @@ spec:
           imagePullPolicy: {{ .Values.metrics.exporter.image.pullPolicy | quote }}
           {{- with .Values.metrics.exporter.securityContext }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- omit . "enabled" | toYaml | nindent 12 }}
           {{- end }}
           {{- with .Values.metrics.exporter.command }}
           command:

--- a/valkey/tests/deployment_test.yaml
+++ b/valkey/tests/deployment_test.yaml
@@ -428,3 +428,76 @@ tests:
               secretKeyRef:
                 name: my-custom-secret
                 key: my-password-key
+
+  - it: should not render enabled key in podSecurityContext
+    set:
+      podSecurityContext:
+        enabled: true
+        fsGroup: 1000
+        runAsUser: 1000
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - notExists:
+          path: spec.template.spec.securityContext.enabled
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+
+  - it: should not render enabled key in container securityContext
+    set:
+      securityContext:
+        enabled: true
+        runAsNonRoot: true
+        readOnlyRootFilesystem: true
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.enabled
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+
+  - it: should not render enabled key in init container securityContext
+    set:
+      securityContext:
+        enabled: true
+        allowPrivilegeEscalation: false
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - notExists:
+          path: spec.template.spec.initContainers[0].securityContext.enabled
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.allowPrivilegeEscalation
+          value: false
+
+  - it: should not render enabled key in metrics exporter securityContext
+    set:
+      metrics.enabled: true
+      metrics.exporter.securityContext:
+        enabled: true
+        runAsNonRoot: true
+        runAsUser: 1000
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - notExists:
+          path: spec.template.spec.containers[1].securityContext.enabled
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.runAsUser
+          value: 1000

--- a/valkey/tests/statefulset_test.yaml
+++ b/valkey/tests/statefulset_test.yaml
@@ -371,3 +371,84 @@ tests:
               secretKeyRef:
                 name: my-custom-secret
                 key: my-password-key
+
+  - it: should not render enabled key in podSecurityContext
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      podSecurityContext:
+        enabled: true
+        fsGroup: 1000
+        runAsUser: 1000
+    template: templates/statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - notExists:
+          path: spec.template.spec.securityContext.enabled
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+
+  - it: should not render enabled key in container securityContext
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      securityContext:
+        enabled: true
+        runAsNonRoot: true
+        readOnlyRootFilesystem: true
+    template: templates/statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.enabled
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+
+  - it: should not render enabled key in init container securityContext
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      securityContext:
+        enabled: true
+        allowPrivilegeEscalation: false
+    template: templates/statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - notExists:
+          path: spec.template.spec.initContainers[0].securityContext.enabled
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.allowPrivilegeEscalation
+          value: false
+
+  - it: should not render enabled key in metrics exporter securityContext
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      metrics.enabled: true
+      metrics.exporter.securityContext:
+        enabled: true
+        runAsNonRoot: true
+        runAsUser: 1000
+    template: templates/statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - notExists:
+          path: spec.template.spec.containers[1].securityContext.enabled
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.runAsUser
+          value: 1000


### PR DESCRIPTION
## Summary

The `podSecurityContext` and `securityContext` values support an `enabled` field as a helm-level toggle (common in Bitnami-style charts). However, `enabled` is not a valid Kubernetes PodSecurityContext or SecurityContext field. When rendered verbatim into the manifest, Kubernetes silently strips it on storage, causing the actual stored state to differ from what Helm rendered. This breaks drift detection in GitOps tools (ArgoCD, Rancher Fleet, etc.), reporting resources as perpetually out-of-sync.

## Changes

Used `omit` to strip the `enabled` key before piping to `toYaml` in all security context rendering locations across both templates:

- `valkey/templates/deploy_valkey.yaml` (4 spots: pod, init container, main container, metrics exporter)
- `valkey/templates/statefulset.yaml` (4 spots: same)

## Testing

Render the chart with `podSecurityContext.enabled=true` and verify `enabled` does not appear in the output YAML:

```bash
helm template valkey valkey --repo https://valkey.io/valkey-helm/ \
  --show-only templates/deploy_valkey.yaml | grep -A 4 "securityContext:"
