### PR TITLE
feat(operator): add PodDisruptionBudget support

### DIFF
--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Add optional PodDisruptionBudget support for the valkey-operator Deployment.
+
 ## 0.2.0
 
 ### Added

--- a/valkey-operator/Chart.yaml
+++ b/valkey-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey-operator
 description: A Helm chart for the Valkey Operator
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "v0.2.0"
 kubeVersion: ">=1.20.0-0"
 home: https://valkey.io/valkey-helm/

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -1,6 +1,6 @@
 # valkey-operator
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 A Helm chart for deploying the [Valkey Operator](https://github.com/valkey-io/valkey-operator) on Kubernetes.
 
@@ -55,6 +55,10 @@ See [values.yaml](values.yaml) for the full list of configurable parameters.
 | `rbac.create` | Create ClusterRole and ClusterRoleBinding | `true` |
 | `manager.leaderElection.enabled` | Enable leader election | `true` |
 | `manager.watchNamespaces` | Restrict cache to these namespaces (cluster-wide if empty) | `[]` |
+| `podDisruptionBudget.enabled` | Enable PodDisruptionBudget | `false` |
+| `podDisruptionBudget.minAvailable` | Minimum pods available during disruptions | `null` |
+| `podDisruptionBudget.maxUnavailable` | Maximum pods unavailable during disruptions | `1` |
+| `podDisruptionBudget.unhealthyPodEvictionPolicy` | Policy for evicting unhealthy pods | `""` |
 | `metrics.enabled` | Enable the metrics endpoint | `true` |
 | `metrics.port` | Metrics endpoint port | `8443` |
 | `resources.limits.cpu` | CPU limit | `500m` |

--- a/valkey-operator/templates/poddisruptionbudget.yaml
+++ b/valkey-operator/templates/poddisruptionbudget.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "valkey-operator.fullname" . }}
+  labels:
+    {{- include "valkey-operator.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "valkey-operator.selectorLabels" . | nindent 6 }}
+  {{- with .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
+{{- end }}

--- a/valkey-operator/tests/poddisruptionbudget_test.yaml
+++ b/valkey-operator/tests/poddisruptionbudget_test.yaml
@@ -1,0 +1,149 @@
+suite: operator poddisruptionbudget configuration
+templates:
+  - templates/poddisruptionbudget.yaml
+tests:
+  - it: should not create PDB when disabled
+    set:
+      podDisruptionBudget.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create PDB when enabled
+    set:
+      podDisruptionBudget.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-operator
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: valkey-operator
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: should use minAvailable when set
+    set:
+      podDisruptionBudget.enabled: true
+      podDisruptionBudget.minAvailable: 2
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 2
+      - isNull:
+          path: spec.maxUnavailable
+
+  - it: should use minAvailable over maxUnavailable when both set
+    set:
+      podDisruptionBudget.enabled: true
+      podDisruptionBudget.minAvailable: 3
+      podDisruptionBudget.maxUnavailable: 2
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 3
+      - isNull:
+          path: spec.maxUnavailable
+
+  - it: should use maxUnavailable when minAvailable is null
+    set:
+      podDisruptionBudget.enabled: true
+      podDisruptionBudget.minAvailable: null
+      podDisruptionBudget.maxUnavailable: 2
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.maxUnavailable
+          value: 2
+      - isNull:
+          path: spec.minAvailable
+
+  - it: should support percentage values for minAvailable
+    set:
+      podDisruptionBudget.enabled: true
+      podDisruptionBudget.minAvailable: "50%"
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: "50%"
+      - isNull:
+          path: spec.maxUnavailable
+
+  - it: should support percentage values for maxUnavailable
+    set:
+      podDisruptionBudget.enabled: true
+      podDisruptionBudget.minAvailable: null
+      podDisruptionBudget.maxUnavailable: "25%"
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.maxUnavailable
+          value: "25%"
+      - isNull:
+          path: spec.minAvailable
+
+  - it: should include unhealthyPodEvictionPolicy when set
+    set:
+      podDisruptionBudget.enabled: true
+      podDisruptionBudget.unhealthyPodEvictionPolicy: "IfHealthyBudget"
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.unhealthyPodEvictionPolicy
+          value: "IfHealthyBudget"
+
+  - it: should not include unhealthyPodEvictionPolicy when empty
+    set:
+      podDisruptionBudget.enabled: true
+      podDisruptionBudget.unhealthyPodEvictionPolicy: ""
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - isNull:
+          path: spec.unhealthyPodEvictionPolicy
+
+  - it: should include standard labels
+    set:
+      podDisruptionBudget.enabled: true
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: valkey-operator
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - isNotNull:
+          path: metadata.labels["helm.sh/chart"]
+
+  - it: should work with custom fullname override
+    set:
+      podDisruptionBudget.enabled: true
+      fullnameOverride: "my-custom-operator"
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: "my-custom-operator"

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -116,7 +116,19 @@ commonLabels: {}
 # TODO: networkPolicy
 # TODO: aggregated ClusterRoles (admin/editor/viewer)
 # TODO: topologySpreadConstraints
-# TODO: podDisruptionBudget
+
+# PodDisruptionBudget configuration
+# Helps keep enough operator replicas available during voluntary disruptions
+podDisruptionBudget:
+  # Enable PodDisruptionBudget
+  enabled: false
+  # Minimum number of pods that must be available (takes precedence over maxUnavailable if both set)
+  minAvailable:
+  # Maximum number of pods that can be unavailable during disruptions
+  maxUnavailable: 1
+  # Unhealthy pod eviction policy (optional)
+  # Valid values: IfHealthyBudget, AlwaysAllow
+  unhealthyPodEvictionPolicy: ""
 
 metrics:
   # Enable the metrics endpoint


### PR DESCRIPTION
## Summary

Adds optional PodDisruptionBudget support to the `valkey-operator` Helm chart.

Fixes #187.

## Changes

- Add `valkey-operator/templates/poddisruptionbudget.yaml`.
- Add `podDisruptionBudget` values with `enabled: false` by default.
- Support `minAvailable`, `maxUnavailable`, and `unhealthyPodEvictionPolicy`.
- Prefer `minAvailable` when both `minAvailable` and `maxUnavailable` are set, matching the main `valkey` chart behavior.
- Document the new values in `valkey-operator/README.md`.
- Add helm-unittest coverage for disabled/default rendering, min/max availability, percentages, unhealthy pod eviction policy, labels, and `fullnameOverride`.
- Bump the operator chart version from `0.2.0` to `0.2.1`.
- Add an Unreleased changelog entry.

## Test plan

- [x] `helm lint ./valkey-operator`
- [x] `helm unittest ./valkey-operator`
- [x] `helm template test ./valkey-operator --set podDisruptionBudget.enabled=true --set podDisruptionBudget.minAvailable=1`
- [x] `helm template test ./valkey-operator` renders no PodDisruptionBudget by default
