### PR TITLE
feat(operator): add priorityClassName support to valkey-operator chart

### DIFF
--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## Unreleased
+## 0.3.2
+
+### Added
+
+- Add optional `priorityClassName` field to the valkey-operator Deployment so the operator pods can be assigned a PriorityClass and protected from eviction under resource pressure.
 
 ## 0.3.1
 

--- a/valkey-operator/Chart.yaml
+++ b/valkey-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey-operator
 description: A Helm chart for the Valkey Operator
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "v0.3.0"
 kubeVersion: ">=1.20.0-0"
 home: https://valkey.io/valkey-helm/

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -60,6 +60,7 @@ See [values.yaml](values.yaml) for the full list of configurable parameters.
 | `podDisruptionBudget.maxUnavailable` | Maximum pods unavailable during disruptions | `1` |
 | `podDisruptionBudget.unhealthyPodEvictionPolicy` | Policy for evicting unhealthy pods | `""` |
 | `topologySpreadConstraints` | Topology spread constraints for the operator pods | `[]` |
+| `priorityClassName` | PriorityClass to assign to the operator pods | `""` |
 | `metrics.enabled` | Enable the metrics endpoint | `true` |
 | `metrics.port` | Metrics endpoint port | `8443` |
 | `metrics.secure` | Serve metrics over HTTPS with authn/authz (passes `--metrics-secure=true`); renders the metrics RBAC. Requires `rbac.create` and `metrics.enabled` | `false` |

--- a/valkey-operator/templates/deployment.yaml
+++ b/valkey-operator/templates/deployment.yaml
@@ -103,3 +103,6 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}

--- a/valkey-operator/tests/priorityclassname_test.yaml
+++ b/valkey-operator/tests/priorityclassname_test.yaml
@@ -1,0 +1,23 @@
+suite: operator priorityClassName configuration
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: should not render priorityClassName by default
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+
+  - it: should render priorityClassName when set
+    set:
+      priorityClassName: system-cluster-critical
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: system-cluster-critical
+
+  - it: should not render priorityClassName when set to empty string
+    set:
+      priorityClassName: ""
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -117,6 +117,11 @@ affinity: {}
 #         app.kubernetes.io/name: valkey-operator
 topologySpreadConstraints: []
 
+# priorityClassName for the operator pods
+# Assign a PriorityClass to protect the operator from eviction under resource pressure
+# priorityClassName: system-cluster-critical
+priorityClassName: ""
+
 # Annotations for pods
 podAnnotations: {}
 # Labels for pods


### PR DESCRIPTION
Adds an optional `priorityClassName` field to the valkey-operator Deployment so the operator pods can be assigned a PriorityClass and protected from eviction under resource pressure. It mirrors the existing scheduling knobs (`nodeSelector` / `affinity` / `tolerations` / `topologySpreadConstraints`).

Default is `""`, which renders byte-identical to before, so existing installs are unaffected.

Validation (run locally):
- `helm lint`: 0 failed
- `helm unittest`: 65/65 pass, including a new `priorityclassname_test.yaml` suite (not rendered by default / rendered when set / not rendered on empty string)
- default `helm template` diff vs `main`: only the `helm.sh/chart` version label (0.3.1 -> 0.3.2)
- `--set priorityClassName=system-cluster-critical` renders on the operator pod spec

Resolves #206

- [x] DCO signed
