### PR TITLE
feat(valkey-resources): target operator v0.4.0

### DIFF
--- a/valkey-resources/CHANGELOG.md
+++ b/valkey-resources/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+## 0.1.2
+
+### Changed
+
+- `appVersion` defaults to operator **v0.4.0**. Workloads created from this chart must target a cluster whose ValkeyCluster CRD matches v0.4.0 (install or upgrade the `valkey-operator` chart / CRDs first). See the [v0.4.0 release notes](https://github.com/valkey-io/valkey-operator/releases/tag/v0.4.0).
+
+Breaking ValkeyCluster API changes in operator v0.4.0 that matter for `cluster.spec` drop-in values:
+
+- Placement fields live under `cluster.spec.scheduling` (`affinity`, `nodeSelector`, `tolerations`, `topologySpreadConstraints`, `priorityClassName`). Top-level copies of those fields are gone.
+- Node host spread: `cluster.spec.scheduling.node.spread.{shard,primaries,pods}.mode` (`Disabled` | `Preferred` | `Required`). Defaults are opt-in (`Disabled`). Prefer this over a bare hostname topology spread for shard anti-colocation.
+- `cluster.spec.podDisruptionBudget` is an object, e.g. `{ mode: Cluster }` or `{ mode: Disabled }` (no longer a bare string `Managed` / `Disabled`).
+
+## 0.1.1
+
+### Added
+
+- Optional Prometheus Operator PodMonitor for ValkeyNode `metrics-exporter` sidecars (`metrics.podMonitor`). Selector uses `valkey.io/cluster` matching the ValkeyCluster name.
+
+## 0.1.0
+
+### Added
+
+- Initial `valkey-resources` chart: one `ValkeyCluster` per release via `cluster.spec` drop-in.
+- Helm `tpl` on `cluster.spec`, labels, and annotations; top-level `extraValues` for template helpers.
+- Unit tests, values schema, release and unittest CI wiring.

--- a/valkey-resources/Chart.yaml
+++ b/valkey-resources/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: valkey-resources
 description: Helm chart for operator-managed Valkey resources (ValkeyCluster)
 type: application
-version: 0.1.1
-appVersion: "v0.3.0"
+version: 0.1.2
+appVersion: "v0.4.0"
 kubeVersion: ">=1.20.0-0"
 home: https://valkey.io/valkey-helm/
 sources:

--- a/valkey-resources/Chart.yaml
+++ b/valkey-resources/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey-resources
 description: Helm chart for operator-managed Valkey resources (ValkeyCluster)
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "v0.3.0"
 kubeVersion: ">=1.20.0-0"
 home: https://valkey.io/valkey-helm/

--- a/valkey-resources/README.md
+++ b/valkey-resources/README.md
@@ -1,6 +1,6 @@
 # valkey-resources
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.0](https://img.shields.io/badge/AppVersion-v0.3.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.0](https://img.shields.io/badge/AppVersion-v0.3.0-informational?style=flat-square)
 
 Deploys a single operator managed `ValkeyCluster`. Does not install the operator.
 
@@ -47,7 +47,23 @@ See [values.yaml](values.yaml) and the [ValkeyCluster API](https://github.com/va
 | `cluster.spec.shards` | Shard groups | `3` |
 | `cluster.spec.replicas` | Replicas per shard | `1` |
 | `extraValues` | Free-form map for use inside `tpl` strings | `{}` |
+| `metrics.podMonitor.enabled` | Create a PodMonitor for ValkeyNode exporter sidecars (Prometheus Operator CRDs) | `false` |
+| `metrics.podMonitor.port` | Scrape port name on the exporter container | `metrics` |
 | `fullnameOverride` | ValkeyCluster name | chart fullname |
+
+### Metrics (PodMonitor)
+
+Operator pods run a `metrics-exporter` sidecar (port name `metrics`, 9121) when `cluster.spec.exporter` is enabled (operator default). This chart can create a **PodMonitor** that selects pods with `valkey.io/cluster=<ValkeyCluster name>` in the release namespace:
+
+```yaml
+metrics:
+  podMonitor:
+    enabled: true
+    labels:
+      release: prometheus
+```
+
+Use PodMonitor (not ServiceMonitor): node metrics are on pods, not a dedicated Service. Operator controller metrics stay on the `valkey-operator` chart ServiceMonitor.
 
 **Release model:** one logical workload per Helm release. v0.1 only renders `ValkeyCluster`. When more kinds land, the chart will keep that model (enable the kinds you need for that one workload; multiple independent clusters remain multiple releases).
 

--- a/valkey-resources/README.md
+++ b/valkey-resources/README.md
@@ -1,6 +1,6 @@
 # valkey-resources
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.0](https://img.shields.io/badge/AppVersion-v0.3.0-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.0](https://img.shields.io/badge/AppVersion-v0.4.0-informational?style=flat-square)
 
 Deploys a single operator managed `ValkeyCluster`. Does not install the operator.
 
@@ -8,9 +8,9 @@ Deploys a single operator managed `ValkeyCluster`. Does not install the operator
 
 * Kubernetes 1.20+
 * Helm 3.5+
-* [valkey-operator](../valkey-operator/) installed (CRDs present)
+* [valkey-operator](../valkey-operator/) **v0.4.0+** installed (CRDs present)
 
-Without CRDs the API server rejects `ValkeyCluster` on apply.
+Without matching CRDs the API server rejects `ValkeyCluster` on apply. Helm does not upgrade CRDs for you; apply the operator chart CRDs when moving to v0.4.0. See [CHANGELOG.md](CHANGELOG.md) and the [operator v0.4.0 notes](https://github.com/valkey-io/valkey-operator/releases/tag/v0.4.0).
 
 ## Install
 
@@ -40,7 +40,30 @@ cluster:
         secretName: "{{ .Values.extraValues.tlsSecret }}"
 ```
 
-See [values.yaml](values.yaml) and the [ValkeyCluster API](https://github.com/valkey-io/valkey-operator/blob/main/docs/valkeycluster.md).
+### Operator v0.4.0 `cluster.spec` shape
+
+Placement and PDB fields changed in the CRD. Use the nested forms in values:
+
+```yaml
+cluster:
+  spec:
+    shards: 3
+    replicas: 1
+    podDisruptionBudget:
+      mode: Cluster   # or Disabled
+    scheduling:
+      priorityClassName: high-priority
+      node:
+        spread:
+          shard:
+            mode: Required    # same-shard pods not co-located (anti-affinity)
+          primaries:
+            mode: Preferred
+          pods:
+            mode: Disabled
+```
+
+See [values.yaml](values.yaml), [CHANGELOG.md](CHANGELOG.md), and the [ValkeyCluster API](https://github.com/valkey-io/valkey-operator/blob/main/docs/valkeycluster.md).
 
 | Parameter | Description | Default |
 |---|---|---|

--- a/valkey-resources/templates/NOTES.txt
+++ b/valkey-resources/templates/NOTES.txt
@@ -11,4 +11,12 @@ Watch status:
 List nodes:
   kubectl get valkeynodes -n {{ .Release.Namespace }}
 
+{{- if .Values.metrics.podMonitor.enabled }}
+
+PodMonitor: {{ include "valkey-resources.fullname" . }}
+  selector: valkey.io/cluster={{ include "valkey-resources.fullname" . }}
+  port: {{ .Values.metrics.podMonitor.port }}
+{{- end }}
+
 Docs: https://github.com/valkey-io/valkey-operator/blob/main/docs/valkeycluster.md
+

--- a/valkey-resources/templates/podmonitor.yaml
+++ b/valkey-resources/templates/podmonitor.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.metrics.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "valkey-resources.fullname" . }}
+  namespace: {{ .Values.metrics.podMonitor.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "valkey-resources.labels" . | nindent 4 }}
+    app.kubernetes.io/component: podmonitor
+    {{- with .Values.metrics.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.metrics.podMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      # Operator labels ValkeyNode pods with valkey.io/cluster=<ValkeyCluster name>
+      valkey.io/cluster: {{ include "valkey-resources.fullname" . | quote }}
+      {{- with .Values.metrics.podMonitor.selector }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  podMetricsEndpoints:
+    - port: {{ .Values.metrics.podMonitor.port }}
+      {{- with .Values.metrics.podMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.scheme }}
+      scheme: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.tlsConfig }}
+      tlsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.metrics.podMonitor.honorLabels }}
+      honorLabels: true
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.podMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- with .Values.metrics.podMonitor.podTargetLabels }}
+  podTargetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if not (empty .Values.metrics.podMonitor.sampleLimit) }}
+  sampleLimit: {{ .Values.metrics.podMonitor.sampleLimit }}
+  {{- end }}
+  {{- if not (empty .Values.metrics.podMonitor.targetLimit) }}
+  targetLimit: {{ .Values.metrics.podMonitor.targetLimit }}
+  {{- end }}
+{{- end }}

--- a/valkey-resources/tests/podmonitor_test.yaml
+++ b/valkey-resources/tests/podmonitor_test.yaml
@@ -1,0 +1,102 @@
+suite: podmonitor
+templates:
+  - templates/podmonitor.yaml
+tests:
+  - it: does not render PodMonitor by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders PodMonitor when enabled
+    set:
+      metrics.podMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodMonitor
+      - equal:
+          path: apiVersion
+          value: monitoring.coreos.com/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-resources
+      - equal:
+          path: spec.selector.matchLabels["valkey.io/cluster"]
+          value: RELEASE-NAME-valkey-resources
+      - equal:
+          path: spec.namespaceSelector.matchNames[0]
+          value: NAMESPACE
+      - equal:
+          path: spec.podMetricsEndpoints[0].port
+          value: metrics
+
+  - it: uses fullnameOverride for name and cluster selector
+    set:
+      fullnameOverride: my-cluster
+      metrics.podMonitor.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-cluster
+      - equal:
+          path: spec.selector.matchLabels["valkey.io/cluster"]
+          value: my-cluster
+
+  - it: honors PodMonitor namespace and scrape knobs
+    set:
+      metrics:
+        podMonitor:
+          enabled: true
+          namespace: monitoring
+          interval: 30s
+          scrapeTimeout: 10s
+          honorLabels: true
+          scheme: https
+          labels:
+            release: prometheus
+          annotations:
+            meta: test
+          podTargetLabels:
+            - valkey.io/shard-index
+          sampleLimit: 1000
+          targetLimit: 50
+          selector:
+            app.kubernetes.io/component: valkey-node
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: monitoring
+      - equal:
+          path: metadata.labels.release
+          value: prometheus
+      - equal:
+          path: metadata.annotations.meta
+          value: test
+      - equal:
+          path: spec.podMetricsEndpoints[0].interval
+          value: 30s
+      - equal:
+          path: spec.podMetricsEndpoints[0].scrapeTimeout
+          value: 10s
+      - equal:
+          path: spec.podMetricsEndpoints[0].scheme
+          value: https
+      - equal:
+          path: spec.podMetricsEndpoints[0].honorLabels
+          value: true
+      - equal:
+          path: spec.podTargetLabels[0]
+          value: valkey.io/shard-index
+      - equal:
+          path: spec.sampleLimit
+          value: 1000
+      - equal:
+          path: spec.targetLimit
+          value: 50
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: valkey-node
+      - equal:
+          path: spec.selector.matchLabels["valkey.io/cluster"]
+          value: RELEASE-NAME-valkey-resources

--- a/valkey-resources/tests/valkeycluster_test.yaml
+++ b/valkey-resources/tests/valkeycluster_test.yaml
@@ -113,7 +113,7 @@ tests:
     asserts:
       - equal:
           path: spec.image
-          value: valkey/valkey:v0.3.0
+          value: valkey/valkey:v0.4.0
       - equal:
           path: spec.tls.certificate.secretName
           value: RELEASE-NAME-tls

--- a/valkey-resources/values.schema.json
+++ b/valkey-resources/values.schema.json
@@ -12,6 +12,21 @@
       "additionalProperties": true,
       "description": "Free-form values referenced from templated strings in cluster.spec (and labels/annotations)."
     },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "podMonitor": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "port": { "type": ["string", "integer"] },
+            "namespace": { "type": "string" }
+          }
+        }
+      }
+    },
     "cluster": {
       "type": "object",
       "required": ["spec"],

--- a/valkey-resources/values.yaml
+++ b/valkey-resources/values.yaml
@@ -55,7 +55,9 @@ cluster:
   # Labels on the ValkeyCluster object (in addition to chart labels)
   labels: {}
 
-  # ValkeyCluster.spec drop-in (any CRD field allowed).
+  # ValkeyCluster.spec drop-in (any CRD field allowed). Tested against operator
+  # appVersion (v0.4.0): scheduling under spec.scheduling, PDB as {mode: ...},
+  # node.spread.shard|primaries|pods. See CHANGELOG.md.
   # Rendered via tpl so string values may use Helm templates, e.g.
   #   image: "valkey/valkey:{{ .Chart.AppVersion }}"
   #   tls.certificate.secretName: "{{ .Release.Name }}-tls"

--- a/valkey-resources/values.yaml
+++ b/valkey-resources/values.yaml
@@ -18,6 +18,33 @@ commonLabels: {}
 #           secretName: "{{ .Values.extraValues.tlsSecret }}"
 extraValues: {}
 
+# Scrape ValkeyNode metrics-exporter sidecars (port name "metrics", default 9121).
+# Requires Prometheus Operator CRDs. Operator enables the exporter by default
+# (cluster.spec.exporter.enabled); disable the exporter there if you do not want metrics.
+metrics:
+  podMonitor:
+    enabled: false
+    # Container port name on the metrics-exporter sidecar
+    port: metrics
+    # Namespace for the PodMonitor (defaults to release namespace)
+    namespace: ""
+    # Extra labels on the PodMonitor object (e.g. prometheus release selector)
+    labels: {}
+    annotations: {}
+    interval: ""
+    scrapeTimeout: ""
+    honorLabels: false
+    scheme: ""
+    tlsConfig: {}
+    relabelings: []
+    metricRelabelings: []
+    podTargetLabels: []
+    sampleLimit: null
+    targetLimit: null
+    # Additional matchLabels merged into the pod selector (default selects
+    # valkey.io/cluster=<ValkeyCluster name> in the release namespace)
+    selector: {}
+
 # ValkeyCluster resource. Nested so future CR kinds (e.g. standalone, sentinel)
 # can sit beside this as valkey / sentinel without a generic top-level "spec".
 # v0.1: one ValkeyCluster per release. Later kinds stay one logical workload


### PR DESCRIPTION
## Summary

Stacked on **#224** (PodMonitor). Bumps `valkey-resources` to **chart 0.1.2** / **appVersion v0.4.0** and adds a **CHANGELOG**.

Operator v0.4.0 broke several `ValkeyCluster` fields that this chart passes through as `cluster.spec`. Document those so chart users target the right CRD.

## Operator v0.4.0 notes (for `cluster.spec`)

- Placement under `scheduling` (`affinity`, `nodeSelector`, `tolerations`, `topologySpreadConstraints`, `priorityClassName`)
- Node host spread: `scheduling.node.spread.{shard,primaries,pods}.mode`
- `podDisruptionBudget` is `{ mode: Cluster | Disabled }` (not a bare string)

Install/upgrade **valkey-operator v0.4.0 CRDs** before applying workloads from this chart version. Helm does not upgrade CRDs automatically.

## Not in this PR

- Broader example values suite (minimal, TLS, persistence, etc.) — later
- No further PodMonitor changes (that is #224)

## Commits

1. PodMonitor (from #224)
2. This commit: appVersion + CHANGELOG + README for v0.4.0

Merge **after #224**, or merge both in order.

## Testing

- `helm lint ./valkey-resources`
- `helm unittest ./valkey-resources`
