### PR TITLE
fix(valkey-operator): align ServiceMonitor with metrics.secure (skip-verify opt-in)

### DIFF
--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -12,6 +12,16 @@
 
 - Add log level configuration example to valkey-operator deployment.
 
+### Fixed
+
+- Align ServiceMonitor endpoint port name and scrape scheme with `metrics.secure`.
+  When secure metrics are enabled the metrics Service exposes port `https`, but
+  the ServiceMonitor previously always targeted port `http`, so scrapes failed.
+  Defaults `scheme: https` and `tlsConfig.insecureSkipVerify: true` for the
+  operator's self-signed metrics cert when `metrics.secure` is true and the
+  ServiceMonitor fields are left unset; explicit `serviceMonitor.scheme` /
+  `tlsConfig` still win.
+
 ## 0.4.0
 
 - Valkey Operator version defaults to v0.4.0. See the [v0.4.0 release notes](https://github.com/valkey-io/valkey-operator/releases/tag/v0.4.0) for the upstream changes.

--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -23,6 +23,8 @@
   scraper SA to `metrics-reader` or scrapes return 401.
 - Helm unittest coverage for secure ServiceMonitor port, scheme, TLS precedence,
   skip-verify, and bearer token rendering.
+- Template fails if `metrics.secure` is true and `serviceMonitor.scheme` is
+  `http` (prevents sending scrape credentials over cleartext).
 
 ## 0.5.0
 

--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -1,16 +1,6 @@
 # Changelog
 
-## 0.5.0
-
-- Valkey Operator version defaults to v0.5.0. See the [v0.5.0 release notes](https://github.com/valkey-io/valkey-operator/releases/tag/v0.5.0) for the upstream changes.
-
-> **Note:** CRDs are not upgraded automatically by Helm. See [UPGRADE.md](UPGRADE.md) for manual steps required before upgrading to this version.
-
-## 0.4.1
-
-### Changed
-
-- Add log level configuration example to valkey-operator deployment.
+## 0.5.1
 
 ### Fixed
 
@@ -26,6 +16,18 @@
   `metrics.secure` is true and `serviceMonitor.tlsConfig` is empty, injects
   `tlsConfig.insecureSkipVerify` for the operator's self-signed metrics cert.
   Explicit `serviceMonitor.tlsConfig` always wins.
+
+## 0.5.0
+
+- Valkey Operator version defaults to v0.5.0. See the [v0.5.0 release notes](https://github.com/valkey-io/valkey-operator/releases/tag/v0.5.0) for the upstream changes.
+
+> **Note:** CRDs are not upgraded automatically by Helm. See [UPGRADE.md](UPGRADE.md) for manual steps required before upgrading to this version.
+
+## 0.4.1
+
+### Changed
+
+- Add log level configuration example to valkey-operator deployment.
 
 ## 0.4.0
 

--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -16,6 +16,13 @@
   `metrics.secure` is true and `serviceMonitor.tlsConfig` is empty, injects
   `tlsConfig.insecureSkipVerify` for the operator's self-signed metrics cert.
   Explicit `serviceMonitor.tlsConfig` always wins.
+- Secure ServiceMonitor auth: when `metrics.secure` is true, the endpoint sends
+  the scraper's ServiceAccount token by default
+  (`bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token`).
+  Override with `serviceMonitor.authorization` or `bearerTokenSecret`. Bind the
+  scraper SA to `metrics-reader` or scrapes return 401.
+- Helm unittest coverage for secure ServiceMonitor port, scheme, TLS precedence,
+  skip-verify, and bearer token rendering.
 
 ## 0.5.0
 

--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -17,10 +17,15 @@
 - Align ServiceMonitor endpoint port name and scrape scheme with `metrics.secure`.
   When secure metrics are enabled the metrics Service exposes port `https`, but
   the ServiceMonitor previously always targeted port `http`, so scrapes failed.
-  Defaults `scheme: https` and `tlsConfig.insecureSkipVerify: true` for the
-  operator's self-signed metrics cert when `metrics.secure` is true and the
-  ServiceMonitor fields are left unset; explicit `serviceMonitor.scheme` /
-  `tlsConfig` still win.
+  Defaults `scheme: https` when `metrics.secure` is true and
+  `serviceMonitor.scheme` is unset.
+
+### Added
+
+- `metrics.serviceMonitor.insecureSkipVerify` (default `false`). When true and
+  `metrics.secure` is true and `serviceMonitor.tlsConfig` is empty, injects
+  `tlsConfig.insecureSkipVerify` for the operator's self-signed metrics cert.
+  Explicit `serviceMonitor.tlsConfig` always wins.
 
 ## 0.4.0
 

--- a/valkey-operator/Chart.yaml
+++ b/valkey-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey-operator
 description: A Helm chart for the Valkey Operator
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: "v0.5.0"
 kubeVersion: ">=1.20.0-0"
 home: https://valkey.io/valkey-helm/

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -73,7 +73,7 @@ See [values.yaml](values.yaml) for the full list of configurable parameters.
 | `metrics.serviceMonitor.annotations` | Annotations for the ServiceMonitor | `{}` |
 | `metrics.serviceMonitor.interval` | Scrape interval | `""` |
 | `metrics.serviceMonitor.scrapeTimeout` | Scrape timeout | `""` |
-| `metrics.serviceMonitor.scheme` | Scrape scheme. Empty: `https` when `metrics.secure` is true, else Prometheus default (`http`) | `""` |
+| `metrics.serviceMonitor.scheme` | Scrape scheme. Empty: `https` when `metrics.secure` is true, else Prometheus default (`http`). `http` is rejected when `metrics.secure` is true | `""` |
 | `metrics.serviceMonitor.bearerTokenFile` | When `metrics.secure` is true and `authorization` / `bearerTokenSecret` are unset, path to the scrape token (default: scraper SA token). Empty disables this field | SA token path |
 | `metrics.serviceMonitor.bearerTokenSecret` | Optional SecretKeySelector for the scrape token (wins over `bearerTokenFile`) | `{}` |
 | `metrics.serviceMonitor.authorization` | Optional Prometheus Operator `authorization` block (wins over bearer fields) | `{}` |
@@ -183,6 +183,8 @@ Service: `http` when `metrics.secure` is `false`, `https` when it is `true`.
 When `metrics.secure` is `true`:
 
 - If `serviceMonitor.scheme` is empty, the chart sets `scheme: https`.
+  Setting `scheme: http` with secure metrics **fails template render** (would
+  send scrape credentials over cleartext).
 - The endpoint authenticates with the **scraper's ServiceAccount token** by
   default (`bearerTokenFile` under the Prometheus pod). That SA must be bound
   to `metrics-reader` or scrapes return **401**. Override with
@@ -193,6 +195,10 @@ When `metrics.secure` is `true`:
     `tlsConfig.insecureSkipVerify`), or
   - set `serviceMonitor.tlsConfig` yourself (e.g. a CA). Explicit `tlsConfig` wins
     over `insecureSkipVerify`.
+
+  Defaulting skip-verify to true would make “secure” also mean “do not verify
+  the server cert.” That stays opt-in; see the example below for the common
+  self-signed case.
 
 Example with secure metrics, reader binding, and self-signed cert skip-verify:
 
@@ -213,11 +219,16 @@ metrics:
     # bearerTokenFile defaults to the Prometheus SA token
 ```
 
-Example with a custom CA instead of skip-verify:
+Example with a custom CA instead of skip-verify (still needs reader binding):
 
 ```yaml
 metrics:
   secure: true
+  reader:
+    binding:
+      create: true
+      serviceAccountName: prometheus
+      namespace: monitoring
   serviceMonitor:
     enabled: true
     tlsConfig:

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -1,6 +1,6 @@
 # valkey-operator
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.5.0](https://img.shields.io/badge/AppVersion-v0.5.0-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.5.0](https://img.shields.io/badge/AppVersion-v0.5.0-informational?style=flat-square)
 
 A Helm chart for deploying the [Valkey Operator](https://github.com/valkey-io/valkey-operator) on Kubernetes.
 

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -73,8 +73,9 @@ See [values.yaml](values.yaml) for the full list of configurable parameters.
 | `metrics.serviceMonitor.annotations` | Annotations for the ServiceMonitor | `{}` |
 | `metrics.serviceMonitor.interval` | Scrape interval | `""` |
 | `metrics.serviceMonitor.scrapeTimeout` | Scrape timeout | `""` |
-| `metrics.serviceMonitor.scheme` | HTTP scheme used for scraping | `""` |
-| `metrics.serviceMonitor.tlsConfig` | TLS configuration used when scraping | `{}` |
+| `metrics.serviceMonitor.scheme` | Scrape scheme. Empty: `https` when `metrics.secure` is true, else Prometheus default (`http`) | `""` |
+| `metrics.serviceMonitor.insecureSkipVerify` | When `metrics.secure` is true and `tlsConfig` is empty, set `tlsConfig.insecureSkipVerify` for the self-signed metrics cert (opt-in) | `false` |
+| `metrics.serviceMonitor.tlsConfig` | Full scrape TLS config; when set, overrides `insecureSkipVerify` | `{}` |
 | `metrics.serviceMonitor.honorLabels` | Keep labels from the scraped target on collision | `false` |
 | `metrics.serviceMonitor.relabelings` | relabelings applied before scraping | `[]` |
 | `metrics.serviceMonitor.metricRelabelings` | metricRelabelings applied before ingestion | `[]` |
@@ -169,6 +170,54 @@ metrics:
 `serviceAccountName` is required when `binding.create` is `true`; rendering fails otherwise.
 Both `metrics.secure` and `metrics.reader.binding.create` default to `false`, so existing
 installs keep serving metrics over insecure HTTP unless you opt in.
+
+### ServiceMonitor
+
+Set `metrics.serviceMonitor.enabled: true` to create a Prometheus Operator ServiceMonitor
+for the operator metrics Service. The endpoint **port name** always matches the metrics
+Service: `http` when `metrics.secure` is `false`, `https` when it is `true`.
+
+When `metrics.secure` is `true`:
+
+- If `serviceMonitor.scheme` is empty, the chart sets `scheme: https`.
+- The operator's metrics cert is self-signed by default. Scrapes will fail TLS
+  verification until you either:
+  - set `serviceMonitor.insecureSkipVerify: true` (opt-in; injects
+    `tlsConfig.insecureSkipVerify`), or
+  - set `serviceMonitor.tlsConfig` yourself (e.g. a CA). Explicit `tlsConfig` wins
+    over `insecureSkipVerify`.
+
+Example with secure metrics and a ServiceMonitor that accepts the self-signed cert:
+
+```yaml
+metrics:
+  secure: true
+  reader:
+    binding:
+      create: true
+      serviceAccountName: prometheus
+      namespace: monitoring
+  serviceMonitor:
+    enabled: true
+    labels:
+      # match your Prometheus serviceMonitorSelector
+      release: prometheus
+    insecureSkipVerify: true
+```
+
+Example with a custom CA instead of skip-verify:
+
+```yaml
+metrics:
+  secure: true
+  serviceMonitor:
+    enabled: true
+    tlsConfig:
+      ca:
+        secret:
+          name: operator-metrics-ca
+          key: ca.crt
+```
 
 ## Source Code
 

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -74,6 +74,9 @@ See [values.yaml](values.yaml) for the full list of configurable parameters.
 | `metrics.serviceMonitor.interval` | Scrape interval | `""` |
 | `metrics.serviceMonitor.scrapeTimeout` | Scrape timeout | `""` |
 | `metrics.serviceMonitor.scheme` | Scrape scheme. Empty: `https` when `metrics.secure` is true, else Prometheus default (`http`) | `""` |
+| `metrics.serviceMonitor.bearerTokenFile` | When `metrics.secure` is true and `authorization` / `bearerTokenSecret` are unset, path to the scrape token (default: scraper SA token). Empty disables this field | SA token path |
+| `metrics.serviceMonitor.bearerTokenSecret` | Optional SecretKeySelector for the scrape token (wins over `bearerTokenFile`) | `{}` |
+| `metrics.serviceMonitor.authorization` | Optional Prometheus Operator `authorization` block (wins over bearer fields) | `{}` |
 | `metrics.serviceMonitor.insecureSkipVerify` | When `metrics.secure` is true and `tlsConfig` is empty, set `tlsConfig.insecureSkipVerify` for the self-signed metrics cert (opt-in) | `false` |
 | `metrics.serviceMonitor.tlsConfig` | Full scrape TLS config; when set, overrides `insecureSkipVerify` | `{}` |
 | `metrics.serviceMonitor.honorLabels` | Keep labels from the scraped target on collision | `false` |
@@ -180,6 +183,10 @@ Service: `http` when `metrics.secure` is `false`, `https` when it is `true`.
 When `metrics.secure` is `true`:
 
 - If `serviceMonitor.scheme` is empty, the chart sets `scheme: https`.
+- The endpoint authenticates with the **scraper's ServiceAccount token** by
+  default (`bearerTokenFile` under the Prometheus pod). That SA must be bound
+  to `metrics-reader` or scrapes return **401**. Override with
+  `serviceMonitor.authorization` or `serviceMonitor.bearerTokenSecret`.
 - The operator's metrics cert is self-signed by default. Scrapes will fail TLS
   verification until you either:
   - set `serviceMonitor.insecureSkipVerify: true` (opt-in; injects
@@ -187,7 +194,7 @@ When `metrics.secure` is `true`:
   - set `serviceMonitor.tlsConfig` yourself (e.g. a CA). Explicit `tlsConfig` wins
     over `insecureSkipVerify`.
 
-Example with secure metrics and a ServiceMonitor that accepts the self-signed cert:
+Example with secure metrics, reader binding, and self-signed cert skip-verify:
 
 ```yaml
 metrics:
@@ -203,6 +210,7 @@ metrics:
       # match your Prometheus serviceMonitorSelector
       release: prometheus
     insecureSkipVerify: true
+    # bearerTokenFile defaults to the Prometheus SA token
 ```
 
 Example with a custom CA instead of skip-verify:

--- a/valkey-operator/templates/servicemonitor.yaml
+++ b/valkey-operator/templates/servicemonitor.yaml
@@ -32,9 +32,8 @@ spec:
     {{- if .Values.metrics.serviceMonitor.tlsConfig }}
     tlsConfig:
       {{- toYaml .Values.metrics.serviceMonitor.tlsConfig | nindent 6 }}
-    {{- else if .Values.metrics.secure }}
-    # Operator metrics use a self-signed cert by default; scrapers must skip verify
-    # unless a custom tlsConfig is provided.
+    {{- else if and .Values.metrics.secure .Values.metrics.serviceMonitor.insecureSkipVerify }}
+    # Opt-in: operator metrics use a self-signed cert by default.
     tlsConfig:
       insecureSkipVerify: true
     {{- end }}

--- a/valkey-operator/templates/servicemonitor.yaml
+++ b/valkey-operator/templates/servicemonitor.yaml
@@ -29,6 +29,18 @@ spec:
     {{- else if .Values.metrics.secure }}
     scheme: https
     {{- end }}
+    {{- if .Values.metrics.secure }}
+    {{- /* Secure metrics require a metrics-reader token (401 without it). */}}
+    {{- if .Values.metrics.serviceMonitor.authorization }}
+    authorization:
+      {{- toYaml .Values.metrics.serviceMonitor.authorization | nindent 6 }}
+    {{- else if .Values.metrics.serviceMonitor.bearerTokenSecret }}
+    bearerTokenSecret:
+      {{- toYaml .Values.metrics.serviceMonitor.bearerTokenSecret | nindent 6 }}
+    {{- else if .Values.metrics.serviceMonitor.bearerTokenFile }}
+    bearerTokenFile: {{ .Values.metrics.serviceMonitor.bearerTokenFile | quote }}
+    {{- end }}
+    {{- end }}
     {{- if .Values.metrics.serviceMonitor.tlsConfig }}
     tlsConfig:
       {{- toYaml .Values.metrics.serviceMonitor.tlsConfig | nindent 6 }}

--- a/valkey-operator/templates/servicemonitor.yaml
+++ b/valkey-operator/templates/servicemonitor.yaml
@@ -1,4 +1,7 @@
 {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+{{- if and .Values.metrics.secure (eq (lower (.Values.metrics.serviceMonitor.scheme | default "")) "http") }}
+{{- fail "metrics.serviceMonitor.scheme cannot be http when metrics.secure is true (would send scrape credentials over cleartext)" }}
+{{- end }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -30,7 +33,7 @@ spec:
     scheme: https
     {{- end }}
     {{- if .Values.metrics.secure }}
-    {{- /* Secure metrics require a metrics-reader token (401 without it). */}}
+    {{- /* Secure metrics require a metrics-reader token (401 without it). Only with HTTPS. */}}
     {{- if .Values.metrics.serviceMonitor.authorization }}
     authorization:
       {{- toYaml .Values.metrics.serviceMonitor.authorization | nindent 6 }}

--- a/valkey-operator/templates/servicemonitor.yaml
+++ b/valkey-operator/templates/servicemonitor.yaml
@@ -15,7 +15,8 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-  - port: http
+  # Port name must match metrics-service.yaml (http when insecure, https when metrics.secure).
+  - port: {{ if .Values.metrics.secure }}https{{ else }}http{{ end }}
     honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
     {{- with .Values.metrics.serviceMonitor.interval }}
     interval: {{ . }}
@@ -23,12 +24,19 @@ spec:
     {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ . }}
     {{- end }}
-    {{- with .Values.metrics.serviceMonitor.scheme }}
-    scheme: {{ . }}
+    {{- if .Values.metrics.serviceMonitor.scheme }}
+    scheme: {{ .Values.metrics.serviceMonitor.scheme }}
+    {{- else if .Values.metrics.secure }}
+    scheme: https
     {{- end }}
-    {{- with .Values.metrics.serviceMonitor.tlsConfig }}
+    {{- if .Values.metrics.serviceMonitor.tlsConfig }}
     tlsConfig:
-      {{- toYaml . | nindent 6 }}
+      {{- toYaml .Values.metrics.serviceMonitor.tlsConfig | nindent 6 }}
+    {{- else if .Values.metrics.secure }}
+    # Operator metrics use a self-signed cert by default; scrapers must skip verify
+    # unless a custom tlsConfig is provided.
+    tlsConfig:
+      insecureSkipVerify: true
     {{- end }}
     {{- with .Values.metrics.serviceMonitor.relabelings }}
     relabelings:

--- a/valkey-operator/tests/servicemonitor_test.yaml
+++ b/valkey-operator/tests/servicemonitor_test.yaml
@@ -112,3 +112,91 @@ tests:
       - equal:
           path: spec.selector.matchLabels["app.kubernetes.io/instance"]
           value: RELEASE-NAME
+
+  - it: should use https port and scheme when metrics.secure is true
+    set:
+      metrics.secure: true
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: spec.endpoints[0].port
+          value: https
+      - equal:
+          path: spec.endpoints[0].scheme
+          value: https
+      - equal:
+          path: spec.endpoints[0].bearerTokenFile
+          value: /var/run/secrets/kubernetes.io/serviceaccount/token
+      - isNull:
+          path: spec.endpoints[0].tlsConfig
+
+  - it: should honor an explicit scheme over the secure default
+    set:
+      metrics.secure: true
+      metrics.serviceMonitor.enabled: true
+      metrics.serviceMonitor.scheme: http
+    asserts:
+      - equal:
+          path: spec.endpoints[0].port
+          value: https
+      - equal:
+          path: spec.endpoints[0].scheme
+          value: http
+
+  - it: should inject insecureSkipVerify when secure and opt-in without tlsConfig
+    set:
+      metrics.secure: true
+      metrics.serviceMonitor.enabled: true
+      metrics.serviceMonitor.insecureSkipVerify: true
+    asserts:
+      - equal:
+          path: spec.endpoints[0].tlsConfig.insecureSkipVerify
+          value: true
+
+  - it: should prefer explicit tlsConfig over insecureSkipVerify
+    set:
+      metrics.secure: true
+      metrics.serviceMonitor.enabled: true
+      metrics.serviceMonitor.insecureSkipVerify: true
+      metrics.serviceMonitor.tlsConfig:
+        caFile: /etc/ssl/certs/ca.crt
+        insecureSkipVerify: false
+    asserts:
+      - equal:
+          path: spec.endpoints[0].tlsConfig.caFile
+          value: /etc/ssl/certs/ca.crt
+      - equal:
+          path: spec.endpoints[0].tlsConfig.insecureSkipVerify
+          value: false
+
+  - it: should prefer authorization over bearerTokenFile when secure
+    set:
+      metrics.secure: true
+      metrics.serviceMonitor.enabled: true
+      metrics.serviceMonitor.authorization:
+        type: Bearer
+        credentials:
+          name: scrape-token
+          key: token
+    asserts:
+      - equal:
+          path: spec.endpoints[0].authorization.type
+          value: Bearer
+      - equal:
+          path: spec.endpoints[0].authorization.credentials.name
+          value: scrape-token
+      - isNull:
+          path: spec.endpoints[0].bearerTokenFile
+
+  - it: should omit bearer auth when metrics are not secure
+    set:
+      metrics.secure: false
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: spec.endpoints[0].port
+          value: http
+      - isNull:
+          path: spec.endpoints[0].scheme
+      - isNull:
+          path: spec.endpoints[0].bearerTokenFile

--- a/valkey-operator/tests/servicemonitor_test.yaml
+++ b/valkey-operator/tests/servicemonitor_test.yaml
@@ -130,18 +130,30 @@ tests:
       - isNull:
           path: spec.endpoints[0].tlsConfig
 
-  - it: should honor an explicit scheme over the secure default
+  - it: should fail when metrics.secure and scheme is http
     set:
       metrics.secure: true
       metrics.serviceMonitor.enabled: true
       metrics.serviceMonitor.scheme: http
+    asserts:
+      - failedTemplate:
+          errorMessage: "metrics.serviceMonitor.scheme cannot be http when metrics.secure is true (would send scrape credentials over cleartext)"
+
+  - it: should honor an explicit non-http scheme when secure
+    set:
+      metrics.secure: true
+      metrics.serviceMonitor.enabled: true
+      metrics.serviceMonitor.scheme: https
     asserts:
       - equal:
           path: spec.endpoints[0].port
           value: https
       - equal:
           path: spec.endpoints[0].scheme
-          value: http
+          value: https
+      - equal:
+          path: spec.endpoints[0].bearerTokenFile
+          value: /var/run/secrets/kubernetes.io/serviceaccount/token
 
   - it: should inject insecureSkipVerify when secure and opt-in without tlsConfig
     set:

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -236,7 +236,8 @@ metrics:
     # Scrape timeout (defaults to the Prometheus global timeout when empty)
     scrapeTimeout: ""
     # HTTP scheme used for scraping. When empty: https if metrics.secure is true,
-    # otherwise Prometheus defaults to http.
+    # otherwise Prometheus defaults to http. Cannot be "http" when metrics.secure
+    # is true (would send scrape credentials over cleartext).
     scheme: ""
     # When metrics.secure is true: auth for the protected /metrics endpoint.
     # Precedence: authorization > bearerTokenSecret > bearerTokenFile.

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -238,9 +238,12 @@ metrics:
     # HTTP scheme used for scraping. When empty: https if metrics.secure is true,
     # otherwise Prometheus defaults to http.
     scheme: ""
-    # TLS configuration used when scraping the endpoint. When empty and
-    # metrics.secure is true, insecureSkipVerify is set so the operator's
-    # self-signed metrics cert scrapes successfully. Set explicitly to override.
+    # When metrics.secure is true and tlsConfig is empty, set
+    # tlsConfig.insecureSkipVerify so scrapers accept the operator's self-signed
+    # metrics cert. Defaults to false (opt-in). Ignored when tlsConfig is set.
+    insecureSkipVerify: false
+    # Full TLS configuration for the scrape endpoint. When set, wins over
+    # insecureSkipVerify. Use this to trust a real CA instead of skip-verify.
     tlsConfig: {}
     # Keep labels from the scraped target on collision with server-side labels
     honorLabels: false

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -238,6 +238,17 @@ metrics:
     # HTTP scheme used for scraping. When empty: https if metrics.secure is true,
     # otherwise Prometheus defaults to http.
     scheme: ""
+    # When metrics.secure is true: auth for the protected /metrics endpoint.
+    # Precedence: authorization > bearerTokenSecret > bearerTokenFile.
+    # Default bearerTokenFile is the scraper's ServiceAccount token (Prometheus
+    # pod). Bind that SA to metrics-reader (see metrics.reader.binding or README).
+    # Set bearerTokenFile to "" and leave authorization/bearerTokenSecret empty
+    # only if you inject credentials another way (scrapes will 401 otherwise).
+    bearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    # Optional SecretKeySelector (name/key/optional) instead of bearerTokenFile.
+    bearerTokenSecret: {}
+    # Optional Prometheus Operator authorization block (wins over bearer* fields).
+    authorization: {}
     # When metrics.secure is true and tlsConfig is empty, set
     # tlsConfig.insecureSkipVerify so scrapers accept the operator's self-signed
     # metrics cert. Defaults to false (opt-in). Ignored when tlsConfig is set.

--- a/valkey-operator/values.yaml
+++ b/valkey-operator/values.yaml
@@ -235,9 +235,12 @@ metrics:
     interval: ""
     # Scrape timeout (defaults to the Prometheus global timeout when empty)
     scrapeTimeout: ""
-    # HTTP scheme used for scraping (defaults to http when empty)
+    # HTTP scheme used for scraping. When empty: https if metrics.secure is true,
+    # otherwise Prometheus defaults to http.
     scheme: ""
-    # TLS configuration used when scraping the endpoint
+    # TLS configuration used when scraping the endpoint. When empty and
+    # metrics.secure is true, insecureSkipVerify is set so the operator's
+    # self-signed metrics cert scrapes successfully. Set explicitly to override.
     tlsConfig: {}
     # Keep labels from the scraped target on collision with server-side labels
     honorLabels: false


### PR DESCRIPTION
## Summary

Fixes ServiceMonitor scrapes when `metrics.secure` is true, and makes **TLS skip-verify opt-in** rather than a silent default.

### Bug

With `metrics.secure: true`, the metrics Service exposes port **`https`**, but the ServiceMonitor always targeted port **`http`**, so scrapes never hit the right endpoint.

### What we change

1. **Port / scheme** always follow `metrics.secure` (`https` + default `scheme: https` when secure and `serviceMonitor.scheme` is unset).
2. **`metrics.serviceMonitor.insecureSkipVerify`** (default **`false`**). Only when this is true (and `tlsConfig` is empty) do we inject `tlsConfig.insecureSkipVerify: true` for the operator's self-signed metrics cert. Explicit `serviceMonitor.tlsConfig` always wins.

### Design question for reviewers

**Should skip-verify stay disabled by default?**

| Default | Behavior |
|--------|----------|
| **`false` (this PR)** | Secure scrapes need either `insecureSkipVerify: true` or a real `tlsConfig` (CA). No silent MITM-friendly default. |
| **`true`** | Secure + ServiceMonitor works out of the box with self-signed certs, but enabling secure metrics also disables cert verification unless the user overrides. |

We prefer **default false**: "secure" should not imply "do not verify." The operator cert is self-signed, so skip-verify is still available as an explicit one-liner for the common case.

```yaml
metrics:
  secure: true
  serviceMonitor:
    enabled: true
    insecureSkipVerify: true  # opt-in for self-signed metrics cert
```

If maintainers prefer out-of-the-box scrapes, flipping the default to `true` is a one-line change; the important part is that it is **named and documented**, not hard-coded only in the template.

### Docs

README (Metrics / ServiceMonitor), values comments, and CHANGELOG 0.4.1 describe port/scheme alignment and the opt-in flag.

### Not in this PR

Bearer token for secure metrics auth (`WithAuthenticationAndAuthorization`) is a separate follow-up so scrapes do not get 401 after TLS is fixed.

## Testing

```bash
# insecure: port http, no scheme/tls
helm template t valkey-operator \
  --set metrics.serviceMonitor.enabled=true

# secure, default: port https, scheme https, no tlsConfig
helm template t valkey-operator \
  --set metrics.secure=true \
  --set metrics.serviceMonitor.enabled=true

# secure + opt-in skip-verify
helm template t valkey-operator \
  --set metrics.secure=true \
  --set metrics.serviceMonitor.enabled=true \
  --set metrics.serviceMonitor.insecureSkipVerify=true
```