### PR TITLE
feat: add metrics auth RBAC, metrics-reader, and ServiceMonitor

### DIFF
--- a/valkey-operator/templates/deployment.yaml
+++ b/valkey-operator/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - --health-probe-bind-address=:8081
         {{- if .Values.metrics.enabled }}
         - --metrics-bind-address=:{{ .Values.metrics.port }}
-        - --metrics-secure=false
+        - --metrics-secure={{ .Values.metrics.secure }}
         {{- else }}
         - --metrics-bind-address=0
         {{- end }}

--- a/valkey-operator/templates/metrics-auth-clusterrole.yaml
+++ b/valkey-operator/templates/metrics-auth-clusterrole.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.rbac.create .Values.metrics.enabled .Values.metrics.secure -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "valkey-operator.fullname" . }}-metrics-auth
+  labels:
+    {{- include "valkey-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+{{- end }}

--- a/valkey-operator/templates/metrics-auth-clusterrolebinding.yaml
+++ b/valkey-operator/templates/metrics-auth-clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.rbac.create .Values.metrics.enabled .Values.metrics.secure -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "valkey-operator.fullname" . }}-metrics-auth
+  labels:
+    {{- include "valkey-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "valkey-operator.fullname" . }}-metrics-auth
+subjects:
+- kind: ServiceAccount
+  name: {{ include "valkey-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/valkey-operator/templates/metrics-reader-clusterrole.yaml
+++ b/valkey-operator/templates/metrics-reader-clusterrole.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.rbac.create .Values.metrics.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "valkey-operator.fullname" . }}-metrics-reader
+  labels:
+    {{- include "valkey-operator.labels" . | nindent 4 }}
+rules:
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get
+{{- end }}

--- a/valkey-operator/templates/metrics-service.yaml
+++ b/valkey-operator/templates/metrics-service.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   type: {{ .Values.metrics.service.type }}
   ports:
-  - name: http
+  - name: {{ if .Values.metrics.secure }}https{{ else }}http{{ end }}
     port: {{ .Values.metrics.port }}
     protocol: TCP
     targetPort: metrics

--- a/valkey-operator/templates/servicemonitor.yaml
+++ b/valkey-operator/templates/servicemonitor.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.prometheus.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "valkey-operator.fullname" . }}
+  namespace: {{ .Values.prometheus.serviceMonitor.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "valkey-operator.labels" . | nindent 4 }}
+    {{- with .Values.prometheus.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  - path: /metrics
+    port: {{ if .Values.metrics.secure }}https{{ else }}http{{ end }}
+    {{- if .Values.metrics.secure }}
+    scheme: https
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    tlsConfig:
+      insecureSkipVerify: true
+    {{- else }}
+    scheme: http
+    {{- end }}
+    {{- with .Values.prometheus.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.prometheus.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
+  selector:
+    matchLabels:
+      {{- include "valkey-operator.selectorLabels" . | nindent 6 }}
+      control-plane: controller-manager
+{{- end }}

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -100,8 +100,6 @@ podLabels: {}
 # Labels to add to all resources
 commonLabels: {}
 
-# TODO: metrics auth RBAC (metrics-auth-role, metrics-reader-role)
-# TODO: prometheus ServiceMonitor
 # TODO: networkPolicy
 # TODO: aggregated ClusterRoles (admin/editor/viewer)
 # TODO: topologySpreadConstraints
@@ -110,6 +108,10 @@ commonLabels: {}
 metrics:
   # Enable the metrics endpoint
   enabled: true
+  # Serve metrics over HTTPS with authentication/authorization.
+  # When true, metrics auth RBAC (tokenreviews, subjectaccessreviews) is created.
+  # Requires a valid serving certificate (e.g. via cert-manager).
+  secure: false
   # Port for the metrics endpoint
   port: 8443
   service:
@@ -118,4 +120,18 @@ metrics:
     # Annotations for the metrics service
     annotations: {}
     # Labels for the metrics service
+    labels: {}
+
+# Prometheus ServiceMonitor
+prometheus:
+  serviceMonitor:
+    # Create a ServiceMonitor resource for Prometheus Operator
+    enabled: false
+    # Namespace for the ServiceMonitor (defaults to release namespace)
+    namespace: ""
+    # Scrape interval
+    interval: ""
+    # Scrape timeout
+    scrapeTimeout: ""
+    # Additional labels for the ServiceMonitor
     labels: {}


### PR DESCRIPTION
## Description

Follow-up to #162. Adds the bits needed for secure metrics and Prometheus scraping.

New `metrics.secure` toggle (defaults to `false`). When flipped to `true` it creates the tokenreviews/subjectaccessreviews RBAC the operator needs for `--metrics-secure=true`, and switches the service port name to `https`. Also adds a `metrics-reader` ClusterRole for `/metrics` access.

ServiceMonitor template behind `prometheus.serviceMonitor.enabled`, picks up the right scheme/port based on the secure flag.

Cleaned up the TODOs in values.yaml that this covers.

## Testing

Linted, templated, deployed on kind with both secure on and off. RBAC resources show up when expected, operator args are correct.

---