### PR TITLE
fix: Add configurability for terminationGracePeriodSeconds

### DIFF
--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## 0.2.5
+
+### Changed
+
+- terminationGracePeriodSeconds is omitted from configuration by default and uses kubernetes default (30s) unless overridden.
+
+### Fixed
+
+- Added configurability for terminationGracePeriodSeconds.
+- Added configurability for serving metrics securely.
+
 ## 0.2.4
 
 ### Added

--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -11,7 +11,6 @@
 ### Fixed
 
 - Added configurability for terminationGracePeriodSeconds.
-- Added configurability for serving metrics securely.
 
 ## 0.2.4
 

--- a/valkey-operator/Chart.yaml
+++ b/valkey-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey-operator
 description: A Helm chart for the Valkey Operator
 type: application
-version: 0.2.7
+version: 0.2.8
 appVersion: "v0.2.0"
 kubeVersion: ">=1.20.0-0"
 home: https://valkey.io/valkey-helm/

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -1,6 +1,6 @@
 # valkey-operator
 
-![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
+![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 A Helm chart for deploying the [Valkey Operator](https://github.com/valkey-io/valkey-operator) on Kubernetes.
 

--- a/valkey-operator/templates/deployment.yaml
+++ b/valkey-operator/templates/deployment.yaml
@@ -28,7 +28,9 @@ spec:
     spec:
       {{- include "valkey-operator.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "valkey-operator.serviceAccountName" . }}
-      terminationGracePeriodSeconds: 10
+      {{- if hasKey .Values "terminationGracePeriodSeconds" }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -88,7 +88,7 @@ securityContext:
 nodeSelector: {}
 
 # Termination grace period for pods (seconds)
-terminationGracePeriodSeconds:
+terminationGracePeriodSeconds: 30
 
 # tolerations:
 #   - key: "node-role.kubernetes.io/control-plane"

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -86,6 +86,9 @@ securityContext:
 #   kubernetes.io/os: linux
 nodeSelector: {}
 
+# Termination grace period for pods (seconds)
+terminationGracePeriodSeconds:
+
 # tolerations:
 #   - key: "node-role.kubernetes.io/control-plane"
 #     operator: "Exists"


### PR DESCRIPTION
Added configurable `terminationGracePeriodSeconds` for operator pod graceful shutdown.

`{{- if .Values.terminationGracePeriodSeconds }}` treats 0 as false/empty, so it would skip rendering when someone explicitly sets 0(essentially setting it to 30s). hasKey checks presence - more correct behavior for numeric config values.
