### PR TITLE
feat(valkey): make Valkey container health probes configurable

### DIFF
--- a/valkey/README.md
+++ b/valkey/README.md
@@ -280,6 +280,12 @@ tls:
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | initResources | object | `{}` |  |
+| livenessProbe.customProbe | object | `{}` | Full probe spec to replace the default valkey-cli ping handler and timing |
+| livenessProbe.enabled | bool | `true` |  |
+| livenessProbe.failureThreshold | int | `3` |  |
+| livenessProbe.initialDelaySeconds | int | `0` |  |
+| livenessProbe.periodSeconds | int | `10` |  |
+| livenessProbe.timeoutSeconds | int | `1` |  |
 | metrics.enabled | bool | `false` |  |
 | metrics.exporter.args | list | `[]` |  |
 | metrics.exporter.command | list | `[]` |  |
@@ -342,6 +348,13 @@ tls:
 | podSecurityContext.runAsUser | int | `1000` |  |
 | priorityClassName | string | `""` |  |
 | runtimeClassName | string | `""` | RuntimeClassName for the pods (e.g. `gvisor`, `kata-containers`); empty uses the cluster default runtime |
+| readinessProbe.customProbe | object | `{}` | Full probe spec to replace the default valkey-cli ping handler and timing |
+| readinessProbe.enabled | bool | `false` | Opt-in; the Valkey container had no readiness probe before |
+| readinessProbe.failureThreshold | int | `3` |  |
+| readinessProbe.initialDelaySeconds | int | `0` |  |
+| readinessProbe.periodSeconds | int | `10` |  |
+| readinessProbe.successThreshold | int | `1` |  |
+| readinessProbe.timeoutSeconds | int | `1` |  |
 | replica.enabled | bool | `false` |  |
 | replica.replicas | int | `2` |  |
 | replica.replicationUser | string | `"default"` |  |
@@ -375,6 +388,12 @@ tls:
 | serviceAccount.automount | bool | `false` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| startupProbe.customProbe | object | `{}` | Full probe spec to replace the default valkey-cli ping handler and timing |
+| startupProbe.enabled | bool | `true` |  |
+| startupProbe.failureThreshold | int | `3` |  |
+| startupProbe.initialDelaySeconds | int | `0` |  |
+| startupProbe.periodSeconds | int | `10` |  |
+| startupProbe.timeoutSeconds | int | `1` |  |
 | tls.caPublicKey | string | `"ca.crt"` |  |
 | tls.dhParamKey | string | `""` |  |
 | tls.enabled | bool | `false` |  |

--- a/valkey/templates/_helpers.tpl
+++ b/valkey/templates/_helpers.tpl
@@ -188,3 +188,41 @@ Validate replica authentication configuration
 {{- end }}
 {{- end -}}
 
+{{/*
+Render the Valkey server container health probes (startupProbe, livenessProbe,
+readinessProbe). Each probe is gated on its own `enabled` flag. When a probe's
+`customProbe` map is set it replaces the default handler and timing entirely;
+otherwise the default valkey-cli ping exec handler (TLS-aware) is emitted with
+whichever timing fields are set on that probe. The command is built as an
+argument list and invokes valkey-cli directly (no shell), with the TLS flags
+appended only when `tls.enabled` is set. Returns nothing when no probe is
+enabled, so callers should guard with `with`.
+*/}}
+{{- define "valkey.healthProbes" -}}
+{{- $cmd := list "valkey-cli" -}}
+{{- if $.Values.tls.enabled -}}
+{{- $cmd = concat $cmd (list "--cacert" (printf "/tls/%s" $.Values.tls.caPublicKey) "--tls") -}}
+{{- end -}}
+{{- $cmd = append $cmd "ping" -}}
+{{- $probes := dict -}}
+{{- range $name := (list "startupProbe" "livenessProbe" "readinessProbe") -}}
+{{- $probe := index $.Values $name -}}
+{{- if $probe -}}
+{{- if $probe.enabled -}}
+{{- if $probe.customProbe -}}
+{{- $probes = set $probes $name $probe.customProbe -}}
+{{- else -}}
+{{- $rendered := dict "exec" (dict "command" $cmd) -}}
+{{- range $field := (list "initialDelaySeconds" "periodSeconds" "timeoutSeconds" "failureThreshold" "successThreshold") -}}
+{{- if hasKey $probe $field -}}{{- $rendered = set $rendered $field (index $probe $field) -}}{{- end -}}
+{{- end -}}
+{{- $probes = set $probes $name $rendered -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if $probes -}}
+{{- toYaml $probes -}}
+{{- end -}}
+{{- end -}}
+

--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -119,20 +119,9 @@ spec:
             - name: tcp
               containerPort: {{ .Values.service.port }}
               protocol: TCP
-          startupProbe:
-            exec:
-              {{- if .Values.tls.enabled }}
-              command: [ "valkey-cli", "--cacert", "/tls/{{ .Values.tls.caPublicKey }}", "--tls", "ping" ]
-              {{- else }}
-              command: [ "valkey-cli", "ping" ]
-              {{- end }}
-          livenessProbe:
-            exec:
-              {{- if .Values.tls.enabled }}
-              command: [ "valkey-cli", "--cacert", "/tls/{{ .Values.tls.caPublicKey }}", "--tls", "ping" ]
-              {{- else }}
-              command: [ "valkey-cli", "ping" ]
-              {{- end }}
+          {{- with (include "valkey.healthProbes" .) }}
+          {{- . | nindent 10 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -138,20 +138,9 @@ spec:
             - name: tcp
               containerPort: {{ .Values.service.port }}
               protocol: TCP
-          startupProbe:
-            exec:
-              {{- if .Values.tls.enabled }}
-              command: [ "valkey-cli", "--cacert", "/tls/{{ .Values.tls.caPublicKey }}", "--tls", "ping" ]
-              {{- else }}
-              command: [ "valkey-cli", "ping" ]
-              {{- end }}
-          livenessProbe:
-            exec:
-              {{- if .Values.tls.enabled }}
-              command: [ "valkey-cli", "--cacert", "/tls/{{ .Values.tls.caPublicKey }}", "--tls", "ping" ]
-              {{- else }}
-              command: [ "valkey-cli", "ping" ]
-              {{- end }}
+          {{- with (include "valkey.healthProbes" .) }}
+          {{- . | nindent 10 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/valkey/tests/healthprobes_test.yaml
+++ b/valkey/tests/healthprobes_test.yaml
@@ -1,0 +1,87 @@
+suite: health probes configuration
+templates:
+  - templates/deploy_valkey.yaml
+  - templates/statefulset.yaml
+  - templates/init_config.yaml
+tests:
+  - it: renders default startup and liveness probes on the Deployment valkey container
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].startupProbe
+      - exists:
+          path: spec.template.spec.containers[0].livenessProbe
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command
+          value: [ "valkey-cli", "ping" ]
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.periodSeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 3
+
+  - it: renders default probes on the StatefulSet valkey container
+    template: templates/statefulset.yaml
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].startupProbe
+      - exists:
+          path: spec.template.spec.containers[0].livenessProbe
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: enables the readiness probe with its success threshold when requested
+    template: templates/deploy_valkey.yaml
+    set:
+      readinessProbe.enabled: true
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].readinessProbe
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.successThreshold
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command
+          value: [ "valkey-cli", "ping" ]
+
+  - it: omits a probe when it is disabled
+    template: templates/deploy_valkey.yaml
+    set:
+      startupProbe.enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe
+      - exists:
+          path: spec.template.spec.containers[0].livenessProbe
+
+  - it: replaces the default handler and timing when customProbe is set
+    template: templates/deploy_valkey.yaml
+    set:
+      livenessProbe.customProbe:
+        tcpSocket:
+          port: 6379
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: 6379
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe.exec
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+
+  - it: uses the TLS-aware ping command when TLS is enabled
+    template: templates/deploy_valkey.yaml
+    set:
+      tls.enabled: true
+      tls.caPublicKey: ca.crt
+      tls.existingSecret: valkey-tls
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.exec.command
+          value: [ "valkey-cli", "--cacert", "/tls/ca.crt", "--tls", "ping" ]

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -113,6 +113,36 @@ initResources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+# Health probes for the main Valkey container.
+# Each probe is gated on its own `enabled` flag and rendered by the
+# `valkey.healthProbes` helper. The default handler is a `valkey-cli ping` exec
+# (TLS-aware). Set `customProbe` to a full probe spec to replace the default
+# handler and timing entirely (e.g. an httpGet or tcpSocket probe).
+# The defaults below match the previous hardcoded behavior (Kubernetes probe
+# defaults); readinessProbe is opt-in since the container had none before.
+startupProbe:
+  enabled: true
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 3
+  customProbe: {}
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 3
+  customProbe: {}
+readinessProbe:
+  enabled: false
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 3
+  successThreshold: 1
+  customProbe: {}
+
 # Additional init containers
 extraInitContainers: []
 


### PR DESCRIPTION
Makes the main Valkey container health probes configurable through values, resolving #123. Each of startupProbe, livenessProbe, and readinessProbe can be toggled and tuned (initialDelaySeconds, periodSeconds, timeoutSeconds, failureThreshold, successThreshold), with a customProbe escape hatch to replace the default valkey-cli ping handler entirely (e.g. an httpGet or tcpSocket probe). A shared valkey.healthProbes helper renders them for both the Deployment (standalone) and StatefulSet (replica) paths.

Scope is the Valkey server container; the metrics exporter probes are left as-is.

Defaults preserve the previous behavior: startupProbe and livenessProbe stay enabled with the Kubernetes default timing, and readinessProbe is opt-in since the container had none before. No change for existing users.

Validation:
- helm lint valkey: passes
- helm unittest ./valkey: 132/132 pass (new health-probes suite covering defaults, readiness opt-in, a disabled probe, customProbe override, and the TLS-aware ping command; existing suites unchanged)
- helm template rendered for the default, readinessProbe.enabled=true, livenessProbe.customProbe, and tls.enabled scenarios

Closes #123
