### PR TITLE
feat(operator): add aggregated admin/editor/viewer ClusterRoles for Valkey CRDs

### DIFF
--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.2.6
+
+### Added
+
+- Add aggregated admin/editor/viewer ClusterRoles for the Valkey CRDs (gated by `rbac.create`).
+
 ## 0.2.5
 
 ### Added

--- a/valkey-operator/Chart.yaml
+++ b/valkey-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey-operator
 description: A Helm chart for the Valkey Operator
 type: application
-version: 0.2.5
+version: 0.2.6
 appVersion: "v0.2.0"
 kubeVersion: ">=1.20.0-0"
 home: https://valkey.io/valkey-helm/

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -1,6 +1,6 @@
 # valkey-operator
 
-![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
+![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 A Helm chart for deploying the [Valkey Operator](https://github.com/valkey-io/valkey-operator) on Kubernetes.
 
@@ -52,7 +52,7 @@ See [values.yaml](values.yaml) for the full list of configurable parameters.
 | `image.tag` | Operator image tag | `""` (uses `.Chart.AppVersion`) |
 | `replicaCount` | Number of operator replicas | `1` |
 | `serviceAccount.create` | Create a ServiceAccount | `true` |
-| `rbac.create` | Create ClusterRole and ClusterRoleBinding | `true` |
+| `rbac.create` | Create the operator ClusterRole/ClusterRoleBinding and the aggregated admin/editor/viewer ClusterRoles | `true` |
 | `manager.leaderElection.enabled` | Enable leader election | `true` |
 | `manager.watchNamespaces` | Restrict cache to these namespaces (cluster-wide if empty) | `[]` |
 | `podDisruptionBudget.enabled` | Enable PodDisruptionBudget | `false` |
@@ -107,6 +107,21 @@ networkPolicy:
   extraEgress: []
 ```
 
+### Aggregated ClusterRoles
+
+When `rbac.create` is enabled (the default), the chart also ships three aggregated
+ClusterRoles for the `valkeyclusters` and `valkeynodes` custom resources, following the
+[kubebuilder convention](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles):
+
+| Role | Aggregation label | Access |
+|---|---|---|
+| `*-valkey-admin` | `rbac.authorization.k8s.io/aggregate-to-admin` | Full management of the CRs (read-only on status) |
+| `*-valkey-editor` | `rbac.authorization.k8s.io/aggregate-to-edit` | Create/update/delete the CRs (read-only on status) |
+| `*-valkey-viewer` | `rbac.authorization.k8s.io/aggregate-to-view` | Read-only access to the CRs and status |
+
+These roll up into the built-in `admin`, `edit`, and `view` ClusterRoles, so cluster
+admins can grant tenants access to the Valkey CRDs without handing out the operator's own
+controller permissions.
 
 ## Source Code
 

--- a/valkey-operator/templates/valkey-admin-role.yaml
+++ b/valkey-operator/templates/valkey-admin-role.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.rbac.create -}}
+# Aggregated ClusterRole granting full management of the Valkey CRDs.
+# Rolls up into the built-in "admin" ClusterRole so namespace admins can
+# manage valkeyclusters/valkeynodes without the operator's controller permissions.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "valkey-operator.fullname" . }}-valkey-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    {{- include "valkey-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - valkey.io
+  resources:
+  - valkeyclusters
+  - valkeynodes
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - valkey.io
+  resources:
+  - valkeyclusters/status
+  - valkeynodes/status
+  verbs:
+  - get
+{{- end }}

--- a/valkey-operator/templates/valkey-editor-role.yaml
+++ b/valkey-operator/templates/valkey-editor-role.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.rbac.create -}}
+# Aggregated ClusterRole granting read/write access to the Valkey CRDs.
+# Rolls up into the built-in "edit" ClusterRole so users can create and modify
+# valkeyclusters/valkeynodes; status subresources stay read-only (controller-owned).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "valkey-operator.fullname" . }}-valkey-editor
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    {{- include "valkey-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - valkey.io
+  resources:
+  - valkeyclusters
+  - valkeynodes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - valkey.io
+  resources:
+  - valkeyclusters/status
+  - valkeynodes/status
+  verbs:
+  - get
+{{- end }}

--- a/valkey-operator/templates/valkey-viewer-role.yaml
+++ b/valkey-operator/templates/valkey-viewer-role.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.rbac.create -}}
+# Aggregated ClusterRole granting read-only access to the Valkey CRDs.
+# Rolls up into the built-in "view" ClusterRole so users can inspect
+# valkeyclusters/valkeynodes (including status) without any write permissions.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "valkey-operator.fullname" . }}-valkey-viewer
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    {{- include "valkey-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - valkey.io
+  resources:
+  - valkeyclusters
+  - valkeynodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - valkey.io
+  resources:
+  - valkeyclusters/status
+  - valkeynodes/status
+  verbs:
+  - get
+{{- end }}

--- a/valkey-operator/tests/aggregated_clusterroles_test.yaml
+++ b/valkey-operator/tests/aggregated_clusterroles_test.yaml
@@ -1,0 +1,132 @@
+suite: operator aggregated clusterroles
+templates:
+  - templates/valkey-admin-role.yaml
+  - templates/valkey-editor-role.yaml
+  - templates/valkey-viewer-role.yaml
+tests:
+  - it: should not render admin role when rbac.create is false
+    template: templates/valkey-admin-role.yaml
+    set:
+      rbac.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render editor role when rbac.create is false
+    template: templates/valkey-editor-role.yaml
+    set:
+      rbac.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render viewer role when rbac.create is false
+    template: templates/valkey-viewer-role.yaml
+    set:
+      rbac.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render admin role with aggregate-to-admin label and full management verbs
+    template: templates/valkey-admin-role.yaml
+    set:
+      rbac.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-operator-valkey-admin
+      - equal:
+          path: metadata.labels["rbac.authorization.k8s.io/aggregate-to-admin"]
+          value: "true"
+      - equal:
+          path: rules[0].resources
+          value:
+            - valkeyclusters
+            - valkeynodes
+      - contains:
+          path: rules[0].verbs
+          content: deletecollection
+      - equal:
+          path: rules[1].resources
+          value:
+            - valkeyclusters/status
+            - valkeynodes/status
+      - equal:
+          path: rules[1].verbs
+          value:
+            - get
+      - isNotNull:
+          path: metadata.labels["helm.sh/chart"]
+
+  - it: should render editor role with aggregate-to-edit label and read/write verbs
+    template: templates/valkey-editor-role.yaml
+    set:
+      rbac.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-operator-valkey-editor
+      - equal:
+          path: metadata.labels["rbac.authorization.k8s.io/aggregate-to-edit"]
+          value: "true"
+      - equal:
+          path: rules[0].verbs
+          value:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+      - notContains:
+          path: rules[0].verbs
+          content: deletecollection
+      - equal:
+          path: rules[1].verbs
+          value:
+            - get
+
+  - it: should render viewer role with aggregate-to-view label and read-only verbs
+    template: templates/valkey-viewer-role.yaml
+    set:
+      rbac.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-operator-valkey-viewer
+      - equal:
+          path: metadata.labels["rbac.authorization.k8s.io/aggregate-to-view"]
+          value: "true"
+      - equal:
+          path: rules[0].verbs
+          value:
+            - get
+            - list
+            - watch
+      - notContains:
+          path: rules[0].verbs
+          content: create
+
+  - it: should respect fullnameOverride in the admin role name
+    template: templates/valkey-admin-role.yaml
+    set:
+      rbac.create: true
+      fullnameOverride: my-custom-operator
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-custom-operator-valkey-admin

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -38,7 +38,8 @@ serviceAccount:
   automount: true
 
 rbac:
-  # Create ClusterRole and ClusterRoleBinding for the operator
+  # Create the operator ClusterRole/ClusterRoleBinding and the aggregated
+  # admin/editor/viewer ClusterRoles for the Valkey CRDs
   create: true
 
 manager:
@@ -122,7 +123,6 @@ commonLabels: {}
 
 # TODO: metrics auth RBAC (metrics-auth-role, metrics-reader-role)
 # TODO: prometheus ServiceMonitor
-# TODO: aggregated ClusterRoles (admin/editor/viewer)
 
 # PodDisruptionBudget configuration
 # Helps keep enough operator replicas available during voluntary disruptions


### PR DESCRIPTION
Adds the standard aggregated admin/editor/viewer ClusterRoles for the
valkeyclusters and valkeynodes CRDs, following the kubebuilder convention.
These let cluster admins grant tenants access to the Valkey CRDs via the
built-in admin/edit/view roles without handing out the operator's own
controller permissions. Resolves #189.

What's in it:
- Three new templates under valkey-operator/templates/, gated by the existing
  rbac.create (manager role behavior unchanged).
- admin: full management incl. deletecollection (status read-only); editor:
  read/write (status read-only); viewer: read-only on the CRs and status.
- One aggregation label per role (aggregate-to-admin / -edit / -view). The
  issue proposal floated double-labeling admin+editor; I used the standard
  one-label-per-role mapping to match the acceptance criteria. Happy to switch
  to the double-label form if you prefer it.
- helm-unittest coverage, README docs, Chart.yaml bump 0.2.1 -> 0.2.3.

Validation (local):
- helm lint . clean
- helm unittest . 18 passing (8 new)
- helm template renders the 3 roles with rbac.create=true, none with
  rbac.create=false; existing resources byte-identical except the chart-version label.

Note: this targets 0.2.3 because my open #195 and #196 both bump to 0.2.2.
Whichever merges first, I'll rebase the others.