### PR TITLE
fix: support secretKeyRef in metrics exporter extraEnvs

### DIFF
--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -213,7 +213,12 @@ spec:
             {{- end }}
             {{- range $key, $val := .Values.metrics.exporter.extraEnvs }}
             - name: {{ $key }}
+              {{- if kindIs "string" $val }}
               value: "{{ $val }}"
+              {{- else }}
+              valueFrom:
+                {{- toYaml $val | nindent 16 }}
+              {{- end }}
             {{- end }}
         {{- end }}
       {{- with .Values.extraContainers }}

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -227,7 +227,12 @@ spec:
             {{- end }}
             {{- range $key, $val := .Values.metrics.exporter.extraEnvs }}
             - name: {{ $key }}
+              {{- if kindIs "string" $val }}
               value: "{{ $val }}"
+              {{- else }}
+              valueFrom:
+                {{- toYaml $val | nindent 16 }}
+              {{- end }}
             {{- end }}
         {{- end }}
         {{- with .Values.extraContainers }}

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -353,8 +353,13 @@ metrics:
     extraExporterSecrets: []
     # Environment variables to inject into the metrics exporter container
     extraEnvs: {}
-    # Example:
-    # LOG_LEVEL: info
+    # Example with plain string values:
+    #   LOG_LEVEL: info
+    # Example with secret references:
+    #   REDIS_PASSWORD:
+    #     secretKeyRef:
+    #       name: valkey-secret
+    #       key: password
     securityContext: {}
       # Example:
       # runAsNonRoot: true


### PR DESCRIPTION
Fixes #151

## Summary
Update the `extraEnvs` template to support Kubernetes secret references (`secretKeyRef`) in addition to plain string values.

## Changes
- `statefulset.yaml` — check value type with `kindIs "string"`, render `value:` for strings or `valueFrom:` for objects
- `deploy_valkey.yaml` — same fix
- `values.yaml` — updated example comments showing both plain and secret reference usage

## Backwards Compatible
Existing plain string `extraEnvs` values continue to work unchanged. Only map/object values are now rendered as `valueFrom:` blocks.

## Example
```yaml
metrics:
  exporter:
    extraEnvs:
      LOG_LEVEL: info  # plain string — works as before
      REDIS_PASSWORD:  # secret reference — now supported
        secretKeyRef:
          name: valkey-secret
          key: password
