### PR TITLE
added metrics auth rbac

### DIFF
--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 ### Added
--Add metrics auth RBAC (metrics-auth-role, metrics-reader-role) support to the valkey-operator chart
+- Add metrics auth RBAC (metrics-auth-role, metrics-reader-role) support to the valkey-operator chart. The metrics RBAC is only rendered when `metrics.enabled` and `metrics.secure` are both true, since the operator only issues TokenReviews/SubjectAccessReviews under secure serving. This avoids leaving orphaned cluster-scoped RBAC when metrics are disabled or served insecurely.
  
 
 ### Added

--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased
+### Added
+-Add metrics auth RBAC (metrics-auth-role, metrics-reader-role) support to the valkey-operator chart
+ 
 
 ### Added
 

--- a/valkey-operator/Chart.yaml
+++ b/valkey-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey-operator
 description: A Helm chart for the Valkey Operator
 type: application
-version: 0.2.1
+version: 0.2.3
 appVersion: "v0.2.0"
 kubeVersion: ">=1.20.0-0"
 home: https://valkey.io/valkey-helm/

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -1,6 +1,6 @@
 # valkey-operator
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 A Helm chart for deploying the [Valkey Operator](https://github.com/valkey-io/valkey-operator) on Kubernetes.
 
@@ -61,10 +61,70 @@ See [values.yaml](values.yaml) for the full list of configurable parameters.
 | `podDisruptionBudget.unhealthyPodEvictionPolicy` | Policy for evicting unhealthy pods | `""` |
 | `metrics.enabled` | Enable the metrics endpoint | `true` |
 | `metrics.port` | Metrics endpoint port | `8443` |
+| `metrics.secure` | Serve metrics over HTTPS with authn/authz | `false` |
+| `metrics.reader.binding.create` | Bind a scraper SA to the metrics-reader role | `false` |
+| `metrics.reader.binding.serviceAccountName` | Scraper SA to authorize (supports templating) | `""` |
+| `metrics.reader.binding.namespace` | Scraper SA namespace (defaults to release namespace) | `""` |
 | `resources.limits.cpu` | CPU limit | `500m` |
 | `resources.limits.memory` | Memory limit | `128Mi` |
 | `resources.requests.cpu` | CPU request | `10m` |
 | `resources.requests.memory` | Memory request | `64Mi` |
+
+## Metrics and RBAC
+
+The operator exposes controller-runtime metrics on `metrics.port` (default `8443`).
+
+When `rbac.create` is `true`, the chart ships two RBAC objects following the
+kubebuilder convention:
+
+- **metrics-auth** (`ClusterRole` + `ClusterRoleBinding` to the operator
+  ServiceAccount): grants `create` on `tokenreviews.authentication.k8s.io` and
+  `subjectaccessreviews.authorization.k8s.io`, so the operator can authenticate
+  and authorize incoming scrape requests.
+- **metrics-reader** (`ClusterRole`): grants `get` on the `/metrics`
+  non-resource URL, so a scraper can be authorized to read metrics.
+
+### Securing the metrics endpoint
+
+By default the endpoint is served over plain HTTP (`metrics.secure: false`),
+preserving the existing behavior. Set `metrics.secure: true` to serve metrics
+over HTTPS and protect them with authn/authz (`--metrics-secure=true`):
+
+```yaml
+metrics:
+  secure: true
+```
+
+When secured, scrapers must present a bearer token whose ServiceAccount is bound
+to the `metrics-reader` ClusterRole. By default the chart leaves that binding to
+the cluster admin. For example, to authorize a Prometheus ServiceAccount:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: valkey-operator-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: valkey-operator-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: monitoring
+```
+
+Alternatively, let the chart create that binding by setting
+`metrics.reader.binding`. The name and namespace support templating:
+
+```yaml
+metrics:
+  reader:
+    binding:
+      create: true
+      serviceAccountName: prometheus
+      namespace: monitoring
+```
 
 ## Source Code
 

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -62,6 +62,7 @@ See [values.yaml](values.yaml) for the full list of configurable parameters.
 | `topologySpreadConstraints` | Topology spread constraints for the operator pods | `[]` |
 | `metrics.enabled` | Enable the metrics endpoint | `true` |
 | `metrics.port` | Metrics endpoint port | `8443` |
+| `networkPolicy.enabled` | Enable creation of a NetworkPolicy for the operator pod | `false` |
 | `resources.limits.cpu` | CPU limit | `500m` |
 | `resources.limits.memory` | Memory limit | `128Mi` |
 | `resources.requests.cpu` | CPU request | `10m` |
@@ -106,6 +107,21 @@ networkPolicy:
   extraEgress: []
 ```
 
+### Aggregated ClusterRoles
+
+When `rbac.create` is enabled (the default), the chart also ships three aggregated
+ClusterRoles for the `valkeyclusters` and `valkeynodes` custom resources, following the
+[kubebuilder convention](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles):
+
+| Role | Aggregation label | Access |
+|---|---|---|
+| `*-valkey-admin` | `rbac.authorization.k8s.io/aggregate-to-admin` | Full management of the CRs (read-only on status) |
+| `*-valkey-editor` | `rbac.authorization.k8s.io/aggregate-to-edit` | Create/update/delete the CRs (read-only on status) |
+| `*-valkey-viewer` | `rbac.authorization.k8s.io/aggregate-to-view` | Read-only access to the CRs and status |
+
+These roll up into the built-in `admin`, `edit`, and `view` ClusterRoles, so cluster
+admins can grant tenants access to the Valkey CRDs without handing out the operator's own
+controller permissions.
 
 ## Source Code
 

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -1,6 +1,5 @@
 # valkey-operator
-![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
-
+![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 A Helm chart for deploying the [Valkey Operator](https://github.com/valkey-io/valkey-operator) on Kubernetes.
 
@@ -62,6 +61,10 @@ See [values.yaml](values.yaml) for the full list of configurable parameters.
 | `topologySpreadConstraints` | Topology spread constraints for the operator pods | `[]` |
 | `metrics.enabled` | Enable the metrics endpoint | `true` |
 | `metrics.port` | Metrics endpoint port | `8443` |
+| `metrics.secure` | Serve metrics over HTTPS with authn/authz (passes `--metrics-secure=true`); renders the metrics RBAC. Requires `rbac.create` and `metrics.enabled` | `false` |
+| `metrics.reader.binding.create` | Bind a scraper ServiceAccount to the `metrics-reader` ClusterRole. Requires `rbac.create`, `metrics.enabled`, and `metrics.secure` | `false` |
+| `metrics.reader.binding.serviceAccountName` | Name of the scraper ServiceAccount to authorize. Supports templating; required when `binding.create` is `true` | `""` |
+| `metrics.reader.binding.namespace` | Namespace of the scraper ServiceAccount. Supports templating; defaults to the release namespace when empty | `""` |
 | `networkPolicy.enabled` | Enable creation of a NetworkPolicy for the operator pod | `false` |
 | `resources.limits.cpu` | CPU limit | `500m` |
 | `resources.limits.memory` | Memory limit | `128Mi` |
@@ -122,6 +125,37 @@ ClusterRoles for the `valkeyclusters` and `valkeynodes` custom resources, follow
 These roll up into the built-in `admin`, `edit`, and `view` ClusterRoles, so cluster
 admins can grant tenants access to the Valkey CRDs without handing out the operator's own
 controller permissions.
+
+## Metrics and RBAC
+
+By default the operator serves its controller-runtime metrics over plain HTTP. Set
+`metrics.secure: true` to serve them over HTTPS with authentication and authorization,
+following the [kubebuilder secure-metrics convention](https://book.kubebuilder.io/reference/metrics.html).
+When secure serving is enabled (and `rbac.create` is `true`), the chart renders:
+
+- a `*-metrics-auth` ClusterRole + ClusterRoleBinding granting the operator ServiceAccount
+  `create` on `tokenreviews.authentication.k8s.io` and `subjectaccessreviews.authorization.k8s.io`,
+  so it can authenticate and authorize incoming scrape requests; and
+- a `*-metrics-reader` ClusterRole granting `get` on the `/metrics` non-resource URL.
+
+A scraper must present a token whose ServiceAccount is bound to `metrics-reader`. You can
+bind it yourself, or let the chart do it by opting in:
+
+```yaml
+metrics:
+  secure: true
+  reader:
+    binding:
+      create: true
+      # Supports templating, e.g. "{{ .Release.Name }}-prometheus"
+      serviceAccountName: prometheus
+      # Defaults to the release namespace when empty
+      namespace: monitoring
+```
+
+`serviceAccountName` is required when `binding.create` is `true`; rendering fails otherwise.
+Both `metrics.secure` and `metrics.reader.binding.create` default to `false`, so existing
+installs keep serving metrics over insecure HTTP unless you opt in.
 
 ## Source Code
 

--- a/valkey-operator/templates/deployment.yaml
+++ b/valkey-operator/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - --health-probe-bind-address=:8081
         {{- if .Values.metrics.enabled }}
         - --metrics-bind-address=:{{ .Values.metrics.port }}
-        - --metrics-secure=false
+        - --metrics-secure={{ .Values.metrics.secure }}
         {{- else }}
         - --metrics-bind-address=0
         {{- end }}

--- a/valkey-operator/templates/metrics-rbac.yaml
+++ b/valkey-operator/templates/metrics-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if and .Values.rbac.create .Values.metrics.enabled .Values.metrics.secure -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/valkey-operator/templates/metrics-rbac.yaml
+++ b/valkey-operator/templates/metrics-rbac.yaml
@@ -45,10 +45,10 @@ rules:
   - /metrics
   verbs:
   - get
-{{- if .Values.metrics.reader.binding.create }}
-{{- if not .Values.metrics.reader.binding.serviceAccountName }}
+{{- if and .Values.metrics.reader.binding.create (not .Values.metrics.reader.binding.serviceAccountName) }}
 {{- fail "metrics.reader.binding.serviceAccountName is required when metrics.reader.binding.create is true" }}
 {{- end }}
+{{- if .Values.metrics.reader.binding.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/valkey-operator/templates/metrics-rbac.yaml
+++ b/valkey-operator/templates/metrics-rbac.yaml
@@ -45,7 +45,10 @@ rules:
   - /metrics
   verbs:
   - get
-{{- if and .Values.metrics.reader.binding.create .Values.metrics.reader.binding.serviceAccountName }}
+{{- if .Values.metrics.reader.binding.create }}
+{{- if not .Values.metrics.reader.binding.serviceAccountName }}
+{{- fail "metrics.reader.binding.serviceAccountName is required when metrics.reader.binding.create is true" }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/valkey-operator/templates/metrics-rbac.yaml
+++ b/valkey-operator/templates/metrics-rbac.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "valkey-operator.fullname" . }}-metrics-auth
+  labels:
+    {{- include "valkey-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "valkey-operator.fullname" . }}-metrics-auth
+  labels:
+    {{- include "valkey-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "valkey-operator.fullname" . }}-metrics-auth
+subjects:
+- kind: ServiceAccount
+  name: {{ include "valkey-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "valkey-operator.fullname" . }}-metrics-reader
+  labels:
+    {{- include "valkey-operator.labels" . | nindent 4 }}
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+{{- if and .Values.metrics.reader.binding.create .Values.metrics.reader.binding.serviceAccountName }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "valkey-operator.fullname" . }}-metrics-reader
+  labels:
+    {{- include "valkey-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "valkey-operator.fullname" . }}-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ tpl .Values.metrics.reader.binding.serviceAccountName . }}
+  namespace: {{ tpl (.Values.metrics.reader.binding.namespace | default .Release.Namespace) . }}
+{{- end }}
+{{- end }}

--- a/valkey-operator/templates/metrics-service.yaml
+++ b/valkey-operator/templates/metrics-service.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   type: {{ .Values.metrics.service.type }}
   ports:
-  - name: http
+  - name: {{ if .Values.metrics.secure }}https{{ else }}http{{ end }}
     port: {{ .Values.metrics.port }}
     protocol: TCP
     targetPort: metrics

--- a/valkey-operator/tests/deployment_test.yaml
+++ b/valkey-operator/tests/deployment_test.yaml
@@ -1,0 +1,41 @@
+suite: operator deployment metrics flags
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: should default to insecure metrics
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --metrics-secure=false
+
+  - it: should pass --metrics-secure=true when metrics.secure is enabled
+    set:
+      metrics.secure: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --metrics-secure=true
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --metrics-secure=false
+
+  - it: should bind metrics on the configured port
+    set:
+      metrics.port: 9443
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --metrics-bind-address=:9443
+
+  - it: should disable metrics when metrics.enabled is false
+    set:
+      metrics.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --metrics-bind-address=0
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --metrics-secure=false

--- a/valkey-operator/tests/metrics-rbac_test.yaml
+++ b/valkey-operator/tests/metrics-rbac_test.yaml
@@ -2,9 +2,11 @@ suite: operator metrics auth RBAC
 templates:
   - templates/metrics-rbac.yaml
 tests:
-  - it: should render the metrics RBAC objects when rbac.create is true
+  - it: should render the metrics RBAC objects when rbac.create and secure metrics are enabled
     set:
       rbac.create: true
+      metrics.enabled: true
+      metrics.secure: true
     asserts:
       - hasDocuments:
           count: 3
@@ -12,11 +14,32 @@ tests:
   - it: should omit the metrics RBAC objects when rbac.create is false
     set:
       rbac.create: false
+      metrics.secure: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should omit the metrics RBAC objects when metrics.secure is false
+    set:
+      rbac.create: true
+      metrics.enabled: true
+      metrics.secure: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should omit the metrics RBAC objects when metrics.enabled is false
+    set:
+      rbac.create: true
+      metrics.enabled: false
+      metrics.secure: true
     asserts:
       - hasDocuments:
           count: 0
 
   - it: should create the metrics-auth ClusterRole with TokenReview and SubjectAccessReview rules
+    set:
+      metrics.secure: true
     documentIndex: 0
     asserts:
       - isKind:
@@ -44,6 +67,8 @@ tests:
               - create
 
   - it: should bind the metrics-auth ClusterRole to the operator ServiceAccount
+    set:
+      metrics.secure: true
     documentIndex: 1
     asserts:
       - isKind:
@@ -65,6 +90,8 @@ tests:
             namespace: NAMESPACE
 
   - it: should create the metrics-reader ClusterRole granting get on /metrics
+    set:
+      metrics.secure: true
     documentIndex: 2
     asserts:
       - isKind:
@@ -81,6 +108,8 @@ tests:
               - get
 
   - it: should include standard labels on the metrics-auth ClusterRole
+    set:
+      metrics.secure: true
     documentIndex: 0
     asserts:
       - equal:
@@ -96,12 +125,15 @@ tests:
           path: metadata.labels["helm.sh/chart"]
 
   - it: should not create the metrics-reader binding by default
+    set:
+      metrics.secure: true
     asserts:
       - hasDocuments:
           count: 3
 
   - it: should not create the metrics-reader binding when serviceAccountName is empty
     set:
+      metrics.secure: true
       metrics.reader.binding.create: true
       metrics.reader.binding.serviceAccountName: ""
     asserts:
@@ -110,6 +142,7 @@ tests:
 
   - it: should create the metrics-reader binding when enabled with a scraper SA
     set:
+      metrics.secure: true
       metrics.reader.binding.create: true
       metrics.reader.binding.serviceAccountName: prometheus
     documentIndex: 3
@@ -137,6 +170,7 @@ tests:
 
   - it: should template the scraper SA name and namespace
     set:
+      metrics.secure: true
       metrics.reader.binding.create: true
       metrics.reader.binding.serviceAccountName: "{{ .Release.Name }}-prometheus"
       metrics.reader.binding.namespace: "monitoring-{{ .Release.Name }}"
@@ -152,6 +186,7 @@ tests:
   - it: should not create the metrics-reader binding when rbac.create is false
     set:
       rbac.create: false
+      metrics.secure: true
       metrics.reader.binding.create: true
       metrics.reader.binding.serviceAccountName: prometheus
     asserts:

--- a/valkey-operator/tests/metrics-rbac_test.yaml
+++ b/valkey-operator/tests/metrics-rbac_test.yaml
@@ -131,14 +131,14 @@ tests:
       - hasDocuments:
           count: 3
 
-  - it: should not create the metrics-reader binding when serviceAccountName is empty
+  - it: should fail when binding.create is true but serviceAccountName is empty
     set:
       metrics.secure: true
       metrics.reader.binding.create: true
       metrics.reader.binding.serviceAccountName: ""
     asserts:
-      - hasDocuments:
-          count: 3
+      - failedTemplate:
+          errorMessage: metrics.reader.binding.serviceAccountName is required when metrics.reader.binding.create is true
 
   - it: should create the metrics-reader binding when enabled with a scraper SA
     set:

--- a/valkey-operator/tests/metrics-rbac_test.yaml
+++ b/valkey-operator/tests/metrics-rbac_test.yaml
@@ -1,0 +1,159 @@
+suite: operator metrics auth RBAC
+templates:
+  - templates/metrics-rbac.yaml
+tests:
+  - it: should render the metrics RBAC objects when rbac.create is true
+    set:
+      rbac.create: true
+    asserts:
+      - hasDocuments:
+          count: 3
+
+  - it: should omit the metrics RBAC objects when rbac.create is false
+    set:
+      rbac.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create the metrics-auth ClusterRole with TokenReview and SubjectAccessReview rules
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-operator-metrics-auth
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - authentication.k8s.io
+            resources:
+              - tokenreviews
+            verbs:
+              - create
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - authorization.k8s.io
+            resources:
+              - subjectaccessreviews
+            verbs:
+              - create
+
+  - it: should bind the metrics-auth ClusterRole to the operator ServiceAccount
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-operator-metrics-auth
+      - equal:
+          path: roleRef.name
+          value: RELEASE-NAME-valkey-operator-metrics-auth
+      - equal:
+          path: roleRef.kind
+          value: ClusterRole
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: RELEASE-NAME-valkey-operator
+            namespace: NAMESPACE
+
+  - it: should create the metrics-reader ClusterRole granting get on /metrics
+    documentIndex: 2
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-operator-metrics-reader
+      - contains:
+          path: rules
+          content:
+            nonResourceURLs:
+              - /metrics
+            verbs:
+              - get
+
+  - it: should include standard labels on the metrics-auth ClusterRole
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: valkey-operator
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - isNotNull:
+          path: metadata.labels["helm.sh/chart"]
+
+  - it: should not create the metrics-reader binding by default
+    asserts:
+      - hasDocuments:
+          count: 3
+
+  - it: should not create the metrics-reader binding when serviceAccountName is empty
+    set:
+      metrics.reader.binding.create: true
+      metrics.reader.binding.serviceAccountName: ""
+    asserts:
+      - hasDocuments:
+          count: 3
+
+  - it: should create the metrics-reader binding when enabled with a scraper SA
+    set:
+      metrics.reader.binding.create: true
+      metrics.reader.binding.serviceAccountName: prometheus
+    documentIndex: 3
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-operator-metrics-reader
+      - equal:
+          path: roleRef.name
+          value: RELEASE-NAME-valkey-operator-metrics-reader
+      - equal:
+          path: roleRef.kind
+          value: ClusterRole
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - equal:
+          path: subjects[0].name
+          value: prometheus
+      - equal:
+          path: subjects[0].namespace
+          value: NAMESPACE
+
+  - it: should template the scraper SA name and namespace
+    set:
+      metrics.reader.binding.create: true
+      metrics.reader.binding.serviceAccountName: "{{ .Release.Name }}-prometheus"
+      metrics.reader.binding.namespace: "monitoring-{{ .Release.Name }}"
+    documentIndex: 3
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: RELEASE-NAME-prometheus
+      - equal:
+          path: subjects[0].namespace
+          value: monitoring-RELEASE-NAME
+
+  - it: should not create the metrics-reader binding when rbac.create is false
+    set:
+      rbac.create: false
+      metrics.reader.binding.create: true
+      metrics.reader.binding.serviceAccountName: prometheus
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/valkey-operator/tests/metrics-service_test.yaml
+++ b/valkey-operator/tests/metrics-service_test.yaml
@@ -1,0 +1,31 @@
+suite: operator metrics service
+templates:
+  - templates/metrics-service.yaml
+tests:
+  - it: should not render the service when metrics are disabled
+    set:
+      metrics.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should name the port http when metrics are insecure
+    set:
+      metrics.secure: false
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports[0].name
+          value: http
+      - equal:
+          path: spec.ports[0].targetPort
+          value: metrics
+
+  - it: should name the port https when metrics are secure
+    set:
+      metrics.secure: true
+    asserts:
+      - equal:
+          path: spec.ports[0].name
+          value: https

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -111,7 +111,6 @@ podLabels: {}
 # Labels to add to all resources
 commonLabels: {}
 
-# TODO: metrics auth RBAC (metrics-auth-role, metrics-reader-role)
 # TODO: prometheus ServiceMonitor
 # TODO: networkPolicy
 # TODO: aggregated ClusterRoles (admin/editor/viewer)
@@ -135,6 +134,25 @@ metrics:
   enabled: true
   # Port for the metrics endpoint
   port: 8443
+  # Serve metrics over HTTPS with authn/authz, protecting the endpoint with
+  # TokenReviews and SubjectAccessReviews (passes --metrics-secure=true).
+  # Requires rbac.create to create the metrics-auth ClusterRole and binding.
+  # Defaults to false to preserve the existing insecure HTTP behavior; scrapers
+  # must then be authorized via the metrics-reader ClusterRole.
+  secure: false
+  reader:
+    # Optionally bind a scraper ServiceAccount to the metrics-reader ClusterRole
+    # so it can read the /metrics endpoint. Disabled by default; most setups
+    # bind their scraper manually (see README). Requires rbac.create.
+    binding:
+      # Create the ClusterRoleBinding for the scraper ServiceAccount.
+      create: false
+      # Name of the scraper ServiceAccount to authorize. Supports templating,
+      # e.g. "{{ .Release.Name }}-prometheus". Required when create is true.
+      serviceAccountName: ""
+      # Namespace of the scraper ServiceAccount. Supports templating.
+      # Defaults to the release namespace when empty.
+      namespace: ""
   service:
     # Service type for the metrics service
     type: ClusterIP

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -136,14 +136,17 @@ metrics:
   port: 8443
   # Serve metrics over HTTPS with authn/authz, protecting the endpoint with
   # TokenReviews and SubjectAccessReviews (passes --metrics-secure=true).
-  # Requires rbac.create to create the metrics-auth ClusterRole and binding.
-  # Defaults to false to preserve the existing insecure HTTP behavior; scrapers
-  # must then be authorized via the metrics-reader ClusterRole.
+  # The metrics RBAC (metrics-auth and metrics-reader ClusterRoles) is only
+  # rendered when this is true, since the operator only issues TokenReviews and
+  # SubjectAccessReviews under secure serving. Also requires rbac.create and
+  # metrics.enabled. Defaults to false to preserve the existing insecure HTTP
+  # behavior.
   secure: false
   reader:
     # Optionally bind a scraper ServiceAccount to the metrics-reader ClusterRole
     # so it can read the /metrics endpoint. Disabled by default; most setups
-    # bind their scraper manually (see README). Requires rbac.create.
+    # bind their scraper manually (see README). Requires rbac.create,
+    # metrics.enabled, and metrics.secure.
     binding:
       # Create the ClusterRoleBinding for the scraper ServiceAccount.
       create: false


### PR DESCRIPTION
https://github.com/valkey-io/valkey-helm/issues/192

 Operator: secure metrics with auth RBAC (metrics-auth + metrics-reader)

  Closes #192

  Summary

  The operator served its controller-runtime metrics over plain HTTP because the deployment hardcoded --metrics-secure=false, and the chart shipped none of the RBAC the kubebuilder secure-metrics convention requires. This PR adds that RBAC, makes secure
  mode toggleable, and documents and tests the flow.

  Changes

  - metrics-auth ClusterRole + ClusterRoleBinding (templates/metrics-rbac.yaml): grants the operator ServiceAccount create on tokenreviews.authentication.k8s.io and subjectaccessreviews.authorization.k8s.io so it can authenticate and authorize incoming
  scrape requests.
  - metrics-reader ClusterRole: grants get on the /metrics non-resource URL.
  - Optional reader binding: metrics.reader.binding.{create,serviceAccountName,namespace} lets the chart bind a scraper ServiceAccount to metrics-reader. The subject name and namespace support templating (tpl), e.g. {{ .Release.Name }}-prometheus.
  Disabled by default, so the admin binds the scraper manually unless they opt in.
  - Secure toggle (templates/deployment.yaml): --metrics-secure={{ .Values.metrics.secure }}, new value metrics.secure defaulting to false.
  - Metrics Service (templates/metrics-service.yaml): port name renders https when secure, http otherwise.
  - All new RBAC is gated behind the existing rbac.create, consistent with the manager ClusterRole/Binding.
  - Docs: new "Metrics and RBAC" section and parameter rows in README.md.
  - Chart version bumped to 0.2.3.

  Backward compatibility

  metrics.secure defaults to false and metrics.reader.binding.create defaults to false, so existing installs are unchanged.

  Testing

  - helm lint clean; helm unittest passes (29 tests across 4 suites) covering: roles render with rbac.create: true and are omitted when false, correct rules and binding subject, the secure flag toggling deployment args, the service port-name switch, and
  the optional reader binding including its tpl behavior.
  - Validated live on a kind cluster with metrics.secure=true:
    - --metrics-secure=true present in deployment args; metrics served over HTTPS.
    - No-token request → 401 (authn enforced).
    - Operator SA token → authenticated but authz-denied (it has metrics-auth, not metrics-reader), proving the SubjectAccessReview path.
    - A ServiceAccount bound to metrics-reader → 200 with real metrics.

  Values

  metrics:
    secure: false
    reader:
      binding:
        create: false
        serviceAccountName: ""
        namespace: ""