### PR TITLE
added support for network policies its a breaking change

### DIFF
--- a/valkey/Chart.yaml
+++ b/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: A Helm chart for Kubernetes
 type: application
-version: 0.10.0
+version: 0.11.0
 appVersion: "9.1.0"
 home: https://valkey.io/valkey-helm/
 sources:

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -318,7 +318,15 @@ tls:
 | metrics.serviceMonitor.scrapeTimeout | string | `""` |  |
 | metrics.serviceMonitor.targetLimit | bool | `false` |  |
 | nameOverride | string | `""` |  |
-| networkPolicy | object | `{}` |  |
+| networkPolicy.enabled | bool | `false` | Enable creation of a NetworkPolicy for the Valkey pods |
+| networkPolicy.allowExternal | bool | `true` | Allow ingress on the Valkey port from any source. When false, ingress is restricted to client-labeled pods, other Valkey pods, and ingressNSMatchLabels |
+| networkPolicy.allowExternalEgress | bool | `true` | Allow unrestricted egress. When false, egress is limited to DNS and intra-cluster communication on the Valkey port |
+| networkPolicy.ingressNSMatchLabels | object | `{}` | Labels selecting namespaces allowed to connect when allowExternal is false |
+| networkPolicy.ingressNSPodMatchLabels | object | `{}` | Labels selecting pods within the matched namespaces |
+| networkPolicy.extraIngress | list | `[]` | Additional ingress rules appended verbatim to the policy |
+| networkPolicy.extraEgress | list | `[]` | Additional egress rules appended verbatim to the policy |
+| networkPolicy.labels | object | `{}` | Extra labels to add to the NetworkPolicy |
+| networkPolicy.annotations | object | `{}` | Extra annotations to add to the NetworkPolicy |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |

--- a/valkey/templates/netpolicy.yaml
+++ b/valkey/templates/netpolicy.yaml
@@ -1,33 +1,77 @@
-{{- with .Values.networkPolicy }}
+{{- if .Values.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "valkey.fullname" $ }}
-  {{- with .labels }}
+  name: {{ include "valkey.fullname" . }}
   labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+    {{- with .Values.networkPolicy.labels }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- with .annotations }}
+    {{- end }}
+  {{- with .Values.networkPolicy.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   podSelector:
     matchLabels:
-      {{- include "valkey.selectorLabels" $ | nindent 6 }}
+      {{- include "valkey.selectorLabels" . | nindent 6 }}
   policyTypes:
-  {{- if .ingress }}
     - Ingress
-  {{- end }}
-  {{- if .egress }}
     - Egress
-  {{- end }}
-  {{- with .ingress }}
-  ingress:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- with .egress }}
   egress:
+    {{- if .Values.networkPolicy.allowExternalEgress }}
+    # Allow all egress traffic
+    - {}
+    {{- else }}
+    # Allow DNS resolution
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow intra-cluster (pod-to-pod) communication on the Valkey port
+    - ports:
+        - port: {{ .Values.service.port }}
+      to:
+        - podSelector:
+            matchLabels:
+              {{- include "valkey.selectorLabels" . | nindent 14 }}
+    {{- end }}
+    {{- with .Values.networkPolicy.extraEgress }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
+  ingress:
+    # Allow inbound connections on the Valkey port
+    - ports:
+        - port: {{ .Values.service.port }}
+      {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+        # Pods explicitly labeled as Valkey clients
+        - podSelector:
+            matchLabels:
+              {{ include "valkey.fullname" . }}-client: "true"
+        # Other Valkey pods (primary/replica replication)
+        - podSelector:
+            matchLabels:
+              {{- include "valkey.selectorLabels" . | nindent 14 }}
+        {{- with .Values.networkPolicy.ingressNSMatchLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+          {{- with $.Values.networkPolicy.ingressNSPodMatchLabels }}
+          podSelector:
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- if .Values.metrics.enabled }}
+    # Allow scraping the metrics exporter port
+    - ports:
+        - port: {{ .Values.metrics.exporter.port }}
+    {{- end }}
+    {{- with .Values.networkPolicy.extraIngress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/valkey/tests/networkpolicy_test.yaml
+++ b/valkey/tests/networkpolicy_test.yaml
@@ -1,0 +1,160 @@
+suite: network policy configuration
+templates:
+  - templates/netpolicy.yaml
+tests:
+  - it: should not render anything when disabled by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a NetworkPolicy when enabled
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: apiVersion
+          value: networking.k8s.io/v1
+      - equal:
+          path: spec.policyTypes
+          value:
+            - Ingress
+            - Egress
+
+  - it: should select the Valkey pods
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - equal:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/name"]
+          value: valkey
+
+  - it: should allow all egress by default
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - contains:
+          path: spec.egress
+          content: {}
+
+  - it: should restrict egress to DNS and intra-cluster when allowExternalEgress is false
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.allowExternalEgress: false
+    asserts:
+      - notContains:
+          path: spec.egress
+          content: {}
+      - contains:
+          path: spec.egress
+          content:
+            ports:
+              - port: 53
+                protocol: UDP
+              - port: 53
+                protocol: TCP
+
+  - it: should allow ingress from any source on the Valkey port when allowExternal is true
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - contains:
+          path: spec.ingress
+          content:
+            ports:
+              - port: 6379
+
+  - it: should restrict ingress to labeled clients when allowExternal is false
+    release:
+      name: rn
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.allowExternal: false
+    asserts:
+      - equal:
+          path: spec.ingress[0].ports
+          value:
+            - port: 6379
+      - equal:
+          path: spec.ingress[0].from[0].podSelector.matchLabels["rn-valkey-client"]
+          value: "true"
+      - equal:
+          path: spec.ingress[0].from[1].podSelector.matchLabels["app.kubernetes.io/name"]
+          value: valkey
+
+  - it: should add namespace selectors when ingressNSMatchLabels is set
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.allowExternal: false
+      networkPolicy.ingressNSMatchLabels:
+        kubernetes.io/metadata.name: my-app
+      networkPolicy.ingressNSPodMatchLabels:
+        role: client
+    asserts:
+      - equal:
+          path: spec.ingress[0].from[2].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: my-app
+      - equal:
+          path: spec.ingress[0].from[2].podSelector.matchLabels.role
+          value: client
+
+  - it: should open the metrics port when metrics are enabled
+    set:
+      networkPolicy.enabled: true
+      metrics.enabled: true
+    asserts:
+      - contains:
+          path: spec.ingress
+          content:
+            ports:
+              - port: 9121
+
+  - it: should not open the metrics port when metrics are disabled
+    set:
+      networkPolicy.enabled: true
+      metrics.enabled: false
+    asserts:
+      - notContains:
+          path: spec.ingress
+          content:
+            ports:
+              - port: 9121
+
+  - it: should append extra ingress and egress rules verbatim
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.extraIngress:
+        - ports:
+            - port: 8080
+      networkPolicy.extraEgress:
+        - to:
+            - ipBlock:
+                cidr: 10.0.0.0/8
+    asserts:
+      - contains:
+          path: spec.ingress
+          content:
+            ports:
+              - port: 8080
+      - contains:
+          path: spec.egress
+          content:
+            to:
+              - ipBlock:
+                  cidr: 10.0.0.0/8
+
+  - it: should apply extra labels and annotations
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.labels:
+        team: data
+      networkPolicy.annotations:
+        owner: platform
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: data
+      - equal:
+          path: metadata.annotations.owner
+          value: platform

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -325,7 +325,36 @@
             "type": "string"
         },
         "networkPolicy": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "allowExternal": {
+                    "type": "boolean"
+                },
+                "allowExternalEgress": {
+                    "type": "boolean"
+                },
+                "ingressNSMatchLabels": {
+                    "type": "object"
+                },
+                "ingressNSPodMatchLabels": {
+                    "type": "object"
+                },
+                "extraIngress": {
+                    "type": "array"
+                },
+                "extraEgress": {
+                    "type": "array"
+                },
+                "labels": {
+                    "type": "object"
+                },
+                "annotations": {
+                    "type": "object"
+                }
+            }
         },
         "nodeSelector": {
             "type": "object"

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -89,9 +89,35 @@ service:
   # Application protocol
   appProtocol: ""
 
-# Network policy to control traffic to the pods
+# Network policy to control traffic to and from the Valkey pods
 # More info: https://kubernetes.io/docs/concepts/services-networking/network-policies/
-networkPolicy: {}
+networkPolicy:
+  # Enable creation of a NetworkPolicy for the Valkey pods
+  enabled: false
+  # Allow ingress on the Valkey port from any source.
+  # When set to false, ingress is restricted to pods carrying the
+  # `<fullname>-client: "true"` label, other Valkey pods (replication),
+  # and any namespaces/pods matched by ingressNSMatchLabels below.
+  allowExternal: true
+  # Allow unrestricted egress from the Valkey pods.
+  # When set to false, egress is limited to DNS and intra-cluster
+  # pod-to-pod communication on the Valkey port (plus any extraEgress rules).
+  allowExternalEgress: true
+  # Labels selecting namespaces allowed to connect when allowExternal is false
+  # Example:
+  #   ingressNSMatchLabels:
+  #     kubernetes.io/metadata.name: my-app
+  ingressNSMatchLabels: {}
+  # Labels selecting pods within the matched namespaces (used together with ingressNSMatchLabels)
+  ingressNSPodMatchLabels: {}
+  # Additional ingress rules appended verbatim to the policy
+  extraIngress: []
+  # Additional egress rules appended verbatim to the policy
+  extraEgress: []
+  # Extra labels to add to the NetworkPolicy
+  labels: {}
+  # Extra annotations to add to the NetworkPolicy
+  annotations: {}
 
 # Resource limits/requests for the main Valkey container
 resources: {}


### PR DESCRIPTION
  Summary

  Adds opinionated NetworkPolicy support to the valkey chart, adapted from the Bitnami Redis chart pattern referenced in the issue. Previously networkPolicy was a bare free-form passthrough (networkPolicy: {}) requiring users to hand-write complete K8s
  ingress/egress rules. This replaces it with a structured, documented config that handles the common cases out of the box while still allowing arbitrary extra rules.

  What it does

  When networkPolicy.enabled: true, the chart renders a NetworkPolicy that:

  - Always permits intra-cluster pod-to-pod traffic on the Valkey port (required for primary/replica replication)
  - Opens the metrics exporter port automatically when metrics.enabled: true
  - With allowExternal: false, restricts client ingress to pods carrying the <fullname>-client: "true" label, other Valkey pods, and any namespaces/pods matched by ingressNSMatchLabels / ingressNSPodMatchLabels
  - With allowExternalEgress: false, limits egress to DNS and intra-cluster communication
  - Appends extraIngress / extraEgress rules verbatim for custom needs

  Disabled by default — no behavior change unless opted in.
