### PR TITLE
feat(valkey-resources): optional PodMonitor for ValkeyNode exporters

### DIFF
--- a/valkey-resources/Chart.yaml
+++ b/valkey-resources/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey-resources
 description: Helm chart for operator-managed Valkey resources (ValkeyCluster)
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "v0.3.0"
 kubeVersion: ">=1.20.0-0"
 home: https://valkey.io/valkey-helm/

--- a/valkey-resources/README.md
+++ b/valkey-resources/README.md
@@ -1,6 +1,6 @@
 # valkey-resources
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.0](https://img.shields.io/badge/AppVersion-v0.3.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.0](https://img.shields.io/badge/AppVersion-v0.3.0-informational?style=flat-square)
 
 Deploys a single operator managed `ValkeyCluster`. Does not install the operator.
 
@@ -47,7 +47,23 @@ See [values.yaml](values.yaml) and the [ValkeyCluster API](https://github.com/va
 | `cluster.spec.shards` | Shard groups | `3` |
 | `cluster.spec.replicas` | Replicas per shard | `1` |
 | `extraValues` | Free-form map for use inside `tpl` strings | `{}` |
+| `metrics.podMonitor.enabled` | Create a PodMonitor for ValkeyNode exporter sidecars (Prometheus Operator CRDs) | `false` |
+| `metrics.podMonitor.port` | Scrape port name on the exporter container | `metrics` |
 | `fullnameOverride` | ValkeyCluster name | chart fullname |
+
+### Metrics (PodMonitor)
+
+Operator pods run a `metrics-exporter` sidecar (port name `metrics`, 9121) when `cluster.spec.exporter` is enabled (operator default). This chart can create a **PodMonitor** that selects pods with `valkey.io/cluster=<ValkeyCluster name>` in the release namespace:
+
+```yaml
+metrics:
+  podMonitor:
+    enabled: true
+    labels:
+      release: prometheus
+```
+
+Use PodMonitor (not ServiceMonitor): node metrics are on pods, not a dedicated Service. Operator controller metrics stay on the `valkey-operator` chart ServiceMonitor.
 
 **Release model:** one logical workload per Helm release. v0.1 only renders `ValkeyCluster`. When more kinds land, the chart will keep that model (enable the kinds you need for that one workload; multiple independent clusters remain multiple releases).
 

--- a/valkey-resources/templates/NOTES.txt
+++ b/valkey-resources/templates/NOTES.txt
@@ -11,4 +11,12 @@ Watch status:
 List nodes:
   kubectl get valkeynodes -n {{ .Release.Namespace }}
 
+{{- if .Values.metrics.podMonitor.enabled }}
+
+PodMonitor: {{ include "valkey-resources.fullname" . }}
+  selector: valkey.io/cluster={{ include "valkey-resources.fullname" . }}
+  port: {{ .Values.metrics.podMonitor.port }}
+{{- end }}
+
 Docs: https://github.com/valkey-io/valkey-operator/blob/main/docs/valkeycluster.md
+

--- a/valkey-resources/templates/podmonitor.yaml
+++ b/valkey-resources/templates/podmonitor.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.metrics.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "valkey-resources.fullname" . }}
+  namespace: {{ .Values.metrics.podMonitor.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "valkey-resources.labels" . | nindent 4 }}
+    app.kubernetes.io/component: podmonitor
+    {{- with .Values.metrics.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.metrics.podMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      # Operator labels ValkeyNode pods with valkey.io/cluster=<ValkeyCluster name>
+      valkey.io/cluster: {{ include "valkey-resources.fullname" . | quote }}
+      {{- with .Values.metrics.podMonitor.selector }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  podMetricsEndpoints:
+    - port: {{ .Values.metrics.podMonitor.port }}
+      {{- with .Values.metrics.podMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.metrics.podMonitor.honorLabels }}
+      honorLabels: true
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- with .Values.metrics.podMonitor.podTargetLabels }}
+  podTargetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if not (empty .Values.metrics.podMonitor.sampleLimit) }}
+  sampleLimit: {{ .Values.metrics.podMonitor.sampleLimit }}
+  {{- end }}
+  {{- if not (empty .Values.metrics.podMonitor.targetLimit) }}
+  targetLimit: {{ .Values.metrics.podMonitor.targetLimit }}
+  {{- end }}
+{{- end }}

--- a/valkey-resources/tests/podmonitor_test.yaml
+++ b/valkey-resources/tests/podmonitor_test.yaml
@@ -1,0 +1,102 @@
+suite: podmonitor
+templates:
+  - templates/podmonitor.yaml
+tests:
+  - it: does not render PodMonitor by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders PodMonitor when enabled
+    set:
+      metrics.podMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodMonitor
+      - equal:
+          path: apiVersion
+          value: monitoring.coreos.com/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-resources
+      - equal:
+          path: spec.selector.matchLabels["valkey.io/cluster"]
+          value: RELEASE-NAME-valkey-resources
+      - equal:
+          path: spec.namespaceSelector.matchNames[0]
+          value: NAMESPACE
+      - equal:
+          path: spec.podMetricsEndpoints[0].port
+          value: metrics
+
+  - it: uses fullnameOverride for name and cluster selector
+    set:
+      fullnameOverride: my-cluster
+      metrics.podMonitor.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-cluster
+      - equal:
+          path: spec.selector.matchLabels["valkey.io/cluster"]
+          value: my-cluster
+
+  - it: honors PodMonitor namespace and scrape knobs
+    set:
+      metrics:
+        podMonitor:
+          enabled: true
+          namespace: monitoring
+          interval: 30s
+          scrapeTimeout: 10s
+          honorLabels: true
+          scheme: https
+          labels:
+            release: prometheus
+          annotations:
+            meta: test
+          podTargetLabels:
+            - valkey.io/shard-index
+          sampleLimit: 1000
+          targetLimit: 50
+          selector:
+            app.kubernetes.io/component: valkey-node
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: monitoring
+      - equal:
+          path: metadata.labels.release
+          value: prometheus
+      - equal:
+          path: metadata.annotations.meta
+          value: test
+      - equal:
+          path: spec.podMetricsEndpoints[0].interval
+          value: 30s
+      - equal:
+          path: spec.podMetricsEndpoints[0].scrapeTimeout
+          value: 10s
+      - equal:
+          path: spec.podMetricsEndpoints[0].scheme
+          value: https
+      - equal:
+          path: spec.podMetricsEndpoints[0].honorLabels
+          value: true
+      - equal:
+          path: spec.podTargetLabels[0]
+          value: valkey.io/shard-index
+      - equal:
+          path: spec.sampleLimit
+          value: 1000
+      - equal:
+          path: spec.targetLimit
+          value: 50
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: valkey-node
+      - equal:
+          path: spec.selector.matchLabels["valkey.io/cluster"]
+          value: RELEASE-NAME-valkey-resources

--- a/valkey-resources/values.schema.json
+++ b/valkey-resources/values.schema.json
@@ -12,6 +12,21 @@
       "additionalProperties": true,
       "description": "Free-form values referenced from templated strings in cluster.spec (and labels/annotations)."
     },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "podMonitor": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "port": { "type": ["string", "integer"] },
+            "namespace": { "type": "string" }
+          }
+        }
+      }
+    },
     "cluster": {
       "type": "object",
       "required": ["spec"],

--- a/valkey-resources/values.yaml
+++ b/valkey-resources/values.yaml
@@ -18,6 +18,33 @@ commonLabels: {}
 #           secretName: "{{ .Values.extraValues.tlsSecret }}"
 extraValues: {}
 
+# Scrape ValkeyNode metrics-exporter sidecars (port name "metrics", default 9121).
+# Requires Prometheus Operator CRDs. Operator enables the exporter by default
+# (cluster.spec.exporter.enabled); disable the exporter there if you do not want metrics.
+metrics:
+  podMonitor:
+    enabled: false
+    # Container port name on the metrics-exporter sidecar
+    port: metrics
+    # Namespace for the PodMonitor (defaults to release namespace)
+    namespace: ""
+    # Extra labels on the PodMonitor object (e.g. prometheus release selector)
+    labels: {}
+    annotations: {}
+    interval: ""
+    scrapeTimeout: ""
+    honorLabels: false
+    scheme: ""
+    tlsConfig: {}
+    relabelings: []
+    metricRelabelings: []
+    podTargetLabels: []
+    sampleLimit: null
+    targetLimit: null
+    # Additional matchLabels merged into the pod selector (default selects
+    # valkey.io/cluster=<ValkeyCluster name> in the release namespace)
+    selector: {}
+
 # ValkeyCluster resource. Nested so future CR kinds (e.g. standalone, sentinel)
 # can sit beside this as valkey / sentinel without a generic top-level "spec".
 # v0.1: one ValkeyCluster per release. Later kinds stay one logical workload


### PR DESCRIPTION
## Summary

Adds an optional Prometheus Operator **PodMonitor** to `valkey-resources` for scraping ValkeyNode `metrics-exporter` sidecars (port name `metrics`, 9121).

Tracked as the next item after the chart scaffold (#220 implementation: PodMonitor for Valkey nodes).

## Why PodMonitor

Operator nodes expose exporter metrics on the pod (sidecar), not a dedicated metrics Service. ServiceMonitor remains on the `valkey-operator` chart for controller metrics.

Selector: `valkey.io/cluster=<ValkeyCluster name>` in the release namespace (matches operator pod labels).

## Usage

```yaml
metrics:
  podMonitor:
    enabled: true
    labels:
      release: prometheus
```

Exporter stays controlled by the CR (`cluster.spec.exporter`, on by default in the operator).

Chart version bump: `0.1.0` → `0.1.1`.

## Testing

- `helm lint ./valkey-resources`
- `helm unittest ./valkey-resources`
