### PR TITLE
fix(valkey): set certificate and key in Valkey health probes (#225)

### DIFF
--- a/valkey/templates/_helpers.tpl
+++ b/valkey/templates/_helpers.tpl
@@ -201,7 +201,7 @@ enabled, so callers should guard with `with`.
 {{- define "valkey.healthProbes" -}}
 {{- $cmd := list "valkey-cli" -}}
 {{- if $.Values.tls.enabled -}}
-{{- $cmd = concat $cmd (list "--cacert" (printf "/tls/%s" $.Values.tls.caPublicKey) "--tls") -}}
+{{- $cmd = concat $cmd (list "--cacert" (printf "/tls/%s" $.Values.tls.caPublicKey) "--cert" (printf "/tls/%s" $.Values.tls.serverPublicKey) "--key" (printf "/tls/%s" $.Values.tls.serverPublicKey) "--tls") -}}
 {{- end -}}
 {{- $cmd = append $cmd "ping" -}}
 {{- $probes := dict -}}


### PR DESCRIPTION
Add `--cert` and `--key` params to `valkey-cli` command in health checks when TLS is enabled.

Fix #225.