### PR TITLE
chore: Add description for valkey-operator log level configuration

### DIFF
--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.1
+
+### Changed
+
+- Add log level configuration example to valkey-operator deployment.
+
 ## 0.4.0
 
 - Valkey Operator version defaults to v0.4.0. See the [v0.4.0 release notes](https://github.com/valkey-io/valkey-operator/releases/tag/v0.4.0) for the upstream changes.

--- a/valkey-operator/Chart.yaml
+++ b/valkey-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey-operator
 description: A Helm chart for the Valkey Operator
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: "v0.4.0"
 kubeVersion: ">=1.20.0-0"
 home: https://valkey.io/valkey-helm/

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -58,6 +58,9 @@ manager:
   #     - valkey-{{ .Values.myEnv }}
   watchNamespaces: []
   # Additional command-line arguments for the operator binary
+  # Example: set log verbosity
+  #   args:
+  #     - --zap-log-level=info    # debug, info, error
   args: []
 
 # Resource limits/requests for the operator container


### PR DESCRIPTION
This change adds comment to valkey-operator Helm chart values.yaml describing how to configure logs verbosity.

fixes: #229

Based on https://github.com/valkey-io/valkey-operator/issues/321#issuecomment-5046334501