### PR TITLE
fix: Added customizability for secure metrics and terminationGracePeriodSeconds

### DIFF
--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -12,6 +12,14 @@
   - Tunable via `networkPolicy.defaultEgressRules` (default `true`), `valkeyPort` (`6379`), `apiServerPort` (`6443`), and `dnsNamespace` (`kube-system`).
   - Supports `ingress`, `egress` (merged with the defaults), `labels`, and `annotations`; `policyTypes` is derived from the rules in effect.
 
+### Changed
+
+- terminationGracePeriodSeconds is omitted from configuration by default and uses kubernetes default (30s) unless overridden.
+
+### Fixed
+
+- Added configurability for terminationGracePeriodSeconds.
+- Added configurability for serving metrics securely.
 
 ## 0.2.1
 

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -60,6 +60,7 @@ See [values.yaml](values.yaml) for the full list of configurable parameters.
 | `podDisruptionBudget.maxUnavailable` | Maximum pods unavailable during disruptions | `1` |
 | `podDisruptionBudget.unhealthyPodEvictionPolicy` | Policy for evicting unhealthy pods | `""` |
 | `metrics.enabled` | Enable the metrics endpoint | `true` |
+| `metrics.secure` | Expose metrics endpoint over TLS | `false` |
 | `metrics.port` | Metrics endpoint port | `8443` |
 | `resources.limits.cpu` | CPU limit | `500m` |
 | `resources.limits.memory` | Memory limit | `128Mi` |

--- a/valkey-operator/templates/deployment.yaml
+++ b/valkey-operator/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       {{- include "valkey-operator.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "valkey-operator.serviceAccountName" . }}
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/valkey-operator/templates/deployment.yaml
+++ b/valkey-operator/templates/deployment.yaml
@@ -28,7 +28,9 @@ spec:
     spec:
       {{- include "valkey-operator.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "valkey-operator.serviceAccountName" . }}
+      {{- if hasKey .Values "terminationGracePeriodSeconds" }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/valkey-operator/templates/deployment.yaml
+++ b/valkey-operator/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - --health-probe-bind-address=:8081
         {{- if .Values.metrics.enabled }}
         - --metrics-bind-address=:{{ .Values.metrics.port }}
-        - --metrics-secure=false
+        - --metrics-secure={{ .Values.metrics.secure }}
         {{- else }}
         - --metrics-bind-address=0
         {{- end }}

--- a/valkey-operator/templates/metrics-service.yaml
+++ b/valkey-operator/templates/metrics-service.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   type: {{ .Values.metrics.service.type }}
   ports:
-  - name: http
+  - name: {{ if .Values.metrics.secure }}https{{ else }}http{{ end }}
     port: {{ .Values.metrics.port }}
     protocol: TCP
     targetPort: metrics

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -133,6 +133,8 @@ podDisruptionBudget:
 metrics:
   # Enable the metrics endpoint
   enabled: true
+  # Expose metrics over TLS
+  secure: false
   # Port for the metrics endpoint
   port: 8443
   service:

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -87,7 +87,7 @@ securityContext:
 nodeSelector: {}
 
 # Termination grace period for pods (seconds)
-terminationGracePeriodSeconds: 10
+#terminationGracePeriodSeconds: 10
 
 # tolerations:
 #   - key: "node-role.kubernetes.io/control-plane"

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -86,6 +86,9 @@ securityContext:
 #   kubernetes.io/os: linux
 nodeSelector: {}
 
+# Termination grace period for pods (seconds)
+terminationGracePeriodSeconds: 10
+
 # tolerations:
 #   - key: "node-role.kubernetes.io/control-plane"
 #     operator: "Exists"


### PR DESCRIPTION
This PR contains 2 changes.
1. Added configurable `terminationGracePeriodSeconds` for operator pod graceful shutdown.
2. Added `.Values.metrics.secure` to control TLS for operator metrics endpoint and service port naming (http/https).