### PR TITLE
feat: added configurable probes

### DIFF
--- a/valkey/templates/_helpers.tpl
+++ b/valkey/templates/_helpers.tpl
@@ -188,3 +188,80 @@ Validate replica authentication configuration
 {{- end }}
 {{- end -}}
 
+{{/*
+Validate probe authentication configuration.
+When auth is enabled, an override must be provided for each probe type
+because the chart cannot safely choose an auth approach on behalf of the operator.
+*/}}
+{{- define "valkey.validateProbeAuth" -}}
+{{- if .Values.auth.enabled -}}
+  {{- if not .Values.probes.startup.override -}}
+    {{- fail "probes.startup.override is required when auth.enabled=true. See values.yaml comments for options." -}}
+  {{- end -}}
+  {{- if not .Values.probes.liveness.override -}}
+    {{- fail "probes.liveness.override is required when auth.enabled=true. See values.yaml comments for options." -}}
+  {{- end -}}
+  {{- if and .Values.probes.readiness.enabled (not .Values.probes.readiness.override) -}}
+    {{- fail "probes.readiness.override is required when auth.enabled=true and probes.readiness.enabled=true. See values.yaml comments for options." -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Base probe renderer.
+Accepts any probe action (exec, tcpSocket, httpGet) as a dict and merges
+user-configured timings on top. If config.override is set, it is rendered
+as-is and the action is ignored entirely.
+
+Usage:
+  include "valkey.probe" (dict "action" $action "config" $probeCfg)
+
+  action  — a dict representing the probe action, e.g.:
+              dict "exec" (dict "command" (list "valkey-cli" "ping"))
+              dict "tcpSocket" (dict "port" "valkey-write")
+  config  — the probe config block from values (startup/liveness/readiness)
+*/}}
+{{- define "valkey.probe" -}}
+{{- $action := .action -}}
+{{- $cfg    := .config -}}
+{{- if $cfg.override }}
+{{- toYaml $cfg.override }}
+{{- else }}
+{{- toYaml $action }}
+{{- end }}
+{{- with $cfg.initialDelaySeconds }}
+initialDelaySeconds: {{ . }}
+{{- end }}
+{{- with $cfg.periodSeconds }}
+periodSeconds: {{ . }}
+{{- end }}
+{{- with $cfg.timeoutSeconds }}
+timeoutSeconds: {{ . }}
+{{- end }}
+{{- with $cfg.failureThreshold }}
+failureThreshold: {{ . }}
+{{- end }}
+{{- with $cfg.successThreshold }}
+successThreshold: {{ . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Render a probe for the main Valkey container.
+When auth is disabled, uses a direct valkey-cli exec (distroless-compatible).
+When auth is enabled, config.override is required (validated at render time).
+
+Usage:
+  include "valkey.probe.valkey" (dict "root" . "config" .Values.probes.startup)
+*/}}
+{{- define "valkey.probe.valkey" -}}
+{{- $root := .root -}}
+{{- $cfg  := .config -}}
+{{- $cmd  := list "valkey-cli" -}}
+{{- if $root.Values.tls.enabled -}}
+  {{- $cmd = concat $cmd (list "--tls" "--cacert" (printf "/tls/%s" $root.Values.tls.caPublicKey)) -}}
+{{- end -}}
+{{- $cmd = append $cmd "ping" -}}
+{{- $action := dict "exec" (dict "command" $cmd) -}}
+{{- include "valkey.probe" (dict "action" $action "config" $cfg) -}}
+{{- end -}}

--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -3,6 +3,7 @@
 {{- $storage := .Values.dataStorage }}
 {{- $createPVC := and $storage.enabled (not (empty $storage.requestedSize)) (empty $storage.persistentVolumeClaimName) }}
 {{- include "valkey.validateAuthConfig" . }}
+{{- include "valkey.validateProbeAuth" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -117,19 +118,13 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           startupProbe:
-            exec:
-              {{- if .Values.tls.enabled }}
-              command: [ "sh", "-c", "valkey-cli --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
-              {{- else }}
-              command: [ "sh", "-c", "valkey-cli ping" ]
-              {{- end }}
+            {{- include "valkey.probe.valkey" (dict "root" . "config" .Values.probes.startup) | nindent 12 }}
           livenessProbe:
-            exec:
-              {{- if .Values.tls.enabled }}
-              command: [ "sh", "-c", "valkey-cli --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
-              {{- else }}
-              command: [ "sh", "-c", "valkey-cli ping" ]
-              {{- end }}
+            {{- include "valkey.probe.valkey" (dict "root" . "config" .Values.probes.liveness) | nindent 12 }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            {{- include "valkey.probe.valkey" (dict "root" . "config" .Values.probes.readiness) | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -2,6 +2,7 @@
 {{- include "valkey.validateAuthConfig" . }}
 {{- include "valkey.validateReplicaPersistence" . }}
 {{- include "valkey.validateReplicaAuth" . }}
+{{- include "valkey.validateProbeAuth" . }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -134,19 +135,13 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           startupProbe:
-            exec:
-              {{- if .Values.tls.enabled }}
-              command: [ "sh", "-c", "valkey-cli --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
-              {{- else }}
-              command: [ "sh", "-c", "valkey-cli ping" ]
-              {{- end }}
+            {{- include "valkey.probe.valkey" (dict "root" . "config" .Values.probes.startup) | nindent 12 }}
           livenessProbe:
-            exec:
-              {{- if .Values.tls.enabled }}
-              command: [ "sh", "-c", "valkey-cli --cacert /tls/{{ .Values.tls.caPublicKey }} --tls ping" ]
-              {{- else }}
-              command: [ "sh", "-c", "valkey-cli ping" ]
-              {{- end }}
+            {{- include "valkey.probe.valkey" (dict "root" . "config" .Values.probes.liveness) | nindent 12 }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            {{- include "valkey.probe.valkey" (dict "root" . "config" .Values.probes.readiness) | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/valkey/tests/probe_test.yaml
+++ b/valkey/tests/probe_test.yaml
@@ -1,0 +1,279 @@
+suite: configurable probes
+templates:
+  - templates/statefulset.yaml
+  - templates/deploy_valkey.yaml
+
+tests:
+
+  - it: valkey startup probe uses direct exec when auth is disabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      auth.enabled: false
+    template: templates/statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.exec.command
+          value: ["valkey-cli", "ping"]
+
+  - it: valkey readiness probe is absent when disabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      auth.enabled: false
+      probes.readiness.enabled: false
+    template: templates/statefulset.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: valkey startup probe respects custom initialDelaySeconds
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      auth.enabled: false
+      probes.startup.initialDelaySeconds: 30
+    template: templates/statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.initialDelaySeconds
+          value: 30
+
+  - it: valkey startup probe uses override when provided
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      auth.enabled: false
+      probes.startup.override:
+        tcpSocket:
+          port: 6379
+        initialDelaySeconds: 10
+    template: templates/statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
+          value: 6379
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe.exec
+
+  - it: valkey probe includes TLS flags when tls.enabled
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      auth.enabled: false
+      tls.enabled: true
+      tls.existingSecret: "my-tls-secret"
+      tls.caPublicKey: "ca.crt"
+    template: templates/statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].startupProbe.exec.command
+          content: "--tls"
+
+  - it: sentinel startup probe uses correct port
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      replica.sentinel.enabled: true
+      auth.enabled: false
+    template: templates/statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].startupProbe.exec.command
+          content: "26379"
+
+  - it: sentinel readiness probe absent by default
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      replica.sentinel.enabled: true
+      auth.enabled: false
+    template: templates/statefulset.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[1].readinessProbe
+
+  # ── deploy_valkey.yaml (standalone mode, replica.enabled=false) ─────────────
+
+  - it: standalone startup probe uses direct exec when auth is disabled
+    set:
+      replica.enabled: false
+      auth.enabled: false
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.exec.command
+          value: ["valkey-cli", "ping"]
+
+  - it: standalone liveness probe uses direct exec when auth is disabled
+    set:
+      replica.enabled: false
+      auth.enabled: false
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command
+          value: ["valkey-cli", "ping"]
+
+  - it: standalone readiness probe is absent when disabled
+    set:
+      replica.enabled: false
+      auth.enabled: false
+      probes.readiness.enabled: false
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: standalone readiness probe is rendered when enabled
+    set:
+      replica.enabled: false
+      auth.enabled: false
+      probes.readiness.enabled: true
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: standalone probe includes TLS flags when tls.enabled
+    set:
+      replica.enabled: false
+      auth.enabled: false
+      tls.enabled: true
+      tls.existingSecret: "my-tls-secret"
+      tls.caPublicKey: "ca.crt"
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].startupProbe.exec.command
+          content: "--tls"
+
+  - it: standalone probe respects custom initialDelaySeconds
+    set:
+      replica.enabled: false
+      auth.enabled: false
+      probes.startup.initialDelaySeconds: 30
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.initialDelaySeconds
+          value: 30
+
+  - it: standalone startup probe uses override when provided
+    set:
+      replica.enabled: false
+      auth.enabled: false
+      probes.startup.override:
+        tcpSocket:
+          port: 6379
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
+          value: 6379
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe.exec
+
+  - it: standalone metrics probes are not affected by probe config
+    set:
+      replica.enabled: false
+      auth.enabled: false
+      metrics.enabled: true
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].startupProbe.tcpSocket.port
+          value: metrics
+
+
+  # ── deploy_valkey.yaml (standalone mode, replica.enabled=false) ─────────────
+
+  - it: standalone startup probe uses direct exec when auth is disabled
+    set:
+      replica.enabled: false
+      auth.enabled: false
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.exec.command
+          value: ["valkey-cli", "ping"]
+
+  - it: standalone liveness probe uses direct exec when auth is disabled
+    set:
+      replica.enabled: false
+      auth.enabled: false
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command
+          value: ["valkey-cli", "ping"]
+
+  - it: standalone readiness probe is absent when disabled
+    set:
+      replica.enabled: false
+      auth.enabled: false
+      probes.readiness.enabled: false
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: standalone readiness probe is rendered when enabled
+    set:
+      replica.enabled: false
+      auth.enabled: false
+      probes.readiness.enabled: true
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: standalone probe includes TLS flags when tls.enabled
+    set:
+      replica.enabled: false
+      auth.enabled: false
+      tls.enabled: true
+      tls.existingSecret: "my-tls-secret"
+      tls.caPublicKey: "ca.crt"
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].startupProbe.exec.command
+          content: "--tls"
+
+  - it: standalone probe respects custom initialDelaySeconds
+    set:
+      replica.enabled: false
+      auth.enabled: false
+      probes.startup.initialDelaySeconds: 30
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.initialDelaySeconds
+          value: 30
+
+  - it: standalone startup probe uses override when provided
+    set:
+      replica.enabled: false
+      auth.enabled: false
+      probes.startup.override:
+        tcpSocket:
+          port: 6379
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
+          value: 6379
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe.exec
+
+  - it: standalone metrics probes are not affected by probe config
+    set:
+      replica.enabled: false
+      auth.enabled: false
+      metrics.enabled: true
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].startupProbe.tcpSocket.port
+          value: metrics

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -1,6 +1,42 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
+    "$defs": {
+        "probeConfig": {
+            "type": "object",
+            "properties": {
+                "override":            { "type": "object" },
+                "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+                "periodSeconds":       { "type": "integer", "minimum": 1 },
+                "timeoutSeconds":      { "type": "integer", "minimum": 1 },
+                "failureThreshold":    { "type": "integer", "minimum": 1 },
+                "successThreshold":    { "type": "integer", "minimum": 1 }
+            },
+            "additionalProperties": false
+        },
+        "probeConfigWithEnabled": {
+            "type": "object",
+            "properties": {
+                "enabled":             { "type": "boolean" },
+                "override":            { "type": "object" },
+                "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+                "periodSeconds":       { "type": "integer", "minimum": 1 },
+                "timeoutSeconds":      { "type": "integer", "minimum": 1 },
+                "failureThreshold":    { "type": "integer", "minimum": 1 },
+                "successThreshold":    { "type": "integer", "minimum": 1 }
+            },
+            "additionalProperties": false
+        },
+        "probesBlock": {
+            "type": "object",
+            "properties": {
+                "startup":   { "$ref": "#/$defs/probeConfig" },
+                "liveness":  { "$ref": "#/$defs/probeConfig" },
+                "readiness": { "$ref": "#/$defs/probeConfigWithEnabled" }
+            },
+            "additionalProperties": false
+        }
+    },
     "properties": {
         "affinity": {
             "type": "object"
@@ -360,6 +396,9 @@
         },
         "priorityClassName": {
             "type": "string"
+        },
+        "probes": {
+            "$ref": "#/$defs/probesBlock"
         },
         "replica": {
             "type": "object",

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -169,6 +169,60 @@ extraVolumeMounts: []
 #  - mountPath: /some/path/
 #    name: hostpath-volume
 
+# Probe configuration for the main Valkey container.
+# The default exec command is distroless-compatible: ["valkey-cli", "ping"].
+# TLS flags are added automatically when tls.enabled=true.
+#
+# When auth.enabled=true, the chart cannot safely handle authentication
+# without knowing your security model. You MUST provide an override for
+# each probe. Two supported patterns:
+#
+#   Option A — distroless compatible.
+#   Requires REDISCLI_AUTH injected via env.secretKeyRef in the container:
+#
+#     override:
+#       exec:
+#         command: ["valkey-cli", "ping"]
+#
+#   Option B — shell-based, reads password from the mounted secret at runtime.
+#   Not compatible with distroless images:
+#
+#     override:
+#       exec:
+#         command:
+#           - sh
+#           - -c
+#           - "p=$(cat /valkey-auth-secret/<passwordKey>); valkey-cli --user <user> -a \"$p\" --no-auth-warning ping"
+#
+probes:
+  startup:
+    # override: {}
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 1
+    failureThreshold: 20
+    successThreshold: 1
+
+  liveness:
+    # override: {}
+    initialDelaySeconds: 20
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+    successThreshold: 1
+
+  readiness:
+    # Disabled by default. In replica mode the Service already routes traffic
+    # based on pod availability. Enable only when fine-grained traffic
+    # exclusion is required (e.g. during large dataset loads).
+    enabled: false
+    # override: {}
+    initialDelaySeconds: 10
+    periodSeconds: 5
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
+
 # Content for valkey.conf (will be mounted via ConfigMap)
 valkeyConfig: ""
 


### PR DESCRIPTION
Related to #169

This PR adds configurable probes for the chart and covers the probe-related gap discussed in #169.
It updates templates, values, schema, and tests to make probe configuration explicit and reusable.