### PR TITLE
added networkPolicy to valkey operator helm chart

### DIFF
--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 - New value `networkPolicy` to attach a NetworkPolicy to the operator pod.
   - Nothing is rendered unless set, preserving existing behavior.
-  - Supports `ingress`, `egress`, `labels`, and `annotations`; `policyTypes` is derived from the rules provided.
+  - Once opted in, the operator's required egress (DNS, Kubernetes API server, and managed Valkey pods on the Valkey port) is injected automatically so reconciliation keeps working under egress lockdown. The Valkey rule targets `manager.watchNamespaces` (all namespaces when empty).
+  - Tunable via `networkPolicy.defaultEgressRules` (default `true`), `valkeyPort` (`6379`), `apiServerPort` (`6443`), and `dnsNamespace` (`kube-system`).
+  - Supports `ingress`, `egress` (merged with the defaults), `labels`, and `annotations`; `policyTypes` is derived from the rules in effect.
 
 ## 0.2.0
 

--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 0.2.2
+
+### Added
+
+- New value `networkPolicy` to attach a NetworkPolicy to the operator pod.
+  - Nothing is rendered unless set, preserving existing behavior.
+  - Supports `ingress`, `egress`, `labels`, and `annotations`; `policyTypes` is derived from the rules provided.
+
 ## 0.2.0
 
 ### Added

--- a/valkey-operator/Chart.yaml
+++ b/valkey-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey-operator
 description: A Helm chart for the Valkey Operator
 type: application
-version: 0.2.0
+version: 0.2.2
 appVersion: "v0.2.0"
 kubeVersion: ">=1.20.0-0"
 home: https://valkey.io/valkey-helm/

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -1,6 +1,6 @@
 # valkey-operator
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 A Helm chart for deploying the [Valkey Operator](https://github.com/valkey-io/valkey-operator) on Kubernetes.
 
@@ -57,10 +57,40 @@ See [values.yaml](values.yaml) for the full list of configurable parameters.
 | `manager.watchNamespaces` | Restrict cache to these namespaces (cluster-wide if empty) | `[]` |
 | `metrics.enabled` | Enable the metrics endpoint | `true` |
 | `metrics.port` | Metrics endpoint port | `8443` |
+| `networkPolicy` | NetworkPolicy for the operator pod (nothing rendered unless set) | `{}` |
 | `resources.limits.cpu` | CPU limit | `500m` |
 | `resources.limits.memory` | Memory limit | `128Mi` |
 | `resources.requests.cpu` | CPU request | `10m` |
 | `resources.requests.memory` | Memory request | `64Mi` |
+
+### Network policy
+
+In clusters that default-deny traffic, you can attach a NetworkPolicy to the operator pod via the `networkPolicy` value. Nothing is rendered unless `networkPolicy` is set, so the default behavior is unchanged. The `policyTypes` field is derived automatically from whether you provide `ingress` and/or `egress` rules, and optional `labels` and `annotations` are added to the resource.
+
+The operator pod exposes the metrics port (`8443` when `metrics.enabled`) and a health probe port (`8081`). The example below allows Prometheus to scrape metrics from a `monitoring` namespace and permits egress to the Kubernetes API server:
+
+```yaml
+networkPolicy:
+  labels: {}
+  annotations: {}
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - protocol: TCP
+          port: 8443
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 6443
+```
+
+> **Note:** A NetworkPolicy only takes effect if your cluster's CNI enforces it (e.g. Calico, Cilium). CNIs such as kindnet do not enforce NetworkPolicy.
 
 ## Source Code
 

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -65,9 +65,20 @@ See [values.yaml](values.yaml) for the full list of configurable parameters.
 
 ### Network policy
 
-In clusters that default-deny traffic, you can attach a NetworkPolicy to the operator pod via the `networkPolicy` value. Nothing is rendered unless `networkPolicy` is set, so the default behavior is unchanged. The `policyTypes` field is derived automatically from whether you provide `ingress` and/or `egress` rules, and optional `labels` and `annotations` are added to the resource.
+In clusters that default-deny traffic, you can attach a NetworkPolicy to the operator pod via the `networkPolicy` value. Nothing is rendered unless `networkPolicy` is set, so the default behavior is unchanged.
 
-The operator pod exposes the metrics port (`8443` when `metrics.enabled`) and a health probe port (`8081`). The example below allows Prometheus to scrape metrics from a `monitoring` namespace and permits egress to the Kubernetes API server:
+Once you opt in, the chart automatically adds the egress the operator needs to function — DNS, the Kubernetes API server, and the managed Valkey pods on the Valkey port (`6379`) — so locking down egress doesn't break reconciliation. The Valkey egress rule targets the namespaces in `manager.watchNamespaces`; when that list is empty (watch all namespaces) it allows the Valkey port to every namespace. The `policyTypes` field is derived automatically from the rules in effect, and optional `labels` and `annotations` are added to the resource.
+
+You can tune or disable this behavior:
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `networkPolicy.defaultEgressRules` | `true` | Inject the operator's required egress. Set `false` to manage all egress yourself. |
+| `networkPolicy.valkeyPort` | `6379` | Port the operator uses to reach Valkey pods. |
+| `networkPolicy.apiServerPort` | `6443` | Kubernetes API server port. |
+| `networkPolicy.dnsNamespace` | `kube-system` | Namespace running kube-dns / CoreDNS. |
+
+The operator pod exposes the metrics port (`8443` when `metrics.enabled`) and a health probe port (`8081`). The example below allows Prometheus to scrape metrics from a `monitoring` namespace; the operator egress rules are added for you:
 
 ```yaml
 networkPolicy:
@@ -81,13 +92,8 @@ networkPolicy:
       ports:
         - protocol: TCP
           port: 8443
-  egress:
-    - to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
-      ports:
-        - protocol: TCP
-          port: 6443
+  # Any extra egress here is merged with the default operator egress rules.
+  egress: []
 ```
 
 > **Note:** A NetworkPolicy only takes effect if your cluster's CNI enforces it (e.g. Calico, Cilium). CNIs such as kindnet do not enforce NetworkPolicy.

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -57,7 +57,7 @@ See [values.yaml](values.yaml) for the full list of configurable parameters.
 | `manager.watchNamespaces` | Restrict cache to these namespaces (cluster-wide if empty) | `[]` |
 | `metrics.enabled` | Enable the metrics endpoint | `true` |
 | `metrics.port` | Metrics endpoint port | `8443` |
-| `networkPolicy` | NetworkPolicy for the operator pod (nothing rendered unless set) | `{}` |
+| `networkPolicy` | NetworkPolicy for the operator pod | `{}` |
 | `resources.limits.cpu` | CPU limit | `500m` |
 | `resources.limits.memory` | Memory limit | `128Mi` |
 | `resources.requests.cpu` | CPU request | `10m` |
@@ -96,7 +96,6 @@ networkPolicy:
   egress: []
 ```
 
-> **Note:** A NetworkPolicy only takes effect if your cluster's CNI enforces it (e.g. Calico, Cilium). CNIs such as kindnet do not enforce NetworkPolicy.
 
 ## Source Code
 

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -62,7 +62,7 @@ See [values.yaml](values.yaml) for the full list of configurable parameters.
 | `podDisruptionBudget.unhealthyPodEvictionPolicy` | Policy for evicting unhealthy pods | `""` |
 | `metrics.enabled` | Enable the metrics endpoint | `true` |
 | `metrics.port` | Metrics endpoint port | `8443` |
-| `networkPolicy` | NetworkPolicy for the operator pod | `{}` |
+| `networkPolicy.enabled` | Enable creation of a NetworkPolicy for the operator pod | `false` |
 | `resources.limits.cpu` | CPU limit | `500m` |
 | `resources.limits.memory` | Memory limit | `128Mi` |
 | `resources.requests.cpu` | CPU request | `10m` |
@@ -70,26 +70,32 @@ See [values.yaml](values.yaml) for the full list of configurable parameters.
 
 ### Network policy
 
-In clusters that default-deny traffic, you can attach a NetworkPolicy to the operator pod via the `networkPolicy` value. Nothing is rendered unless `networkPolicy` is set, so the default behavior is unchanged.
+In clusters that default-deny traffic, you can attach a NetworkPolicy to the operator pod by setting `networkPolicy.enabled: true`. It is disabled by default, so the default behavior is unchanged. This naming mirrors the [valkey chart](../valkey) (`enabled`, `extraIngress`, `extraEgress`) for a consistent experience across both charts.
 
-Once you opt in, the chart automatically adds the egress the operator needs to function — DNS, the Kubernetes API server, and the managed Valkey pods on the Valkey port (`6379`) — so locking down egress doesn't break reconciliation. The Valkey egress rule targets the namespaces in `manager.watchNamespaces`; when that list is empty (watch all namespaces) it allows the Valkey port to every namespace. The `policyTypes` field is derived automatically from the rules in effect, and optional `labels` and `annotations` are added to the resource.
+Once enabled, the chart automatically adds the egress the operator needs to function — DNS, the Kubernetes API server, and the managed Valkey pods on the Valkey port (`6379`) — so locking down egress doesn't break reconciliation. The Valkey egress rule targets the namespaces in `manager.watchNamespaces`; when that list is empty (watch all namespaces) it allows the Valkey port to every namespace. The `policyTypes` field is derived automatically from the rules in effect, and optional `labels` and `annotations` are added to the resource.
 
 You can tune or disable this behavior:
 
 | Field | Default | Description |
 | --- | --- | --- |
+| `networkPolicy.enabled` | `false` | Enable creation of a NetworkPolicy for the operator pod. |
 | `networkPolicy.defaultEgressRules` | `true` | Inject the operator's required egress. Set `false` to manage all egress yourself. |
 | `networkPolicy.valkeyPort` | `6379` | Port the operator uses to reach Valkey pods. |
 | `networkPolicy.apiServerPort` | `6443` | Kubernetes API server port. |
 | `networkPolicy.dnsNamespace` | `kube-system` | Namespace running kube-dns / CoreDNS. |
+| `networkPolicy.extraIngress` | `[]` | Additional ingress rules appended verbatim to the policy (templated with `tpl`). |
+| `networkPolicy.extraEgress` | `[]` | Additional egress rules merged with the default operator egress (templated with `tpl`). |
+| `networkPolicy.labels` | `{}` | Extra labels to add to the NetworkPolicy. |
+| `networkPolicy.annotations` | `{}` | Extra annotations to add to the NetworkPolicy. |
 
 The operator pod exposes the metrics port (`8443` when `metrics.enabled`) and a health probe port (`8081`). The example below allows Prometheus to scrape metrics from a `monitoring` namespace; the operator egress rules are added for you:
 
 ```yaml
 networkPolicy:
+  enabled: true
   labels: {}
   annotations: {}
-  ingress:
+  extraIngress:
     - from:
         - namespaceSelector:
             matchLabels:
@@ -98,7 +104,7 @@ networkPolicy:
         - protocol: TCP
           port: 8443
   # Any extra egress here is merged with the default operator egress rules.
-  egress: []
+  extraEgress: []
 ```
 
 

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -1,6 +1,5 @@
 # valkey-operator
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 ![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 A Helm chart for deploying the [Valkey Operator](https://github.com/valkey-io/valkey-operator) on Kubernetes.

--- a/valkey-operator/templates/netpolicy.yaml
+++ b/valkey-operator/templates/netpolicy.yaml
@@ -1,0 +1,36 @@
+{{- with .Values.networkPolicy }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "valkey-operator.fullname" $ }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "valkey-operator.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "valkey-operator.selectorLabels" $ | nindent 6 }}
+      control-plane: controller-manager
+  policyTypes:
+  {{- if .ingress }}
+    - Ingress
+  {{- end }}
+  {{- if .egress }}
+    - Egress
+  {{- end }}
+  {{- with .ingress }}
+  ingress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .egress }}
+  egress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/valkey-operator/templates/netpolicy.yaml
+++ b/valkey-operator/templates/netpolicy.yaml
@@ -60,8 +60,7 @@ spec:
           port: {{ $apiServerPort }}
     # Managed Valkey pods on the Valkey port
     - to:
-        {{- if $watch }}
-        - namespaceSelector:
+        - {{ if $watch }}namespaceSelector:
             matchExpressions:
               - key: kubernetes.io/metadata.name
                 operator: In
@@ -69,9 +68,10 @@ spec:
                   {{- range $watch }}
                   - {{ . }}
                   {{- end }}
-        {{- else }}
-        - namespaceSelector: {}
-        {{- end }}
+          {{ end }}podSelector:
+            matchLabels:
+              app.kubernetes.io/managed-by: valkey-operator
+              app.kubernetes.io/name: valkey
       ports:
         - protocol: TCP
           port: {{ $valkeyPort }}

--- a/valkey-operator/templates/netpolicy.yaml
+++ b/valkey-operator/templates/netpolicy.yaml
@@ -61,11 +61,14 @@ spec:
     # Managed Valkey pods on the Valkey port
     - to:
         {{- if $watch }}
-        {{- range $watch }}
         - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ . }}
-        {{- end }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  {{- range $watch }}
+                  - {{ . }}
+                  {{- end }}
         {{- else }}
         - namespaceSelector: {}
         {{- end }}

--- a/valkey-operator/templates/netpolicy.yaml
+++ b/valkey-operator/templates/netpolicy.yaml
@@ -36,7 +36,7 @@ spec:
   {{- end }}
   {{- with .ingress }}
   ingress:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
   {{- if $hasEgress }}
   egress:
@@ -74,7 +74,7 @@ spec:
           port: {{ $valkeyPort }}
     {{- end }}
     {{- with .egress }}
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/valkey-operator/templates/netpolicy.yaml
+++ b/valkey-operator/templates/netpolicy.yaml
@@ -1,4 +1,13 @@
 {{- with .Values.networkPolicy }}
+{{- $useDefaults := true }}
+{{- if hasKey . "defaultEgressRules" }}
+{{- $useDefaults = .defaultEgressRules }}
+{{- end }}
+{{- $valkeyPort := .valkeyPort | default 6379 }}
+{{- $apiServerPort := .apiServerPort | default 6443 }}
+{{- $dnsNamespace := .dnsNamespace | default "kube-system" }}
+{{- $watch := $.Values.manager.watchNamespaces }}
+{{- $hasEgress := or .egress $useDefaults }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -22,15 +31,50 @@ spec:
   {{- if .ingress }}
     - Ingress
   {{- end }}
-  {{- if .egress }}
+  {{- if $hasEgress }}
     - Egress
   {{- end }}
   {{- with .ingress }}
   ingress:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .egress }}
+  {{- if $hasEgress }}
   egress:
+    {{- if $useDefaults }}
+    # DNS resolution (kube-dns / CoreDNS)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $dnsNamespace }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Kubernetes API server
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: {{ $apiServerPort }}
+    # Managed Valkey pods on the Valkey port
+    - to:
+        {{- if $watch }}
+        {{- range $watch }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ . }}
+        {{- end }}
+        {{- else }}
+        - namespaceSelector: {}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ $valkeyPort }}
+    {{- end }}
+    {{- with .egress }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/valkey-operator/templates/netpolicy.yaml
+++ b/valkey-operator/templates/netpolicy.yaml
@@ -60,7 +60,8 @@ spec:
           port: {{ $apiServerPort }}
     # Managed Valkey pods on the Valkey port
     - to:
-        - {{ if $watch }}namespaceSelector:
+        - {{- if $watch }}
+          namespaceSelector:
             matchExpressions:
               - key: kubernetes.io/metadata.name
                 operator: In
@@ -68,7 +69,10 @@ spec:
                   {{- range $watch }}
                   - {{ . }}
                   {{- end }}
-          {{ end }}podSelector:
+          {{- else }}
+          namespaceSelector: {}
+          {{- end }}
+          podSelector:
             matchLabels:
               app.kubernetes.io/managed-by: valkey-operator
               app.kubernetes.io/name: valkey

--- a/valkey-operator/templates/netpolicy.yaml
+++ b/valkey-operator/templates/netpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.networkPolicy.enabled }}
 {{- with .Values.networkPolicy }}
 {{- $useDefaults := true }}
 {{- if hasKey . "defaultEgressRules" }}
@@ -7,7 +8,7 @@
 {{- $apiServerPort := .apiServerPort | default 6443 }}
 {{- $dnsNamespace := .dnsNamespace | default "kube-system" }}
 {{- $watch := $.Values.manager.watchNamespaces }}
-{{- $hasEgress := or .egress $useDefaults }}
+{{- $hasEgress := or .extraEgress $useDefaults }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -27,13 +28,13 @@ spec:
     matchLabels:
       {{- include "valkey-operator.selectorLabels" $ | nindent 6 }}
   policyTypes:
-  {{- if .ingress }}
+  {{- if .extraIngress }}
     - Ingress
   {{- end }}
   {{- if $hasEgress }}
     - Egress
   {{- end }}
-  {{- with .ingress }}
+  {{- with .extraIngress }}
   ingress:
     {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
@@ -72,8 +73,9 @@ spec:
         - protocol: TCP
           port: {{ $valkeyPort }}
     {{- end }}
-    {{- with .egress }}
+    {{- with .extraEgress }}
     {{- tpl (toYaml .) $ | nindent 4 }}
     {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/valkey-operator/templates/netpolicy.yaml
+++ b/valkey-operator/templates/netpolicy.yaml
@@ -26,7 +26,6 @@ spec:
   podSelector:
     matchLabels:
       {{- include "valkey-operator.selectorLabels" $ | nindent 6 }}
-      control-plane: controller-manager
   policyTypes:
   {{- if .ingress }}
     - Ingress

--- a/valkey-operator/tests/networkpolicy_test.yaml
+++ b/valkey-operator/tests/networkpolicy_test.yaml
@@ -41,6 +41,36 @@ tests:
           path: spec.egress
           count: 3
 
+  - it: should scope the Valkey egress to managed pods cluster-wide when no watchNamespaces
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - equal:
+          path: spec.egress[2].to[0].podSelector.matchLabels["app.kubernetes.io/managed-by"]
+          value: valkey-operator
+      - equal:
+          path: spec.egress[2].to[0].podSelector.matchLabels["app.kubernetes.io/name"]
+          value: valkey
+
+  - it: should combine namespace and pod selectors for the Valkey egress when watching namespaces
+    set:
+      networkPolicy.enabled: true
+      manager.watchNamespaces:
+        - ns-a
+        - ns-b
+    asserts:
+      - equal:
+          path: spec.egress[2].to[0].namespaceSelector.matchExpressions[0].key
+          value: kubernetes.io/metadata.name
+      - equal:
+          path: spec.egress[2].to[0].namespaceSelector.matchExpressions[0].values
+          value:
+            - ns-a
+            - ns-b
+      - equal:
+          path: spec.egress[2].to[0].podSelector.matchLabels["app.kubernetes.io/managed-by"]
+          value: valkey-operator
+
   - it: should omit default egress when defaultEgressRules is false
     set:
       networkPolicy.enabled: true

--- a/valkey-operator/tests/networkpolicy_test.yaml
+++ b/valkey-operator/tests/networkpolicy_test.yaml
@@ -1,0 +1,103 @@
+suite: operator network policy configuration
+templates:
+  - templates/netpolicy.yaml
+tests:
+  - it: should not render anything when disabled by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a NetworkPolicy when enabled
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: apiVersion
+          value: networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-operator
+
+  - it: should select the operator pods
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - equal:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/name"]
+          value: valkey-operator
+
+  - it: should inject default egress rules when enabled
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - lengthEqual:
+          path: spec.egress
+          count: 3
+
+  - it: should omit default egress when defaultEgressRules is false
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.defaultEgressRules: false
+    asserts:
+      - isNull:
+          path: spec.egress
+
+  - it: should append extraIngress rules and set the Ingress policyType
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.extraIngress:
+        - from:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: monitoring
+          ports:
+            - protocol: TCP
+              port: 8443
+    asserts:
+      - contains:
+          path: spec.policyTypes
+          content: Ingress
+      - lengthEqual:
+          path: spec.ingress
+          count: 1
+
+  - it: should merge extraEgress with the default egress rules
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.extraEgress:
+        - to:
+            - ipBlock:
+                cidr: 10.0.0.0/8
+          ports:
+            - protocol: TCP
+              port: 443
+    asserts:
+      - lengthEqual:
+          path: spec.egress
+          count: 4
+
+  - it: should keep extraEgress when default egress is disabled
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.defaultEgressRules: false
+      networkPolicy.extraEgress:
+        - to:
+            - ipBlock:
+                cidr: 10.0.0.0/8
+          ports:
+            - protocol: TCP
+              port: 443
+    asserts:
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - lengthEqual:
+          path: spec.egress
+          count: 1

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -130,36 +130,45 @@ podDisruptionBudget:
   unhealthyPodEvictionPolicy: ""
 
 # Network policy to control traffic to/from the operator pod.
-# Nothing is rendered unless this is set. As soon as you opt in (set any field
-# under networkPolicy), the operator's required egress is added automatically:
-# DNS, the Kubernetes API server, and managed Valkey pods on the Valkey port.
-# This keeps the operator working when egress is locked down. policyTypes are
-# derived from the rules in effect (ingress you provide, and/or egress).
+# Disabled by default. When enabled, the operator's required egress is added
+# automatically: DNS, the Kubernetes API server, and managed Valkey pods on the
+# Valkey port. This keeps the operator working when egress is locked down.
+# policyTypes are derived from the rules in effect (extraIngress you provide,
+# and/or egress).
 # More info: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 #
 # The default Valkey egress rule targets the namespaces in manager.watchNamespaces;
 # when that list is empty (watch all namespaces) it allows the Valkey port to every
-# namespace. Tunables:
-#   defaultEgressRules: true   # set false to manage all egress yourself
-#   valkeyPort: 6379           # port the operator uses to reach Valkey pods
-#   apiServerPort: 6443        # Kubernetes API server port
-#   dnsNamespace: kube-system  # namespace running kube-dns / CoreDNS
-#
-# Example (allow Prometheus to scrape metrics; operator egress is added for you):
-#   networkPolicy:
-#     labels: {}
-#     annotations: {}
-#     ingress:
-#       - from:
-#           - namespaceSelector:
-#               matchLabels:
-#                 kubernetes.io/metadata.name: monitoring
-#         ports:
-#           - protocol: TCP
-#             port: 8443
-#     # Any extra egress here is merged with the default operator egress rules.
-#     egress: []
-networkPolicy: {}
+# namespace.
+networkPolicy:
+  # Enable creation of a NetworkPolicy for the operator pod
+  enabled: false
+  # Inject the operator's required egress (DNS, API server, managed Valkey pods).
+  # Set false to manage all egress yourself via extraEgress.
+  defaultEgressRules: true
+  # Port the operator uses to reach Valkey pods
+  valkeyPort: 6379
+  # Kubernetes API server port
+  apiServerPort: 6443
+  # Namespace running kube-dns / CoreDNS
+  dnsNamespace: kube-system
+  # Extra labels to add to the NetworkPolicy
+  labels: {}
+  # Extra annotations to add to the NetworkPolicy
+  annotations: {}
+  # Additional ingress rules appended verbatim to the policy (templated with tpl)
+  extraIngress: []
+  # Additional egress rules merged with the default operator egress (templated with tpl)
+  extraEgress: []
+  # Example (allow Prometheus to scrape metrics; operator egress is added for you):
+  #   extraIngress:
+  #     - from:
+  #         - namespaceSelector:
+  #             matchLabels:
+  #               kubernetes.io/metadata.name: monitoring
+  #       ports:
+  #         - protocol: TCP
+  #           port: 8443
 
 
 

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -118,10 +118,22 @@ commonLabels: {}
 # TODO: podDisruptionBudget
 
 # Network policy to control traffic to/from the operator pod.
-# Nothing is rendered unless this is set. When configured, policyTypes are
-# derived from the ingress/egress rules you provide.
+# Nothing is rendered unless this is set. As soon as you opt in (set any field
+# under networkPolicy), the operator's required egress is added automatically:
+# DNS, the Kubernetes API server, and managed Valkey pods on the Valkey port.
+# This keeps the operator working when egress is locked down. policyTypes are
+# derived from the rules in effect (ingress you provide, and/or egress).
 # More info: https://kubernetes.io/docs/concepts/services-networking/network-policies/
-# Example (allow Prometheus to scrape metrics and egress to the Kubernetes API server):
+#
+# The default Valkey egress rule targets the namespaces in manager.watchNamespaces;
+# when that list is empty (watch all namespaces) it allows the Valkey port to every
+# namespace. Tunables:
+#   defaultEgressRules: true   # set false to manage all egress yourself
+#   valkeyPort: 6379           # port the operator uses to reach Valkey pods
+#   apiServerPort: 6443        # Kubernetes API server port
+#   dnsNamespace: kube-system  # namespace running kube-dns / CoreDNS
+#
+# Example (allow Prometheus to scrape metrics; operator egress is added for you):
 #   networkPolicy:
 #     labels: {}
 #     annotations: {}
@@ -133,13 +145,8 @@ commonLabels: {}
 #         ports:
 #           - protocol: TCP
 #             port: 8443
-#     egress:
-#       - to:
-#           - ipBlock:
-#               cidr: 0.0.0.0/0
-#         ports:
-#           - protocol: TCP
-#             port: 6443
+#     # Any extra egress here is merged with the default operator egress rules.
+#     egress: []
 networkPolicy: {}
 
 

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -113,10 +113,36 @@ commonLabels: {}
 
 # TODO: metrics auth RBAC (metrics-auth-role, metrics-reader-role)
 # TODO: prometheus ServiceMonitor
-# TODO: networkPolicy
 # TODO: aggregated ClusterRoles (admin/editor/viewer)
 # TODO: topologySpreadConstraints
 # TODO: podDisruptionBudget
+
+# Network policy to control traffic to/from the operator pod.
+# Nothing is rendered unless this is set. When configured, policyTypes are
+# derived from the ingress/egress rules you provide.
+# More info: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+# Example (allow Prometheus to scrape metrics and egress to the Kubernetes API server):
+#   networkPolicy:
+#     labels: {}
+#     annotations: {}
+#     ingress:
+#       - from:
+#           - namespaceSelector:
+#               matchLabels:
+#                 kubernetes.io/metadata.name: monitoring
+#         ports:
+#           - protocol: TCP
+#             port: 8443
+#     egress:
+#       - to:
+#           - ipBlock:
+#               cidr: 0.0.0.0/0
+#         ports:
+#           - protocol: TCP
+#             port: 6443
+networkPolicy: {}
+
+
 
 metrics:
   # Enable the metrics endpoint


### PR DESCRIPTION
The valkey-operator chart exposes ports on the operator pod (metrics on 8443 when metrics.enabled, and a health probe port on 8081) but previously offered no way to define a NetworkPolicy to control traffic to them. In default-deny clusters this is a
  gap: operators commonly need explicit policy to allow Prometheus to scrape metrics, allow probes to reach the health port, and allow egress to the Kubernetes API server.

  This adds an opt-in networkPolicy value to the operator chart, mirroring the existing implementation in the valkey chart for consistency.

  Changes

  - templates/netpolicy.yaml (new): renders only when networkPolicy is set ({{- with .Values.networkPolicy }} guard). Uses the operator's valkey-operator.fullname/selectorLabels helpers, scopes the podSelector to the operator pod (control-plane:
  controller-manager), derives policyTypes from the provided ingress/egress rules, and passes rule lists through via toYaml. Supports optional labels and annotations.
  - values.yaml: replaced the # TODO: networkPolicy placeholder with a documented networkPolicy: {} default and a commented example. Backward-compatible — nothing renders unless configured.
  - README.md: documented the new value (table row + a "Network policy" section with a worked example allowing metrics scraping and egress to the API server, plus a CNI-enforcement note).
  - CHANGELOG.md / Chart.yaml: added a 0.2.2 entry and bumped the chart version 0.2.0 → 0.2.2 (appVersion unchanged).

  Testing

  - helm lint valkey-operator passes.
  - helm template verified: no NetworkPolicy by default; correct object with policyTypes derived from rules; labels/annotations passthrough; ingress-only yields policyTypes: [Ingress].
  - Enforcement validated on a local kind cluster with Calico:
    - monitoring namespace → operator :8443 → allowed (open)
    - intruder namespace → operator :8443 → denied (connection timed out)
    - Toggling the value off removes the NetworkPolicy.