### PR TITLE
added a ci check for version bump

### DIFF
--- a/.github/workflows/test-operator.yml
+++ b/.github/workflows/test-operator.yml
@@ -67,3 +67,42 @@ jobs:
           name: valkey-operator-template-k${{ matrix.kube }}
           path: /tmp/valkey-operator-*.yaml
           if-no-files-found: error
+
+  chart-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need full history to diff against the base branch
+
+      - name: Check chart version is bumped when templates change
+        run: |
+          set -euo pipefail
+
+          BASE="origin/${GITHUB_BASE_REF:-main}"
+          git fetch --no-tags --depth=1 origin "${GITHUB_BASE_REF:-main}"
+
+          # Did any chart template (or the chart metadata) change vs the base branch?
+          if git diff --quiet "$BASE"...HEAD -- valkey-operator/templates valkey-operator/crds; then
+            echo "No valkey-operator template changes detected; skipping version check."
+            exit 0
+          fi
+          echo "valkey-operator template changes detected; verifying chart version bump."
+
+          read_version() { awk '/^version:/ {print $2; exit}' "$1"; }
+
+          NEW_VERSION="$(read_version valkey-operator/Chart.yaml)"
+          OLD_VERSION="$(git show "$BASE:valkey-operator/Chart.yaml" | awk '/^version:/ {print $2; exit}')"
+
+          echo "Base version: $OLD_VERSION"
+          echo "Current version: $NEW_VERSION"
+
+          # Fail unless the new version is strictly greater than the base version.
+          HIGHEST="$(printf '%s\n%s\n' "$OLD_VERSION" "$NEW_VERSION" | sort -V | tail -n1)"
+          if [ "$NEW_VERSION" = "$OLD_VERSION" ] || [ "$HIGHEST" != "$NEW_VERSION" ]; then
+            echo "::error file=valkey-operator/Chart.yaml::please bump the chart version (current: $NEW_VERSION, base: $OLD_VERSION)"
+            exit 1
+          fi
+
+          echo "Chart version bumped from $OLD_VERSION to $NEW_VERSION."


### PR DESCRIPTION
## Add CI check to enforce chart version bump on template changes

  ### What

  Adds a new chart-version job to .github/workflows/test-operator.yml that fails the build when valkey-operator template files are modified without bumping the
  chart version in Chart.yaml.

  ### Why

  It is easy to change a chart's templates and forget to bump the chart version. Shipping template changes under an unchanged version means consumers can pull a
  different chart for the same version, which breaks reproducibility and caching. This check makes the version bump a required, automated gate.

  ### How it works

  1. Checks out full history (fetch-depth: 0) and fetches the base branch.
  2. Diffs valkey-operator/templates and valkey-operator/crds against the base branch (origin/${GITHUB_BASE_REF:-main}). If nothing there changed, the check is
  skipped.
  3. If templates changed, it reads the chart version from the current Chart.yaml and from the base branch's Chart.yaml.
  4. Using semver-aware comparison (sort -V), the check passes only if the new version is strictly greater than the base version. Otherwise it fails with a
  GitHub annotation: "please bump the chart version".

  ### Examples

  - 0.2.4 to 0.2.5 or 0.3.0: passes
  - 0.2.4 unchanged while templates changed: fails
  - downgrade (0.2.4 to 0.2.3): fails