### PR TITLE
feat: add manager.watchNamespaces value

### DIFF
--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 0.1.1
+
+### Added
+
+- New value `manager.watchNamespaces`
+  - Accepts a list of templatable namespaces that will be passed to `--watch-namespace` on the operator
+
+## 0.1.0
+
+Initial release

--- a/valkey-operator/Chart.yaml
+++ b/valkey-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey-operator
 description: A Helm chart for the Valkey Operator
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "v0.1.0"
 kubeVersion: ">=1.20.0-0"
 home: https://valkey.io/valkey-helm/

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -20,7 +20,7 @@ helm install valkey-operator valkey/valkey-operator \
   -n valkey-operator-system --create-namespace
 ```
 
-This will deploy the operator into the `valkey-operator-system` namespace. The operator will watch for `ValkeyCluster` custom resources across all namespaces.
+This will deploy the operator into the `valkey-operator-system` namespace. By default the operator watches for `ValkeyCluster` resources across all namespaces. Set `manager.watchNamespaces` to restrict it to specific namespaces.
 
 ## Creating a ValkeyCluster
 
@@ -50,6 +50,7 @@ See [values.yaml](values.yaml) for the full list of configurable parameters.
 | `serviceAccount.create` | Create a ServiceAccount | `true` |
 | `rbac.create` | Create ClusterRole and ClusterRoleBinding | `true` |
 | `manager.leaderElection.enabled` | Enable leader election | `true` |
+| `manager.watchNamespaces` | Restrict cache to these namespaces (cluster-wide if empty) | `[]` |
 | `metrics.enabled` | Enable the metrics endpoint | `true` |
 | `metrics.port` | Metrics endpoint port | `8443` |
 | `resources.limits.cpu` | CPU limit | `500m` |

--- a/valkey-operator/templates/deployment.yaml
+++ b/valkey-operator/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
         {{- else }}
         - --metrics-bind-address=0
         {{- end }}
+        {{- range .Values.manager.watchNamespaces }}
+        - --watch-namespace={{ tpl . $ }}
+        {{- end }}
         {{- with .Values.manager.args }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -45,6 +45,17 @@ manager:
   # Leader election prevents multiple operator instances from conflicting
   leaderElection:
     enabled: true
+  # Restrict the operator's informer cache to these namespaces.
+  # Each entry maps to a --watch-namespace flag passed to the operator binary.
+  # Leave empty (default) to watch all namespaces cluster-wide.
+  # When set, include every namespace containing managed resources.
+  # Omitting a namespace where managed resources live will cause reconcile errors.
+  # Example:
+  #   watchNamespaces:
+  #     - valkey-prod
+  #     - valkey-staging
+  #     - valkey-{{ .Values.myEnv }}
+  watchNamespaces: []
   # Additional command-line arguments for the operator binary
   args: []
 


### PR DESCRIPTION
### Added

- New value `manager.watchNamespaces`
  - Accepts a list of templatable namespaces that will be passed to `--watch-namespace` on the operator

Also added a changelog for tracking changes.

Dependent on the operator version that gets deployed with this: 
- https://github.com/valkey-io/valkey-operator/pull/175