### PR TITLE
feat(operator): add topologySpreadConstraints support to valkey-operator chart

### DIFF
--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.2.5
+
+### Added
+
+- Add optional `topologySpreadConstraints` support for the valkey-operator Deployment.
+
 ## 0.2.4
 
 ### Added

--- a/valkey-operator/Chart.yaml
+++ b/valkey-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey-operator
 description: A Helm chart for the Valkey Operator
 type: application
-version: 0.2.4
+version: 0.2.5
 appVersion: "v0.2.0"
 kubeVersion: ">=1.20.0-0"
 home: https://valkey.io/valkey-helm/

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -1,6 +1,6 @@
 # valkey-operator
 
-![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
+![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 A Helm chart for deploying the [Valkey Operator](https://github.com/valkey-io/valkey-operator) on Kubernetes.
 
@@ -59,6 +59,7 @@ See [values.yaml](values.yaml) for the full list of configurable parameters.
 | `podDisruptionBudget.minAvailable` | Minimum pods available during disruptions | `null` |
 | `podDisruptionBudget.maxUnavailable` | Maximum pods unavailable during disruptions | `1` |
 | `podDisruptionBudget.unhealthyPodEvictionPolicy` | Policy for evicting unhealthy pods | `""` |
+| `topologySpreadConstraints` | Topology spread constraints for the operator pods | `[]` |
 | `metrics.enabled` | Enable the metrics endpoint | `true` |
 | `metrics.port` | Metrics endpoint port | `8443` |
 | `networkPolicy.enabled` | Enable creation of a NetworkPolicy for the operator pod | `false` |

--- a/valkey-operator/templates/deployment.yaml
+++ b/valkey-operator/templates/deployment.yaml
@@ -97,3 +97,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/valkey-operator/tests/topologyspreadconstraints_test.yaml
+++ b/valkey-operator/tests/topologyspreadconstraints_test.yaml
@@ -1,0 +1,51 @@
+suite: operator topologySpreadConstraints configuration
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: should not render topologySpreadConstraints by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.topologySpreadConstraints
+
+  - it: should render topologySpreadConstraints when set
+    set:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: valkey-operator
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].maxSkew
+          value: 1
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: topology.kubernetes.io/zone
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].whenUnsatisfiable
+          value: DoNotSchedule
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels["app.kubernetes.io/name"]
+          value: valkey-operator
+
+  - it: should support multiple topologySpreadConstraints
+    set:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.topologySpreadConstraints
+          count: 2
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[1].topologyKey
+          value: kubernetes.io/hostname
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[1].whenUnsatisfiable
+          value: ScheduleAnyway

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -104,6 +104,15 @@ tolerations: []
 #                 - arm64
 affinity: {}
 
+# topologySpreadConstraints:
+#   - maxSkew: 1
+#     topologyKey: topology.kubernetes.io/zone
+#     whenUnsatisfiable: DoNotSchedule
+#     labelSelector:
+#       matchLabels:
+#         app.kubernetes.io/name: valkey-operator
+topologySpreadConstraints: []
+
 # Annotations for pods
 podAnnotations: {}
 # Labels for pods
@@ -114,7 +123,6 @@ commonLabels: {}
 # TODO: metrics auth RBAC (metrics-auth-role, metrics-reader-role)
 # TODO: prometheus ServiceMonitor
 # TODO: aggregated ClusterRoles (admin/editor/viewer)
-# TODO: topologySpreadConstraints
 
 # PodDisruptionBudget configuration
 # Helps keep enough operator replicas available during voluntary disruptions


### PR DESCRIPTION
Adds an optional `topologySpreadConstraints` field to the valkey-operator chart's Deployment, resolving #188. It mirrors the existing nodeSelector / affinity / tolerations pattern, and values.yaml already carried a `# TODO: topologySpreadConstraints` placeholder. Default is `[]`, so the default render is unchanged.

Validation (run locally):
- helm lint ./valkey-operator: 0 failed
- helm unittest ./valkey-operator: 14 passed (3 new cases: default-absent, single, multiple)
- helm template default render is byte-identical to main (only the chart version label changed)

related: #188