### PR TITLE
fix: sync valkey-operator chart with v0.1.0 release

### DIFF
--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## 0.1.1
+
+### Fixed
+
+- Update CRDs and RBAC to match valkey-operator v0.1.0.
+  - Add persistence field and CEL validation rules to both CRDs.
+  - Add serverConfigHash field to ValkeyNode CRD.
+  - Add persistentvolumeclaims to ClusterRole RBAC.
+
+## 0.1.0
+
+Initial release.

--- a/valkey-operator/Chart.yaml
+++ b/valkey-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey-operator
 description: A Helm chart for the Valkey Operator
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "v0.1.0"
 kubeVersion: ">=1.20.0-0"
 home: https://valkey.io/valkey-helm/

--- a/valkey-operator/crds/valkey.io_valkeyclusters.yaml
+++ b/valkey-operator/crds/valkey.io_valkeyclusters.yaml
@@ -2580,6 +2580,33 @@ spec:
                   type: string
                 description: NodeSelector to apply to the pods
                 type: object
+              persistence:
+                description: Persistence defines durable storage that is propagated
+                  to each ValkeyNode.
+                properties:
+                  reclaimPolicy:
+                    default: Retain
+                    description: |-
+                      ReclaimPolicy controls whether the managed PVC is retained or deleted when
+                      the ValkeyNode is deleted. Defaults to Retain.
+                    enum:
+                    - Retain
+                    - Delete
+                    type: string
+                  size:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Size is the requested PVC size.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  storageClassName:
+                    description: StorageClassName is the storage class to use for
+                      the PVC.
+                    type: string
+                required:
+                - size
+                type: object
               replicas:
                 description: The number of replicas for each shard group.
                 format: int32
@@ -2814,6 +2841,21 @@ spec:
                 - message: workloadType is immutable
                   rule: self == oldSelf
             type: object
+            x-kubernetes-validations:
+            - message: persistence requires workloadType StatefulSet
+              rule: '!(has(self.persistence) && self.workloadType == ''Deployment'')'
+            - message: persistence cannot be removed once set
+              rule: '!has(oldSelf.persistence) || has(self.persistence)'
+            - message: persistence cannot be added after creation
+              rule: has(oldSelf.persistence) || !has(self.persistence)
+            - message: persistence.size may only be expanded
+              rule: '!has(self.persistence) || !has(oldSelf.persistence) || quantity(self.persistence.size).compareTo(quantity(oldSelf.persistence.size))
+                >= 0'
+            - message: persistence.storageClassName is immutable
+              rule: '!has(self.persistence) || !has(oldSelf.persistence) || ((!has(self.persistence.storageClassName)
+                && !has(oldSelf.persistence.storageClassName)) || (has(self.persistence.storageClassName)
+                && has(oldSelf.persistence.storageClassName) && self.persistence.storageClassName
+                == oldSelf.persistence.storageClassName))'
           status:
             default:
               readyShards: 0

--- a/valkey-operator/crds/valkey.io_valkeynodes.yaml
+++ b/valkey-operator/crds/valkey.io_valkeynodes.yaml
@@ -2579,6 +2579,32 @@ spec:
                   type: string
                 description: NodeSelector defines the node selection constraints.
                 type: object
+              persistence:
+                description: Persistence defines durable storage for the ValkeyNode.
+                properties:
+                  reclaimPolicy:
+                    default: Retain
+                    description: |-
+                      ReclaimPolicy controls whether the managed PVC is retained or deleted when
+                      the ValkeyNode is deleted. Defaults to Retain.
+                    enum:
+                    - Retain
+                    - Delete
+                    type: string
+                  size:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Size is the requested PVC size.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  storageClassName:
+                    description: StorageClassName is the storage class to use for
+                      the PVC.
+                    type: string
+                required:
+                - size
+                type: object
               resources:
                 description: Resources defines the resource requirements for the Valkey
                   container.
@@ -2639,6 +2665,13 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+              serverConfigHash:
+                description: |-
+                  ServerConfigHash is a hash of the server ConfigMap contents. When set by
+                  the ValkeyCluster controller it bumps the spec Generation, which triggers
+                  the ValkeyNode controller to reconcile and update the pod template
+                  annotation — causing a rolling restart when the cluster config changes.
+                type: string
               serverConfigMapName:
                 description: |-
                   ServerConfigMapName specifies the name of the ConfigMap that contains the
@@ -2720,6 +2753,21 @@ spec:
                 - message: workloadType is immutable
                   rule: self == oldSelf
             type: object
+            x-kubernetes-validations:
+            - message: persistence requires workloadType StatefulSet
+              rule: '!(has(self.persistence) && self.workloadType == ''Deployment'')'
+            - message: persistence cannot be removed once set
+              rule: '!has(oldSelf.persistence) || has(self.persistence)'
+            - message: persistence cannot be added after creation
+              rule: has(oldSelf.persistence) || !has(self.persistence)
+            - message: persistence.size may only be expanded
+              rule: '!has(self.persistence) || !has(oldSelf.persistence) || quantity(self.persistence.size).compareTo(quantity(oldSelf.persistence.size))
+                >= 0'
+            - message: persistence.storageClassName is immutable
+              rule: '!has(self.persistence) || !has(oldSelf.persistence) || ((!has(self.persistence.storageClassName)
+                && !has(oldSelf.persistence.storageClassName)) || (has(self.persistence.storageClassName)
+                && has(oldSelf.persistence.storageClassName) && self.persistence.storageClassName
+                == oldSelf.persistence.storageClassName))'
           status:
             description: ValkeyNodeStatus defines the observed state of ValkeyNode.
             properties:

--- a/valkey-operator/templates/clusterrole.yaml
+++ b/valkey-operator/templates/clusterrole.yaml
@@ -10,6 +10,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - persistentvolumeclaims
   - secrets
   - services
   verbs:


### PR DESCRIPTION
Update CRDs and RBAC to match valkey-operator `v0.1.0`,
which is the default version used in the charts already.

- Add persistence field and CEL validation rules to both CRDs
- Add serverConfigHash field to ValkeyNode CRD (important for a cluster creation)
- Add persistentvolumeclaims to ClusterRole RBAC

Updated using `make manifests` in the operator repo on tag `v0.1.0` and copied to crds.