### PR TITLE
feat: add namespaceOverride support

### DIFF
--- a/valkey/templates/_helpers.tpl
+++ b/valkey/templates/_helpers.tpl
@@ -1,4 +1,12 @@
 {{/*
+Expand the namespace of the release.
+Allows overriding it for multi-namespace deployments in combined charts.
+*/}}
+{{- define "valkey.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "valkey.name" -}}

--- a/valkey/templates/configmap.yaml
+++ b/valkey/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "valkey.fullname" . }}-config
+  namespace: {{ include "valkey.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
 data:

--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -7,6 +7,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "valkey.fullname" . }}
+  namespace: {{ include "valkey.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
   {{- with .Values.workloadAnnotations }}

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "valkey.fullname" . }}-init-scripts
+  namespace: {{ include "valkey.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
 data:

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -161,7 +161,7 @@ data:
 
     # Configure replica settings
     if [ "$IS_MASTER" = "false" ]; then
-      MASTER_HOST="{{ include "valkey.fullname" . }}-0.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+      MASTER_HOST="{{ include "valkey.fullname" . }}-0.{{ include "valkey.headlessServiceName" . }}.{{ include "valkey.namespace" . }}.svc.{{ .Values.clusterDomain }}"
       MASTER_PORT="{{ .Values.service.port }}"
 
       log "Configuring replica to follow master at $MASTER_HOST:$MASTER_PORT"
@@ -170,7 +170,7 @@ data:
         echo ""
         echo "# Replica Configuration"
         echo "replicaof $MASTER_HOST $MASTER_PORT"
-        echo "replica-announce-ip {{ include "valkey.fullname" . }}-$POD_INDEX.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+        echo "replica-announce-ip {{ include "valkey.fullname" . }}-$POD_INDEX.{{ include "valkey.headlessServiceName" . }}.{{ include "valkey.namespace" . }}.svc.{{ .Values.clusterDomain }}"
         {{- if .Values.replica.disklessSync }}
         echo ""
         echo "# Diskless replication"

--- a/valkey/templates/metrics-svc.yaml
+++ b/valkey/templates/metrics-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ printf "%s-metrics" (include "valkey.fullname" .) }}
+  namespace: {{ include "valkey.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics

--- a/valkey/templates/netpolicy.yaml
+++ b/valkey/templates/netpolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "valkey.fullname" $ }}
+  namespace: {{ include "valkey.namespace" . }}
   {{- with .labels }}
   labels:
     {{- toYaml . | nindent 4 }}

--- a/valkey/templates/netpolicy.yaml
+++ b/valkey/templates/netpolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "valkey.fullname" $ }}
-  namespace: {{ include "valkey.namespace" . }}
+  namespace: {{ include "valkey.namespace" $ }}
   {{- with .labels }}
   labels:
     {{- toYaml . | nindent 4 }}

--- a/valkey/templates/poddisruptionbudget.yaml
+++ b/valkey/templates/poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "valkey.fullname" . }}
+  namespace: {{ include "valkey.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
 spec:

--- a/valkey/templates/podmonitor.yaml
+++ b/valkey/templates/podmonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ include "valkey.fullname" . }}
+  namespace: {{ include "valkey.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
     app.kubernetes.io/part-of: valkey
@@ -46,7 +47,7 @@ spec:
   {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "valkey.namespace" . }}
   selector:
     matchLabels:
     {{- include "valkey.selectorLabels" . | nindent 6 }}

--- a/valkey/templates/prometheusrules.yaml
+++ b/valkey/templates/prometheusrules.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ include "valkey.fullname" . }}
+  namespace: {{ include "valkey.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
     app.kubernetes.io/part-of: valkey

--- a/valkey/templates/pvc.yaml
+++ b/valkey/templates/pvc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "valkey.fullname" . }}
+  namespace: {{ include "valkey.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
     {{- with .Values.dataStorage.labels }}

--- a/valkey/templates/secret.yaml
+++ b/valkey/templates/secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "valkey.fullname" . }}-auth
+  namespace: {{ include "valkey.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
 type: Opaque

--- a/valkey/templates/service-headless.yaml
+++ b/valkey/templates/service-headless.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "valkey.fullname" . }}-headless
+  namespace: {{ include "valkey.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
     app.kubernetes.io/component: headless

--- a/valkey/templates/service-read.yaml
+++ b/valkey/templates/service-read.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "valkey.fullname" . }}-read
+  namespace: {{ include "valkey.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
     app.kubernetes.io/component: read

--- a/valkey/templates/service.yaml
+++ b/valkey/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "valkey.fullname" . }}
+  namespace: {{ include "valkey.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
     app.kubernetes.io/component: primary

--- a/valkey/templates/serviceaccount.yaml
+++ b/valkey/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "valkey.serviceAccountName" . }}
+  namespace: {{ include "valkey.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/valkey/templates/servicemonitor.yaml
+++ b/valkey/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "valkey.fullname" . }}
+  namespace: {{ include "valkey.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
     app.kubernetes.io/part-of: valkey
@@ -46,7 +47,7 @@ spec:
   {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "valkey.namespace" . }}
   selector:
     matchLabels:
       {{- include "valkey.selectorLabels" . | nindent 6 }}

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -6,6 +6,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "valkey.fullname" . }}
+  namespace: {{ include "valkey.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
   {{- with .Values.workloadAnnotations }}

--- a/valkey/templates/tests/auth.yaml
+++ b/valkey/templates/tests/auth.yaml
@@ -12,6 +12,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ include "valkey.fullname" . }}-test-auth-generated
+  namespace: {{ include "valkey.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
   annotations:

--- a/valkey/tests/namespace_test.yaml
+++ b/valkey/tests/namespace_test.yaml
@@ -1,0 +1,207 @@
+suite: namespaceOverride scopes every resource
+tests:
+  # --- main workloads (explicitly requested in review) ---
+  - it: Deployment honors namespaceOverride
+    template: templates/deploy_valkey.yaml
+    set:
+      namespaceOverride: custom-namespace
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+  - it: StatefulSet honors namespaceOverride
+    template: templates/statefulset.yaml
+    set:
+      namespaceOverride: custom-namespace
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+  - it: init scripts ConfigMap honors namespaceOverride
+    template: templates/init_config.yaml
+    set:
+      namespaceOverride: custom-namespace
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+  # --- every other resource the chart can render ---
+  - it: config ConfigMap honors namespaceOverride
+    template: templates/configmap.yaml
+    set:
+      namespaceOverride: custom-namespace
+      valkeyConfig: "maxmemory 100mb"
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+  - it: Service honors namespaceOverride
+    template: templates/service.yaml
+    set:
+      namespaceOverride: custom-namespace
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+  - it: headless Service honors namespaceOverride
+    template: templates/service-headless.yaml
+    set:
+      namespaceOverride: custom-namespace
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+  - it: read Service honors namespaceOverride
+    template: templates/service-read.yaml
+    set:
+      namespaceOverride: custom-namespace
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      replica.service.enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+  - it: ServiceAccount honors namespaceOverride
+    template: templates/serviceaccount.yaml
+    set:
+      namespaceOverride: custom-namespace
+      serviceAccount.create: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+  - it: Secret honors namespaceOverride
+    template: templates/secret.yaml
+    set:
+      namespaceOverride: custom-namespace
+      auth.enabled: true
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          password: "p"
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+  - it: PersistentVolumeClaim honors namespaceOverride
+    template: templates/pvc.yaml
+    set:
+      namespaceOverride: custom-namespace
+      dataStorage.enabled: true
+      dataStorage.requestedSize: "8Gi"
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+  - it: PodDisruptionBudget honors namespaceOverride
+    template: templates/poddisruptionbudget.yaml
+    set:
+      namespaceOverride: custom-namespace
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      podDisruptionBudget.enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+  - it: metrics Service honors namespaceOverride
+    template: templates/metrics-svc.yaml
+    set:
+      namespaceOverride: custom-namespace
+      metrics.enabled: true
+      metrics.service.enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+  - it: PodMonitor honors namespaceOverride
+    template: templates/podmonitor.yaml
+    set:
+      namespaceOverride: custom-namespace
+      metrics.enabled: true
+      metrics.podMonitor.enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+  - it: ServiceMonitor honors namespaceOverride
+    template: templates/servicemonitor.yaml
+    set:
+      namespaceOverride: custom-namespace
+      metrics.enabled: true
+      metrics.service.enabled: true
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+  - it: PrometheusRule honors namespaceOverride
+    template: templates/prometheusrules.yaml
+    set:
+      namespaceOverride: custom-namespace
+      metrics.enabled: true
+      metrics.prometheusRule.enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+  - it: NetworkPolicy honors namespaceOverride
+    template: templates/netpolicy.yaml
+    set:
+      namespaceOverride: custom-namespace
+      networkPolicy:
+        ingress: []
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+  - it: helm test Pod honors namespaceOverride
+    template: templates/tests/auth.yaml
+    set:
+      namespaceOverride: custom-namespace
+      auth.enabled: true
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          password: "p"
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+  # --- default behavior: fall back to the release namespace when not overridden ---
+  - it: falls back to the release namespace when namespaceOverride is unset
+    template: templates/deploy_valkey.yaml
+    release:
+      namespace: my-release-ns
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: my-release-ns

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -21,6 +21,9 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Override the namespace for all resources (defaults to .Release.Namespace)
+namespaceOverride: ""
+
 # Kubernetes cluster domain name
 clusterDomain: cluster.local
 


### PR DESCRIPTION
Add namespaceOverride value (empty by default) and valkey.namespace helper to allow deploying resources into a different namespace when used as a subchart in umbrella charts. No breaking change for existing users.