### PR TITLE
feat: template existing secret name value

### DIFF
--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -204,7 +204,7 @@ spec:
                   {{- if .Values.auth.usersExistingSecret }}
                   {{- $defaultUser := index .Values.auth.aclUsers "default" | default dict }}
                   {{- $passwordKey := $defaultUser.passwordKey | default "default" }}
-                  name: {{ .Values.auth.usersExistingSecret }}
+                  name: {{ tpl .Values.auth.usersExistingSecret . }}
                   key: {{ $passwordKey }}
                   {{- else }}
                   name: {{ include "valkey.fullname" . }}-auth
@@ -264,7 +264,7 @@ spec:
         {{- if .Values.auth.usersExistingSecret }}
         - name: valkey-users-secret
           secret:
-            secretName: {{ .Values.auth.usersExistingSecret }}
+            secretName: {{ tpl .Values.auth.usersExistingSecret . }}
             defaultMode: 0400
         {{- end }}
         {{- if or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig }}

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -218,7 +218,7 @@ spec:
                   {{- if .Values.auth.usersExistingSecret }}
                   {{- $defaultUser := index .Values.auth.aclUsers "default" | default dict }}
                   {{- $passwordKey := $defaultUser.passwordKey | default "default" }}
-                  name: {{ .Values.auth.usersExistingSecret }}
+                  name: {{ tpl .Values.auth.usersExistingSecret . }}
                   key: {{ $passwordKey }}
                   {{- else }}
                   name: {{ include "valkey.fullname" . }}-auth
@@ -278,7 +278,7 @@ spec:
         {{- if .Values.auth.usersExistingSecret }}
         - name: valkey-users-secret
           secret:
-            secretName: {{ .Values.auth.usersExistingSecret }}
+            secretName: {{ tpl .Values.auth.usersExistingSecret . }}
             defaultMode: 0400
         {{- end }}
         {{- if or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig }}

--- a/valkey/templates/tests/auth.yaml
+++ b/valkey/templates/tests/auth.yaml
@@ -135,7 +135,7 @@ spec:
   volumes:
     - name: valkey-users-secret
       secret:
-        secretName: {{ .Values.auth.usersExistingSecret }}
+        secretName: {{ tpl .Values.auth.usersExistingSecret . }}
     {{- if .Values.tls.enabled }}
     - name: valkey-tls
       secret:

--- a/valkey/tests/auth_validation_test.yaml
+++ b/valkey/tests/auth_validation_test.yaml
@@ -91,6 +91,21 @@ tests:
       - isKind:
           of: Deployment
 
+  - it: should succeed with templated usersExistingSecret
+    set:
+      auth.enabled: true
+      auth.usersExistingSecret: "my-secret-{{ .Release.Name }}"
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+        readonly:
+          permissions: "~* +@read"
+          passwordKey: "readonly-pwd"
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+
   - it: should succeed with mixed inline and existing secret passwords
     set:
       auth.enabled: true

--- a/valkey/tests/deployment_test.yaml
+++ b/valkey/tests/deployment_test.yaml
@@ -69,6 +69,25 @@ tests:
             mountPath: /valkey-users-secret
             readOnly: true
 
+  - it: should render users-secret volume with templated usersExistingSecret
+    set:
+      auth.enabled: true
+      auth.usersExistingSecret: "my-custom-secret-{{ .Release.Name }}"
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: valkey-users-secret
+            secret:
+              secretName: my-custom-secret-RELEASE-NAME
+              defaultMode: 0400
+
   - it: should have both volumes with mixed passwords
     set:
       auth.enabled: true
@@ -405,6 +424,27 @@ tests:
             valueFrom:
               secretKeyRef:
                 name: my-custom-secret
+                key: default
+
+  - it: should render templated usersExistingSecret in metrics exporter
+    set:
+      auth.enabled: true
+      auth.usersExistingSecret: "my-custom-secret-{{ .Release.Name }}"
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+      metrics.enabled: true
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-custom-secret-RELEASE-NAME
                 key: default
 
   - it: should set REDIS_PASSWORD using custom passwordKey in metrics exporter when usersExistingSecret is set

--- a/valkey/tests/statefulset_test.yaml
+++ b/valkey/tests/statefulset_test.yaml
@@ -287,6 +287,27 @@ tests:
           path: metadata.annotations["custom.annotation"]
           value: "custom-value"
 
+  - it: should render users-secret volume with templated usersExistingSecret
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      auth.enabled: true
+      auth.usersExistingSecret: "my-custom-secret-{{ .Release.Name }}"
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+    template: templates/statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: valkey-users-secret
+            secret:
+              secretName: my-custom-secret-RELEASE-NAME
+              defaultMode: 0400
+
   - it: should not have REDIS_PASSWORD env in metrics exporter when auth is disabled
     set:
       replica.enabled: true
@@ -346,6 +367,29 @@ tests:
             valueFrom:
               secretKeyRef:
                 name: my-custom-secret
+                key: default
+
+  - it: should render templated usersExistingSecret in metrics exporter
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      auth.enabled: true
+      auth.usersExistingSecret: "my-custom-secret-{{ .Release.Name }}"
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+      metrics.enabled: true
+    template: templates/statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-custom-secret-RELEASE-NAME
                 key: default
 
   - it: should set REDIS_PASSWORD using custom passwordKey in metrics exporter when usersExistingSecret is set

--- a/valkey/tests/test_pod_test.yaml
+++ b/valkey/tests/test_pod_test.yaml
@@ -59,6 +59,25 @@ tests:
             secret:
               secretName: my-secret
 
+  - it: should render existing secret test pod with templated usersExistingSecret
+    set:
+      auth.enabled: true
+      auth.usersExistingSecret: "my-secret-{{ .Release.Name }}"
+      auth.aclUsers:
+        admin:
+          permissions: "~* &* +@all"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Pod
+      - contains:
+          path: spec.volumes
+          content:
+            name: valkey-users-secret
+            secret:
+              secretName: my-secret-RELEASE-NAME
+
   - it: should not render test pods with aclConfig only
     set:
       auth.enabled: true

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -180,6 +180,7 @@ auth:
   enabled: false
 
   # Use an existing secret for user passwords. Key defaults to username.
+  # Supports templating, e.g.: "users-{{ .Release.Name }}"
   usersExistingSecret: ""
 
   # Map of users to create with ACL permissions.


### PR DESCRIPTION
This PR adds `tpl` rendering for `auth.usersExistingSecret` Helm chart value, so secret name can be dynamic.

Example:

```yaml
auth:
  enabled: true
  usersExistingSecret: "{{ .Release.Name }}-users"
  aclUsers:
    default:
      permissions: "~* &* +@all"
      # Password will be read from secret key "default" (defaults to username)
```

If release name is `my-valkey`, the chart uses `my-valkey-users` as the secret name.

