### PR TITLE
Fix valkey-operator helm install notes

### DIFF
--- a/valkey-operator/templates/NOTES.txt
+++ b/valkey-operator/templates/NOTES.txt
@@ -6,12 +6,12 @@ To verify the operator is running:
 
 To create a ValkeyCluster:
 
-  cat <<EOF | kubectl apply -f -
-  apiVersion: valkey.io/v1alpha1
-  kind: ValkeyCluster
-  metadata:
-    name: my-cluster
-  spec:
-    shards: 3
-    replicas: 1
-  EOF
+kubectl apply -f - <<EOF
+apiVersion: valkey.io/v1alpha1
+kind: ValkeyCluster
+metadata:
+  name: my-cluster
+spec:
+  shards: 3
+  replicas: 1
+EOF


### PR DESCRIPTION
When copying the code out of the shell and executing it, the command doesn't recognize the `EOF` because it's indented.