### PR TITLE
feat(operator): add Prometheus ServiceMonitor support to valkey-operator chart

### DIFF
--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.3.1
+
+### Added
+
+- Add optional Prometheus ServiceMonitor support for the valkey-operator metrics endpoint.
+
 ## 0.3.0
 
 ### Added

--- a/valkey-operator/Chart.yaml
+++ b/valkey-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey-operator
 description: A Helm chart for the Valkey Operator
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "v0.3.0"
 kubeVersion: ">=1.20.0-0"
 home: https://valkey.io/valkey-helm/

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -66,6 +66,17 @@ See [values.yaml](values.yaml) for the full list of configurable parameters.
 | `metrics.reader.binding.create` | Bind a scraper ServiceAccount to the `metrics-reader` ClusterRole. Requires `rbac.create`, `metrics.enabled`, and `metrics.secure` | `false` |
 | `metrics.reader.binding.serviceAccountName` | Name of the scraper ServiceAccount to authorize. Supports templating; required when `binding.create` is `true` | `""` |
 | `metrics.reader.binding.namespace` | Namespace of the scraper ServiceAccount. Supports templating; defaults to the release namespace when empty | `""` |
+| `metrics.serviceMonitor.enabled` | Create a Prometheus ServiceMonitor for the metrics endpoint (requires the Prometheus Operator CRDs) | `false` |
+| `metrics.serviceMonitor.namespace` | Namespace for the ServiceMonitor | `""` (release namespace) |
+| `metrics.serviceMonitor.labels` | Additional labels for the ServiceMonitor | `{}` |
+| `metrics.serviceMonitor.annotations` | Annotations for the ServiceMonitor | `{}` |
+| `metrics.serviceMonitor.interval` | Scrape interval | `""` |
+| `metrics.serviceMonitor.scrapeTimeout` | Scrape timeout | `""` |
+| `metrics.serviceMonitor.scheme` | HTTP scheme used for scraping | `""` |
+| `metrics.serviceMonitor.tlsConfig` | TLS configuration used when scraping | `{}` |
+| `metrics.serviceMonitor.honorLabels` | Keep labels from the scraped target on collision | `false` |
+| `metrics.serviceMonitor.relabelings` | relabelings applied before scraping | `[]` |
+| `metrics.serviceMonitor.metricRelabelings` | metricRelabelings applied before ingestion | `[]` |
 | `networkPolicy.enabled` | Enable creation of a NetworkPolicy for the operator pod | `false` |
 | `resources.limits.cpu` | CPU limit | `500m` |
 | `resources.limits.memory` | Memory limit | `128Mi` |

--- a/valkey-operator/templates/servicemonitor.yaml
+++ b/valkey-operator/templates/servicemonitor.yaml
@@ -1,0 +1,47 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "valkey-operator.fullname" . }}-metrics
+  namespace: {{ .Values.metrics.serviceMonitor.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "valkey-operator.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.metrics.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+  - port: http
+    honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
+    {{- with .Values.metrics.serviceMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.scheme }}
+    scheme: {{ . }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.tlsConfig }}
+    tlsConfig:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.relabelings }}
+    relabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "valkey-operator.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/valkey-operator/tests/servicemonitor_test.yaml
+++ b/valkey-operator/tests/servicemonitor_test.yaml
@@ -1,0 +1,114 @@
+suite: operator servicemonitor configuration
+templates:
+  - templates/servicemonitor.yaml
+tests:
+  - it: should not create ServiceMonitor by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create ServiceMonitor when metrics are disabled
+    set:
+      metrics.enabled: false
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create ServiceMonitor when enabled
+    set:
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceMonitor
+      - isAPIVersion:
+          of: monitoring.coreos.com/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-operator-metrics
+      - equal:
+          path: spec.endpoints[0].port
+          value: http
+
+  - it: should default the namespace to the release namespace
+    set:
+      metrics.serviceMonitor.enabled: true
+    release:
+      namespace: monitoring
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: monitoring
+      - equal:
+          path: spec.namespaceSelector.matchNames[0]
+          value: monitoring
+
+  - it: should honor an explicit ServiceMonitor namespace
+    set:
+      metrics.serviceMonitor.enabled: true
+      metrics.serviceMonitor.namespace: prometheus
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: prometheus
+
+  - it: should include standard chart labels
+    set:
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: valkey-operator
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - isNotNull:
+          path: metadata.labels["helm.sh/chart"]
+
+  - it: should merge additional ServiceMonitor labels
+    set:
+      metrics.serviceMonitor.enabled: true
+      metrics.serviceMonitor.labels:
+        release: kube-prometheus-stack
+    asserts:
+      - equal:
+          path: metadata.labels["release"]
+          value: kube-prometheus-stack
+
+  - it: should set interval and scrapeTimeout when provided
+    set:
+      metrics.serviceMonitor.enabled: true
+      metrics.serviceMonitor.interval: 30s
+      metrics.serviceMonitor.scrapeTimeout: 10s
+    asserts:
+      - equal:
+          path: spec.endpoints[0].interval
+          value: 30s
+      - equal:
+          path: spec.endpoints[0].scrapeTimeout
+          value: 10s
+
+  - it: should omit interval and scrapeTimeout when empty
+    set:
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - isNull:
+          path: spec.endpoints[0].interval
+      - isNull:
+          path: spec.endpoints[0].scrapeTimeout
+
+  - it: should select the operator metrics service
+    set:
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: valkey-operator
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -124,8 +124,6 @@ podLabels: {}
 # Labels to add to all resources
 commonLabels: {}
 
-# TODO: prometheus ServiceMonitor
-
 # PodDisruptionBudget configuration
 # Helps keep enough operator replicas available during voluntary disruptions
 podDisruptionBudget:
@@ -180,8 +178,6 @@ networkPolicy:
   #         - protocol: TCP
   #           port: 8443
 
-
-
 metrics:
   # Enable the metrics endpoint
   enabled: true
@@ -216,3 +212,28 @@ metrics:
     annotations: {}
     # Labels for the metrics service
     labels: {}
+  # Prometheus ServiceMonitor for the operator metrics endpoint
+  # Requires the Prometheus Operator CRDs (monitoring.coreos.com) to be installed
+  serviceMonitor:
+    # Enable the ServiceMonitor
+    enabled: false
+    # Namespace for the ServiceMonitor (defaults to the release namespace)
+    namespace: ""
+    # Additional labels for the ServiceMonitor (e.g. to match the Prometheus serviceMonitorSelector)
+    labels: {}
+    # Annotations for the ServiceMonitor
+    annotations: {}
+    # Scrape interval (defaults to the Prometheus global interval when empty)
+    interval: ""
+    # Scrape timeout (defaults to the Prometheus global timeout when empty)
+    scrapeTimeout: ""
+    # HTTP scheme used for scraping (defaults to http when empty)
+    scheme: ""
+    # TLS configuration used when scraping the endpoint
+    tlsConfig: {}
+    # Keep labels from the scraped target on collision with server-side labels
+    honorLabels: false
+    # relabelings applied to samples before scraping
+    relabelings: []
+    # metricRelabelings applied to samples before ingestion
+    metricRelabelings: []


### PR DESCRIPTION
Adds an optional Prometheus ServiceMonitor for the valkey-operator metrics
endpoint, gated on `metrics.serviceMonitor.enabled` (default `false`).
Resolves #191 and clears the `# TODO: prometheus ServiceMonitor` placeholder
in values.yaml. Mirrors the recently merged PodDisruptionBudget addition (#193).

The ServiceMonitor targets the existing operator metrics Service (`*-metrics`,
port `http`) and exposes the standard scrape knobs (interval, scrapeTimeout,
scheme, tlsConfig, honorLabels, relabelings, metricRelabelings, extra
labels/annotations, namespace). It renders only when both `metrics.enabled` and
`metrics.serviceMonitor.enabled` are true, so the default render is unchanged.

Validation (run locally):
- `helm unittest .` — 21 passed (10 new ServiceMonitor cases + existing PDB suite)
- `helm lint .` — 0 failed
- default `helm template` render byte-identical to main except the chart-version label (0.2.1 -> 0.2.2)
- `helm template --set metrics.serviceMonitor.enabled=true` renders a valid ServiceMonitor

resolves: #191

Note: Chart.yaml bumps 0.2.1 -> 0.2.2, colliding with my open #195
(topologySpreadConstraints) which also bumps to 0.2.2. They are independent;
whichever merges first, I'll rebase the other to the next patch.
