### PR TITLE
fix: Add namespace field in pdb resource

### DIFF
--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.2.3
+
+### Fixed
+
+- Add namespace field in PodDisruptionBudget
+
 ## 0.2.2
 
 ### Added
@@ -11,10 +17,6 @@
   - Once opted in, the operator's required egress (DNS, Kubernetes API server, and managed Valkey pods on the Valkey port) is injected automatically so reconciliation keeps working under egress lockdown. The Valkey rule targets `manager.watchNamespaces` (all namespaces when empty).
   - Tunable via `networkPolicy.defaultEgressRules` (default `true`), `valkeyPort` (`6379`), `apiServerPort` (`6443`), and `dnsNamespace` (`kube-system`).
   - Supports `ingress`, `egress` (merged with the defaults), `labels`, and `annotations`; `policyTypes` is derived from the rules in effect.
-
-### Fixed
-
-- Add namespace field in PodDisruptionBudget
 
 ## 0.2.1
 

--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
-### Added
+### 0.2.2
+
+- Add namespace field in PodDisruptionBudget
+
+### 0.2.1
 
 - Add optional PodDisruptionBudget support for the valkey-operator Deployment.
 

--- a/valkey-operator/Chart.yaml
+++ b/valkey-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey-operator
 description: A Helm chart for the Valkey Operator
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "v0.2.0"
 kubeVersion: ">=1.20.0-0"
 home: https://valkey.io/valkey-helm/

--- a/valkey-operator/Chart.yaml
+++ b/valkey-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey-operator
 description: A Helm chart for the Valkey Operator
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: "v0.2.0"
 kubeVersion: ">=1.20.0-0"
 home: https://valkey.io/valkey-helm/

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -1,6 +1,6 @@
 # valkey-operator
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 A Helm chart for deploying the [Valkey Operator](https://github.com/valkey-io/valkey-operator) on Kubernetes.
 

--- a/valkey-operator/templates/poddisruptionbudget.yaml
+++ b/valkey-operator/templates/poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "valkey-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "valkey-operator.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
PodDisruptionBudget is a namespaced resource. 
Added namespace field to keep it similar to other namespace scoped resource in the helm.
ps - found this while trying to use the helm chart as our cicd pipeline distinguishes rbac for cluster scope and namespace scoped resources