### PR TITLE
added support for runtimeClasses

### DIFF
--- a/valkey/Chart.yaml
+++ b/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: A Helm chart for Kubernetes
 type: application
-version: 0.11.0
+version: 0.10.0
 appVersion: "9.1.0"
 home: https://valkey.io/valkey-helm/
 sources:

--- a/valkey/Chart.yaml
+++ b/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: A Helm chart for Kubernetes
 type: application
-version: 0.10.0
+version: 0.11.0
 appVersion: "9.1.0"
 home: https://valkey.io/valkey-helm/
 sources:

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -331,6 +331,7 @@ tls:
 | podSecurityContext.runAsGroup | int | `1000` |  |
 | podSecurityContext.runAsUser | int | `1000` |  |
 | priorityClassName | string | `""` |  |
+| runtimeClassName | string | `""` | RuntimeClassName for the pods (e.g. `gvisor`, `kata-containers`); empty uses the cluster default runtime |
 | replica.enabled | bool | `false` |  |
 | replica.replicas | int | `2` |  |
 | replica.replicationUser | string | `"default"` |  |

--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -45,6 +45,9 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName | quote }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -59,6 +59,9 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName | quote }}
+      {{- end }}
       securityContext:
       {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:

--- a/valkey/tests/deployment_test.yaml
+++ b/valkey/tests/deployment_test.yaml
@@ -428,3 +428,24 @@ tests:
               secretKeyRef:
                 name: my-custom-secret
                 key: my-password-key
+
+  - it: should not set runtimeClassName when empty
+    set:
+      runtimeClassName: ""
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - notExists:
+          path: spec.template.spec.runtimeClassName
+
+  - it: should set runtimeClassName when provided
+    set:
+      runtimeClassName: "gvisor"
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.runtimeClassName
+          value: "gvisor"

--- a/valkey/tests/statefulset_test.yaml
+++ b/valkey/tests/statefulset_test.yaml
@@ -371,3 +371,27 @@ tests:
               secretKeyRef:
                 name: my-custom-secret
                 key: my-password-key
+  - it: should not set runtimeClassName when empty
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      runtimeClassName: ""
+    template: templates/statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - notExists:
+          path: spec.template.spec.runtimeClassName
+
+  - it: should set runtimeClassName when provided
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      runtimeClassName: "kata-containers"
+    template: templates/statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: spec.template.spec.runtimeClassName
+          value: "kata-containers"

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -361,6 +361,9 @@
         "priorityClassName": {
             "type": "string"
         },
+        "runtimeClassName": {
+            "type": "string"
+        },
         "replica": {
             "type": "object",
             "properties": {

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -55,6 +55,11 @@ podSecurityContext:
 # Priority class name for pod scheduling (leave empty to use cluster's default)
 priorityClassName: ""
 
+# RuntimeClassName for the pods, used to select the container runtime configuration
+# (e.g. "gvisor", "kata-containers"). Leave empty to use the cluster's default runtime.
+# See https://kubernetes.io/docs/concepts/containers/runtime-class/#usage
+runtimeClassName: ""
+
 # Security context for the Valkey containers
 securityContext:
   allowPrivilegeEscalation: false


### PR DESCRIPTION
Summary
Adds a top-level runtimeClassName value that propagates to the pod spec of both the Deployment (standalone mode) and the StatefulSet (replica mode), letting users select a non-default container runtime (e.g. gvisor, kata-containers) for Valkey pods.

RuntimeClass lets operators run workloads under sandboxed or hardware-isolated runtimes for stronger workload isolation. The chart previously had no way to set pod.spec.runtimeClassName, forcing users to
patch rendered manifests or use post-render hooks.
  
  Behavior

  - Default (""): no runtimeClassName is emitted — identical output to before this change (backward compatible).
  - Set: the named RuntimeClass must already exist in the cluster; otherwise pods are not admitted.
  
  runtimeClassName: gvisor
  
    Testing

  - helm lint passes.
  - helm template verified in both modes — runtimeClassName renders correctly with replica.enabled=false (Deployment) and replica.enabled=true (StatefulSet), and is omitted when empty.
  - Smoke-tested on a local kind cluster against a runc RuntimeClass: pod schedules and runs with .spec.runtimeClassName set as expected.

  Notes

  - This only sets the field; provisioning/registering the runtime handler and RuntimeClass object remains the cluster operator's responsibility.