### PR TITLE
feat(valkey): add Valkey Sentinel for automatic failover

### DIFF
--- a/valkey/.helmignore
+++ b/valkey/.helmignore
@@ -24,5 +24,7 @@
 
 .github/
 
-# Unit tests (only ignore root-level tests/, not templates/tests/)
+# Example values files and unit tests (only ignore root-level tests/, not templates/tests/)
 /tests/
+/examples/
+

--- a/valkey/Chart.yaml
+++ b/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: A Helm chart for Kubernetes
 type: application
-version: 0.11.0
+version: 0.12.0
 appVersion: "9.1.1"
 home: https://valkey.io/valkey-helm/
 sources:

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -89,7 +89,7 @@ topologySpreadConstraints:
 
 **Services:**
 
-* `valkey`: load balances across all pods, the master can be any of them
+* `valkey`: load balances across all pods, the master can be any of them, so it is labelled `app.kubernetes.io/component: nodes` rather than `primary` and is not a write endpoint
 * `valkey-sentinel`: Sentinel endpoints, used by clients to resolve the current master
 * `valkey-headless`: headless service for Valkey pod discovery
 * `valkey-sentinel-headless`: headless service for Sentinel peer discovery

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -144,8 +144,10 @@ The replication topology survives a full restart of the StatefulSet: each pod as
 
 On a cold start the Sentinels are restarting too, and a Sentinel cannot name a master until a Valkey node is up, so waiting for one would leave both halves waiting for each other.
 Each pod therefore mirrors the current master onto its data volume, as a host and a port with no credential in it, every `replica.sentinel.masterRecordRefreshSeconds`.
-A pod that finds no Sentinel comes back in that recorded role instead of refusing to start, which puts nodes on the network for the Sentinels to find.
-A pod with neither a Sentinel nor a record still refuses to start rather than guess.
+A pod that finds no Sentinel first asks the other Valkey nodes whether one of them is already up as the primary, and follows that answer if it gets one.
+A node that is running outranks the record, both because a pod that was down across a failover still has its own name in its record, which would bring it back writable next to the node that was promoted, and because the record may name a node that has since been demoted.
+Only when nothing answers does the record decide, which is what puts nodes on the network for the Sentinels to find.
+A pod with neither a Sentinel, nor a running node, nor a record still refuses to start rather than guess.
 
 The record is read from the config file Valkey rewrites when Sentinel changes a pod's role, so it needs no credentials.
 A rewrite empties that file before filling it again, and a check landing in between sees no `replicaof` line, which is indistinguishable from a promotion.

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -149,7 +149,7 @@ A pod that finds no Sentinel first asks the other Valkey nodes whether one of th
 A node that is running outranks the record, both because a pod that was down across a failover still has its own name in its record, which would bring it back writable next to the node that was promoted, and because the record may name a node that has since been demoted.
 Only when nothing answers does the record decide, which is what puts nodes on the network for the Sentinels to find.
 A pod with neither a Sentinel, nor a running node, nor a record waits up to `replica.sentinel.initialTopologyWaitSeconds` for one of them and then refuses to start rather than guess.
-That wait is what a first install spends: the Sentinels bootstrap a master once their own `replica.sentinel.startupTimeoutSeconds` expires, and the pod is simply there to be told, so the value has to stay comfortably above it.
+That wait is what a first install spends: the Sentinels bootstrap a master once their own `replica.sentinel.startupTimeoutSeconds` expires, and the pod is simply there to be told, so the chart refuses to render unless the wait is at least 30 seconds above it.
 
 The record is read from the config file Valkey rewrites when Sentinel changes a pod's role, so it needs no credentials.
 A rewrite empties that file before filling it again, and a check landing in between sees no `replicaof` line, which is indistinguishable from a promotion.

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -130,7 +130,8 @@ Changing `replica.sentinel.persistence.enabled` later changes the Sentinel State
 
 A master that stops responding for `replica.sentinel.downAfterMilliseconds` is replaced within a few seconds.
 When a master pod is terminated by a rolling update, its `preStop` hook asks Sentinel to promote a replica first, so the failover happens before the pod goes away rather than after.
-The replication topology survives a full restart of the StatefulSet: each pod restores the replication target Sentinel last wrote, and each Sentinel rediscovers the current master instead of assuming it is pod-0.
+The replication topology survives a full restart of the StatefulSet: each pod asks Sentinel for the current master instead of assuming it is pod-0.
+To avoid starting with a stale role, a restarted pod with existing state waits for Sentinel discovery to become available.
 
 ## Cluster Mode
 

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -63,21 +63,23 @@ If fewer than `minReplicasToWrite` replicas are available, the master will rejec
 ### High Availability Mode (Sentinel)
 
 Replication mode alone does not recover from a master failure: the master is always pod-0 and a client keeps writing to it until an operator intervenes.
-Enabling Sentinel adds a `valkey-sentinel` container to every Valkey pod.
+Enabling Sentinel creates a separate StatefulSet with three Sentinel pods by default.
 The Sentinels monitor each other and the Valkey nodes, and promote a replica automatically when the master stops responding.
 
 ```bash
 helm install valkey valkey/valkey -f examples/ha-sentinel.yaml
 ```
 
-Sentinel needs at least three pods to form a quorum, so `replica.replicas` must be 2 or more.
+Sentinel needs at least three instances to form a quorum, independently of the Valkey pod count.
+Valkey still needs at least one replica to provide a failover target.
 See [examples/ha-sentinel.yaml](examples/ha-sentinel.yaml) for a complete values file.
 
 **Services:**
 
 * `valkey`: load balances across all pods, the master can be any of them
 * `valkey-sentinel`: Sentinel endpoints, used by clients to resolve the current master
-* `valkey-headless`: headless service for pod and Sentinel discovery
+* `valkey-headless`: headless service for Valkey pod discovery
+* `valkey-sentinel-headless`: headless service for Sentinel peer discovery
 
 **Connecting:**
 
@@ -108,17 +110,8 @@ The minimum permissions are:
 +config|rewrite +client|setname +client|kill +script|kill +psync +replconf
 ```
 
-**Enabling Sentinel on an existing release:**
-
-`podManagementPolicy` is immutable, and the chart switches it to `Parallel` when Sentinel is enabled, so `helm upgrade` on an existing replication release is rejected by Kubernetes.
-Either set `replica.podManagementPolicy: OrderedReady` to keep the current value, or recreate the StatefulSet while keeping the pods and volumes:
-
-```bash
-kubectl delete statefulset <release>-valkey --cascade=orphan
-helm upgrade <release> valkey/valkey -f your-values.yaml
-```
-
-The same applies to `replica.sentinel.persistence.enabled`, which adds a `volumeClaimTemplates` entry.
+Sentinel can be enabled on an existing replication release without changing the Valkey StatefulSet's immutable fields.
+Changing `replica.sentinel.persistence.enabled` later changes the Sentinel StatefulSet's `volumeClaimTemplates` and therefore requires recreating that StatefulSet.
 
 **Failover behaviour:**
 
@@ -440,6 +433,7 @@ tls:
 | replica.persistence.storageClass | string | `""` |  |
 | replica.persistence.accessModes | list | `""` |  |
 | replica.sentinel.enabled | bool | `false` | Run Valkey Sentinel for automatic failover |
+| replica.sentinel.replicas | int | `3` | Number of independently deployed Sentinel pods |
 | replica.sentinel.port | int | `26379` |  |
 | replica.sentinel.masterSet | string | `"mymaster"` |  |
 | replica.sentinel.quorum | int | `2` | Sentinels that must agree before a failover starts |
@@ -462,6 +456,7 @@ tls:
 | replica.sentinel.persistence.enabled | bool | `false` |  |
 | replica.sentinel.persistence.size | string | `"100Mi"` |  |
 | replica.sentinel.persistence.storageClass | string | `""` |  |
+| replica.sentinel.persistentVolumeClaimRetentionPolicy | object | `{}` | PVC retention policy for the Sentinel StatefulSet |
 | resources | object | `{}` |  |
 | securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | securityContext.readOnlyRootFilesystem | bool | `true` |  |

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -74,6 +74,19 @@ Sentinel needs at least three instances to form a quorum, independently of the V
 Valkey still needs at least one replica to provide a failover target.
 See [examples/ha-sentinel.yaml](examples/ha-sentinel.yaml) for a complete values file.
 
+Spread Sentinel pods across failure domains so one node or zone cannot remove the quorum.
+The existing global `topologySpreadConstraints` value applies to both StatefulSets, and a selector for the Sentinel component limits the rule to Sentinel pods:
+
+```yaml
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/component: sentinel
+```
+
 **Services:**
 
 * `valkey`: load balances across all pods, the master can be any of them

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -147,6 +147,10 @@ Each pod therefore mirrors the current master onto its data volume, as a host an
 A pod that finds no Sentinel comes back in that recorded role instead of refusing to start, which puts nodes on the network for the Sentinels to find.
 A pod with neither a Sentinel nor a record still refuses to start rather than guess.
 
+The record is read from the config file Valkey rewrites when Sentinel changes a pod's role, so it needs no credentials, and a reading has to hold for two consecutive checks before it is written, so a read taken while Valkey is rewriting that file cannot land in it.
+It is therefore about two intervals behind reality, one second by default.
+A promotion followed inside that window by the loss of every pod at once still comes back on the pre-promotion topology: agreeing on a master when no node can be reached is a consensus problem rather than a record keeping one, and this chart does not solve it.
+
 ## Cluster Mode
 
 This chart does not and will not support **Valkey cluster** mode. Managing a clustered topology is fundamentally different from standalone or replicated deployments, and the operational requirements go well beyond what this chart is designed to handle.
@@ -464,7 +468,7 @@ tls:
 | replica.sentinel.replicas | int | `3` | Number of independently deployed Sentinel pods |
 | replica.sentinel.port | int | `26379` |  |
 | replica.sentinel.masterSet | string | `"mymaster"` |  |
-| replica.sentinel.masterRecordRefreshSeconds | int | `10` | How stale the cold-start topology record can be |
+| replica.sentinel.masterRecordRefreshSeconds | int | `1` | How often the cold-start topology record is checked against the running config |
 | replica.sentinel.quorum | int | `2` | Sentinels that must agree before a failover starts |
 | replica.sentinel.downAfterMilliseconds | int | `5000` |  |
 | replica.sentinel.failoverTimeout | int | `60000` |  |

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -141,7 +141,11 @@ It is off by default and not needed, because each Sentinel rediscovers the curre
 A master that stops responding for `replica.sentinel.downAfterMilliseconds` is replaced within a few seconds.
 When a master pod is terminated by a rolling update, its `preStop` hook asks Sentinel to promote a replica first, so the failover happens before the pod goes away rather than after.
 The replication topology survives a full restart of the StatefulSet: each pod asks Sentinel for the current master instead of assuming it is pod-0.
-To avoid starting with a stale role, every Valkey pod waits for Sentinel discovery to become available before it starts.
+
+On a cold start the Sentinels are restarting too, and a Sentinel cannot name a master until a Valkey node is up, so waiting for one would leave both halves waiting for each other.
+Each pod therefore mirrors the current master onto its data volume, as a host and a port with no credential in it, every `replica.sentinel.masterRecordRefreshSeconds`.
+A pod that finds no Sentinel comes back in that recorded role instead of refusing to start, which puts nodes on the network for the Sentinels to find.
+A pod with neither a Sentinel nor a record still refuses to start rather than guess.
 
 ## Cluster Mode
 
@@ -460,6 +464,7 @@ tls:
 | replica.sentinel.replicas | int | `3` | Number of independently deployed Sentinel pods |
 | replica.sentinel.port | int | `26379` |  |
 | replica.sentinel.masterSet | string | `"mymaster"` |  |
+| replica.sentinel.masterRecordRefreshSeconds | int | `10` | How stale the cold-start topology record can be |
 | replica.sentinel.quorum | int | `2` | Sentinels that must agree before a failover starts |
 | replica.sentinel.downAfterMilliseconds | int | `5000` |  |
 | replica.sentinel.failoverTimeout | int | `60000` |  |

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -126,6 +126,16 @@ The minimum permissions are:
 Sentinel can be enabled on an existing replication release without changing the Valkey StatefulSet's immutable fields.
 Changing `replica.sentinel.persistence.enabled` later changes the Sentinel StatefulSet's `volumeClaimTemplates` and therefore requires recreating that StatefulSet.
 
+**Credentials on disk:**
+
+Valkey needs the replication password in plain text in its configuration, and `CONFIG REWRITE` writes it back on every failover even if the chart does not.
+The configuration therefore lives on a memory backed `emptyDir` rather than on the data volume, so no credential is written to persistent storage.
+The ACL file is hashed and also memory backed, and the Sentinel state is memory backed for the same reason, since Sentinel rewrites `auth-pass` and `sentinel-pass` into `sentinel.conf`.
+Only the RDB or AOF and the init log stay on the data volume.
+
+Enabling `replica.sentinel.persistence` opts out of this and puts `sentinel.conf`, credentials included, on a PersistentVolume.
+It is off by default and not needed, because each Sentinel rediscovers the current master on startup.
+
 **Failover behaviour:**
 
 A master that stops responding for `replica.sentinel.downAfterMilliseconds` is replaced within a few seconds.

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -148,7 +148,8 @@ Each pod therefore mirrors the current master onto its data volume, as a host an
 A pod that finds no Sentinel first asks the other Valkey nodes whether one of them is already up as the primary, and follows that answer if it gets one.
 A node that is running outranks the record, both because a pod that was down across a failover still has its own name in its record, which would bring it back writable next to the node that was promoted, and because the record may name a node that has since been demoted.
 Only when nothing answers does the record decide, which is what puts nodes on the network for the Sentinels to find.
-A pod with neither a Sentinel, nor a running node, nor a record still refuses to start rather than guess.
+A pod with neither a Sentinel, nor a running node, nor a record waits up to `replica.sentinel.initialTopologyWaitSeconds` for one of them and then refuses to start rather than guess.
+That wait is what a first install spends: the Sentinels bootstrap a master once their own `replica.sentinel.startupTimeoutSeconds` expires, and the pod is simply there to be told, so the value has to stay comfortably above it.
 
 The record is read from the config file Valkey rewrites when Sentinel changes a pod's role, so it needs no credentials.
 A rewrite empties that file before filling it again, and a check landing in between sees no `replicaof` line, which is indistinguishable from a promotion.
@@ -481,6 +482,7 @@ tls:
 | replica.sentinel.replicas | int | `3` | Number of independently deployed Sentinel pods |
 | replica.sentinel.port | int | `26379` |  |
 | replica.sentinel.masterSet | string | `"mymaster"` |  |
+| replica.sentinel.initialTopologyWaitSeconds | int | `180` | How long a pod with no recorded topology waits to be told one before giving up |
 | replica.sentinel.masterRecordRefreshSeconds | int | `1` | How often the cold-start topology record is checked against the running config |
 | replica.sentinel.quorum | int | `2` | Sentinels that must agree before a failover starts |
 | replica.sentinel.downAfterMilliseconds | int | `5000` |  |

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -147,9 +147,14 @@ Each pod therefore mirrors the current master onto its data volume, as a host an
 A pod that finds no Sentinel comes back in that recorded role instead of refusing to start, which puts nodes on the network for the Sentinels to find.
 A pod with neither a Sentinel nor a record still refuses to start rather than guess.
 
-The record is read from the config file Valkey rewrites when Sentinel changes a pod's role, so it needs no credentials, and a reading has to hold for two consecutive checks before it is written, so a read taken while Valkey is rewriting that file cannot land in it.
-It is therefore about two intervals behind reality, one second by default.
-A promotion followed inside that window by the loss of every pod at once still comes back on the pre-promotion topology: agreeing on a master when no node can be reached is a consensus problem rather than a record keeping one, and this chart does not solve it.
+The record is read from the config file Valkey rewrites when Sentinel changes a pod's role, so it needs no credentials.
+A rewrite empties that file before filling it again, and a check landing in between sees no `replicaof` line, which is indistinguishable from a promotion.
+A pod naming itself as the master therefore has to see that on two consecutive checks, while a pod that finds a master to follow records it on the first, since a partial read can drop a `replicaof` line but cannot invent one.
+The record is one interval behind a demotion and two behind a promotion, one second each by default.
+
+A promotion followed inside that window by the loss of every pod at once no longer hands writes back to the demoted node, because that node recorded its demotion on the first check.
+It comes back as a replica of a node that is not yet primary, which costs a resync once Sentinel settles the topology, not the writes.
+Agreeing on a primary when no node can be reached is a consensus problem rather than a record keeping one, and this chart does not solve it.
 
 ## Cluster Mode
 

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -106,6 +106,18 @@ The minimum permissions are:
 +config|rewrite +client|setname +client|kill +script|kill +psync +replconf
 ```
 
+**Enabling Sentinel on an existing release:**
+
+`podManagementPolicy` is immutable, and the chart switches it to `Parallel` when Sentinel is enabled, so `helm upgrade` on an existing replication release is rejected by Kubernetes.
+Either set `replica.podManagementPolicy: OrderedReady` to keep the current value, or recreate the StatefulSet while keeping the pods and volumes:
+
+```bash
+kubectl delete statefulset <release>-valkey --cascade=orphan
+helm upgrade <release> valkey/valkey -f your-values.yaml
+```
+
+The same applies to `replica.sentinel.persistence.enabled`, which adds a `volumeClaimTemplates` entry.
+
 **Failover behaviour:**
 
 A master that stops responding for `replica.sentinel.downAfterMilliseconds` is replaced within a few seconds.

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -96,7 +96,9 @@ Writes sent to the `valkey` service directly may land on a replica and fail with
 
 **Authentication:**
 
-When `auth.enabled` is true, Sentinel reuses the `default` user password to secure its own port and the Sentinel-to-Sentinel gossip.
+When `auth.enabled` is true, set `replica.sentinel.password` to a credential used only for the Sentinel endpoint.
+With `auth.usersExistingSecret`, store that credential under `replica.sentinel.passwordKey` (default: `sentinel`) instead.
+Valkey user passwords are deliberately not accepted by Sentinel, so restrictions on application ACL users cannot be bypassed through Sentinel commands.
 Sentinel reaches the Valkey nodes as `replica.sentinel.monitorUser`, which defaults to `replica.replicationUser`.
 That user must be allowed to promote a replica, otherwise every failover aborts with `-failover-abort-slave-timeout`.
 The minimum permissions are:
@@ -445,6 +447,8 @@ tls:
 | replica.sentinel.failoverTimeout | int | `60000` |  |
 | replica.sentinel.parallelSyncs | int | `1` |  |
 | replica.sentinel.monitorUser | string | `""` | Defaults to replica.replicationUser |
+| replica.sentinel.password | string | `""` | Dedicated Sentinel ACL password; required with auth unless supplied by auth.usersExistingSecret |
+| replica.sentinel.passwordKey | string | `"sentinel"` | Key containing the Sentinel password in auth.usersExistingSecret |
 | replica.sentinel.preStopFailover | bool | `true` | Fail over before a master pod is terminated |
 | replica.sentinel.preStopFailoverTimeoutSeconds | int | `20` |  |
 | replica.sentinel.startupTimeoutSeconds | int | `60` |  |

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -153,8 +153,13 @@ A pod naming itself as the master therefore has to see that on two consecutive c
 The record is one interval behind a demotion and two behind a promotion, one second each by default.
 
 A promotion followed inside that window by the loss of every pod at once no longer hands writes back to the demoted node, because that node recorded its demotion on the first check.
-It comes back as a replica of a node that is not yet primary, which costs a resync once Sentinel settles the topology, not the writes.
+What can still happen is that a pod which was down during a failover comes back following a node that has since been demoted, so it replicates through that node rather than from the primary.
 Agreeing on a primary when no node can be reached is a consensus problem rather than a record keeping one, and this chart does not solve it.
+
+Sentinel cannot repair that on its own, because it only learns which nodes are replicas by asking the primary, and a node replicating from a replica is not in that answer.
+Each Sentinel therefore checks every `replica.sentinel.orphanCheckSeconds` for a node that is replicating from something other than the current primary and that Sentinel does not list, and points it back at the primary.
+It only touches nodes Sentinel cannot see, which are exactly the ones Sentinel is not reconfiguring itself, and it stands down entirely while the primary is not plainly up.
+A node that answers as a primary is left alone and logged rather than demoted.
 
 ## Cluster Mode
 
@@ -479,6 +484,7 @@ tls:
 | replica.sentinel.failoverTimeout | int | `60000` |  |
 | replica.sentinel.parallelSyncs | int | `1` |  |
 | replica.sentinel.monitorUser | string | `""` | Defaults to replica.replicationUser |
+| replica.sentinel.orphanCheckSeconds | int | `30` | How often each Sentinel looks for a node replicating from something it cannot see |
 | replica.sentinel.password | string | `""` | Dedicated Sentinel ACL password; required with Sentinel unless supplied by auth.usersExistingSecret |
 | replica.sentinel.passwordKey | string | `"sentinel"` | Key containing the Sentinel password in auth.usersExistingSecret |
 | replica.sentinel.preStopFailover | bool | `true` | Fail over before a master pod is terminated |

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -131,7 +131,7 @@ Changing `replica.sentinel.persistence.enabled` later changes the Sentinel State
 A master that stops responding for `replica.sentinel.downAfterMilliseconds` is replaced within a few seconds.
 When a master pod is terminated by a rolling update, its `preStop` hook asks Sentinel to promote a replica first, so the failover happens before the pod goes away rather than after.
 The replication topology survives a full restart of the StatefulSet: each pod asks Sentinel for the current master instead of assuming it is pod-0.
-To avoid starting with a stale role, a restarted pod with existing state waits for Sentinel discovery to become available.
+To avoid starting with a stale role, every Valkey pod waits for Sentinel discovery to become available before it starts.
 
 ## Cluster Mode
 

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -42,14 +42,6 @@ helm install valkey valkey/valkey --set replica.enabled=true --set replica.persi
 
 **IMPORTANT**
 
-## Cluster Mode
-
-This chart does not and will not support **Valkey cluster** mode. Managing a clustered topology is fundamentally different from standalone or replicated deployments, and the operational requirements go well beyond what this chart is designed to handle.
-
-For cluster mode, a separate chart is being developed that uses the valkey-operator to deploy and manage clusters. The operator must be installed first.
-
-To follow progress or get involved, see the [weekly meeting wiki](https://github.com/valkey-io/valkey-operator/wiki/Weekly-meeting). 
-
 **Services:**
 
 * `valkey`: Master/write service
@@ -67,6 +59,66 @@ replica:
 ```
 
 If fewer than `minReplicasToWrite` replicas are available, the master will reject write operations.
+
+### High Availability Mode (Sentinel)
+
+Replication mode alone does not recover from a master failure: the master is always pod-0 and a client keeps writing to it until an operator intervenes.
+Enabling Sentinel adds a `valkey-sentinel` container to every Valkey pod.
+The Sentinels monitor each other and the Valkey nodes, and promote a replica automatically when the master stops responding.
+
+```bash
+helm install valkey valkey/valkey -f examples/ha-sentinel.yaml
+```
+
+Sentinel needs at least three pods to form a quorum, so `replica.replicas` must be 2 or more.
+See [examples/ha-sentinel.yaml](examples/ha-sentinel.yaml) for a complete values file.
+
+**Services:**
+
+* `valkey`: load balances across all pods, the master can be any of them
+* `valkey-sentinel`: Sentinel endpoints, used by clients to resolve the current master
+* `valkey-headless`: headless service for pod and Sentinel discovery
+
+**Connecting:**
+
+Because the master moves, clients must ask Sentinel for its address instead of connecting to a fixed pod.
+Most client libraries do this for you:
+
+```python
+from valkey.sentinel import Sentinel
+
+sentinel = Sentinel([("valkey-sentinel", 26379)], password="...")
+master = sentinel.master_for("mymaster")
+master.set("key", "value")
+```
+
+Writes sent to the `valkey` service directly may land on a replica and fail with `-READONLY`.
+
+**Authentication:**
+
+When `auth.enabled` is true, Sentinel reuses the `default` user password to secure its own port and the Sentinel-to-Sentinel gossip.
+Sentinel reaches the Valkey nodes as `replica.sentinel.monitorUser`, which defaults to `replica.replicationUser`.
+That user must be allowed to promote a replica, otherwise every failover aborts with `-failover-abort-slave-timeout`.
+The minimum permissions are:
+
+```
+~* &* +multi +exec +ping +info +role +subscribe +publish +slaveof +replicaof
++config|rewrite +client|setname +client|kill +script|kill +psync +replconf
+```
+
+**Failover behaviour:**
+
+A master that stops responding for `replica.sentinel.downAfterMilliseconds` is replaced within a few seconds.
+When a master pod is terminated by a rolling update, its `preStop` hook asks Sentinel to promote a replica first, so the failover happens before the pod goes away rather than after.
+The replication topology survives a full restart of the StatefulSet: each pod restores the replication target Sentinel last wrote, and each Sentinel rediscovers the current master instead of assuming it is pod-0.
+
+## Cluster Mode
+
+This chart does not and will not support **Valkey cluster** mode. Managing a clustered topology is fundamentally different from standalone or replicated deployments, and the operational requirements go well beyond what this chart is designed to handle.
+
+For cluster mode, a separate chart is being developed that uses the valkey-operator to deploy and manage clusters. The operator must be installed first.
+
+To follow progress or get involved, see the [weekly meeting wiki](https://github.com/valkey-io/valkey-operator/wiki/Weekly-meeting).
 
 ## Storage
 
@@ -373,6 +425,27 @@ tls:
 | replica.persistence.size | string | `""` | Required if replica is enabled |
 | replica.persistence.storageClass | string | `""` |  |
 | replica.persistence.accessModes | list | `""` |  |
+| replica.sentinel.enabled | bool | `false` | Run Valkey Sentinel for automatic failover |
+| replica.sentinel.port | int | `26379` |  |
+| replica.sentinel.masterSet | string | `"mymaster"` |  |
+| replica.sentinel.quorum | int | `2` | Sentinels that must agree before a failover starts |
+| replica.sentinel.downAfterMilliseconds | int | `5000` |  |
+| replica.sentinel.failoverTimeout | int | `60000` |  |
+| replica.sentinel.parallelSyncs | int | `1` |  |
+| replica.sentinel.monitorUser | string | `""` | Defaults to replica.replicationUser |
+| replica.sentinel.preStopFailover | bool | `true` | Fail over before a master pod is terminated |
+| replica.sentinel.preStopFailoverTimeoutSeconds | int | `20` |  |
+| replica.sentinel.startupTimeoutSeconds | int | `60` |  |
+| replica.sentinel.extraConfig | string | `""` | Raw lines appended to sentinel.conf |
+| replica.sentinel.resources | object | `{}` |  |
+| replica.sentinel.securityContext | object | `{}` | Defaults to securityContext |
+| replica.sentinel.service.enabled | bool | `true` |  |
+| replica.sentinel.service.type | string | `"ClusterIP"` |  |
+| replica.sentinel.service.port | int | `26379` |  |
+| replica.sentinel.service.annotations | object | `{}` |  |
+| replica.sentinel.persistence.enabled | bool | `false` |  |
+| replica.sentinel.persistence.size | string | `"100Mi"` |  |
+| replica.sentinel.persistence.storageClass | string | `""` |  |
 | resources | object | `{}` |  |
 | securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | securityContext.readOnlyRootFilesystem | bool | `true` |  |

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -96,7 +96,7 @@ Writes sent to the `valkey` service directly may land on a replica and fail with
 
 **Authentication:**
 
-When `auth.enabled` is true, set `replica.sentinel.password` to a credential used only for the Sentinel endpoint.
+Set `replica.sentinel.password` to a credential used only for the Sentinel endpoint, even when Valkey authentication is disabled.
 With `auth.usersExistingSecret`, store that credential under `replica.sentinel.passwordKey` (default: `sentinel`) instead.
 Valkey user passwords are deliberately not accepted by Sentinel, so restrictions on application ACL users cannot be bypassed through Sentinel commands.
 Sentinel reaches the Valkey nodes as `replica.sentinel.monitorUser`, which defaults to `replica.replicationUser`.
@@ -447,7 +447,7 @@ tls:
 | replica.sentinel.failoverTimeout | int | `60000` |  |
 | replica.sentinel.parallelSyncs | int | `1` |  |
 | replica.sentinel.monitorUser | string | `""` | Defaults to replica.replicationUser |
-| replica.sentinel.password | string | `""` | Dedicated Sentinel ACL password; required with auth unless supplied by auth.usersExistingSecret |
+| replica.sentinel.password | string | `""` | Dedicated Sentinel ACL password; required with Sentinel unless supplied by auth.usersExistingSecret |
 | replica.sentinel.passwordKey | string | `"sentinel"` | Key containing the Sentinel password in auth.usersExistingSecret |
 | replica.sentinel.preStopFailover | bool | `true` | Fail over before a master pod is terminated |
 | replica.sentinel.preStopFailoverTimeoutSeconds | int | `20` |  |

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -101,7 +101,7 @@ Sentinel reaches the Valkey nodes as `replica.sentinel.monitorUser`, which defau
 That user must be allowed to promote a replica, otherwise every failover aborts with `-failover-abort-slave-timeout`.
 The minimum permissions are:
 
-```
+```text
 ~* &* +multi +exec +ping +info +role +subscribe +publish +slaveof +replicaof
 +config|rewrite +client|setname +client|kill +script|kill +psync +replconf
 ```

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -116,6 +116,7 @@ With `auth.usersExistingSecret`, store that credential under `replica.sentinel.p
 Valkey user passwords are deliberately not accepted by Sentinel, so restrictions on application ACL users cannot be bypassed through Sentinel commands.
 Sentinel reaches the Valkey nodes as `replica.sentinel.monitorUser`, which defaults to `replica.replicationUser`.
 That user must be allowed to promote a replica, otherwise every failover aborts with `-failover-abort-slave-timeout`.
+A starting pod asks the other nodes which of them is the primary as the same user, rather than as `replica.replicationUser`, whose documented minimum cannot run `INFO`.
 The minimum permissions are:
 
 ```text

--- a/valkey/examples/ha-sentinel.yaml
+++ b/valkey/examples/ha-sentinel.yaml
@@ -1,0 +1,36 @@
+# Valkey in high availability mode: 3 pods, each running a Valkey server and a
+# Sentinel. Sentinel promotes a replica automatically when the master fails.
+#
+#   helm install valkey ./valkey -f valkey/examples/ha-sentinel.yaml
+#
+# Clients resolve the current master through the valkey-sentinel service, see
+# the notes printed after the install.
+
+replica:
+  enabled: true
+  # 2 replicas + 1 master = 3 pods, the minimum for a Sentinel quorum
+  replicas: 2
+  persistence:
+    size: 1Gi
+
+  # Used both for replication and by Sentinel to monitor the nodes
+  replicationUser: replicator
+
+  sentinel:
+    enabled: true
+    quorum: 2
+
+auth:
+  enabled: true
+  aclUsers:
+    default:
+      permissions: "~* &* +@all"
+      password: "changeme"
+    replicator:
+      # Sentinel needs all of these to monitor the nodes and to promote a
+      # replica, see replica.sentinel.monitorUser in values.yaml
+      permissions: >-
+        on ~* &* +multi +exec +ping +info +role +subscribe +publish +slaveof
+        +replicaof +config|rewrite +client|setname +client|kill +script|kill
+        +psync +replconf
+      password: "changeme-too"

--- a/valkey/examples/ha-sentinel.yaml
+++ b/valkey/examples/ha-sentinel.yaml
@@ -5,6 +5,13 @@
 #
 # Clients resolve the current master through the valkey-sentinel service, see
 # the notes printed after the install.
+#
+# SECURITY: the passwords below are placeholders and grant full access. Replace
+# both before installing anywhere real, or drop the inline passwords and point
+# auth.usersExistingSecret at a secret you manage:
+#
+#   kubectl create secret generic valkey-users \
+#     --from-literal=default=... --from-literal=replicator=...
 
 replica:
   enabled: true
@@ -25,7 +32,7 @@ auth:
   aclUsers:
     default:
       permissions: "~* &* +@all"
-      password: "changeme"
+      password: "REPLACE-ME"
     replicator:
       # Sentinel needs all of these to monitor the nodes and to promote a
       # replica, see replica.sentinel.monitorUser in values.yaml
@@ -33,4 +40,4 @@ auth:
         on ~* &* +multi +exec +ping +info +role +subscribe +publish +slaveof
         +replicaof +config|rewrite +client|setname +client|kill +script|kill
         +psync +replconf
-      password: "changeme-too"
+      password: "REPLACE-ME-TOO"

--- a/valkey/examples/ha-sentinel.yaml
+++ b/valkey/examples/ha-sentinel.yaml
@@ -1,5 +1,5 @@
-# Valkey in high availability mode: 3 pods, each running a Valkey server and a
-# Sentinel. Sentinel promotes a replica automatically when the master fails.
+# Valkey in high availability mode: one Valkey StatefulSet and an independent
+# three-pod Sentinel StatefulSet. Sentinel promotes a replica automatically.
 #
 #   helm install valkey ./valkey -f valkey/examples/ha-sentinel.yaml
 #
@@ -17,7 +17,7 @@
 
 replica:
   enabled: true
-  # 2 replicas + 1 master = 3 pods, the minimum for a Sentinel quorum
+  # 2 replicas + 1 master
   replicas: 2
   persistence:
     size: 1Gi
@@ -27,6 +27,7 @@ replica:
 
   sentinel:
     enabled: true
+    replicas: 3
     # Use a distinct credential for the Sentinel endpoint. In production,
     # prefer auth.usersExistingSecret and set passwordKey instead.
     password: "replace-with-a-sentinel-password"

--- a/valkey/examples/ha-sentinel.yaml
+++ b/valkey/examples/ha-sentinel.yaml
@@ -25,6 +25,9 @@ replica:
 
   sentinel:
     enabled: true
+    # Use a distinct credential for the Sentinel endpoint. In production,
+    # prefer auth.usersExistingSecret and set passwordKey instead.
+    password: "replace-with-a-sentinel-password"
     quorum: 2
 
 auth:

--- a/valkey/examples/ha-sentinel.yaml
+++ b/valkey/examples/ha-sentinel.yaml
@@ -6,12 +6,14 @@
 # Clients resolve the current master through the valkey-sentinel service, see
 # the notes printed after the install.
 #
-# SECURITY: the passwords below are placeholders and grant full access. Replace
-# both before installing anywhere real, or drop the inline passwords and point
-# auth.usersExistingSecret at a secret you manage:
+# SECURITY: the passwords below are placeholders. Replace all three credentials
+# before installing anywhere real, or drop the inline passwords and point
+# auth.usersExistingSecret at a secret you manage. The dedicated Sentinel
+# credential is required and must match replica.sentinel.passwordKey:
 #
 #   kubectl create secret generic valkey-users \
-#     --from-literal=default=... --from-literal=replicator=...
+#     --from-literal=default=... --from-literal=replicator=... \
+#     --from-literal=sentinel=...
 
 replica:
   enabled: true

--- a/valkey/examples/ha-sentinel.yaml
+++ b/valkey/examples/ha-sentinel.yaml
@@ -47,3 +47,12 @@ auth:
         +replicaof +config|rewrite +client|setname +client|kill +script|kill
         +psync +replconf
       password: "REPLACE-ME-TOO"
+
+# Spread the Sentinel quorum across nodes when the cluster has capacity.
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/component: sentinel

--- a/valkey/templates/NOTES.txt
+++ b/valkey/templates/NOTES.txt
@@ -100,7 +100,7 @@ WRITE Operations (resolve the master via Sentinel first):
   $ MASTER=$(valkey-cli -h {{ include "valkey.sentinel.fullname" . }} -p {{ .Values.replica.sentinel.service.port }}{{ if .Values.tls.enabled }} --tls{{- end }} --user sentinel -a <sentinel password> --raw \
       SENTINEL get-master-addr-by-name {{ .Values.replica.sentinel.masterSet }} | tr '\n' ' ')
   $ set -- $MASTER
-  $ valkey-cli -h "$1" -p "$2"{{ if .Values.tls.enabled }} --tls{{- end }} PING
+  $ valkey-cli -h "$1" -p "$2"{{ if .Values.tls.enabled }} --tls{{- end }}{{ if .Values.auth.enabled }} --user <Valkey user> -a <Valkey password>{{ end }} PING
 
 2) Local access:
   $ MASTER=$(kubectl -n {{ .Release.Namespace }} exec {{ include "valkey.sentinel.fullname" . }}-0 -- \
@@ -108,7 +108,7 @@ WRITE Operations (resolve the master via Sentinel first):
       SENTINEL get-master-addr-by-name {{ .Values.replica.sentinel.masterSet }} | tr '\n' ' ')
   $ set -- $MASTER
   $ kubectl -n {{ .Release.Namespace }} port-forward "pod/${1%%.*}" "6379:$2"
-  $ valkey-cli -h 127.0.0.1 -p 6379{{ if .Values.tls.enabled }} --tls{{- end }} SET key value
+  $ valkey-cli -h 127.0.0.1 -p 6379{{ if .Values.tls.enabled }} --tls{{- end }}{{ if .Values.auth.enabled }} --user <Valkey user> -a <Valkey password>{{ end }} SET key value
 {{- else }}
 WRITE Operations (Master only):
   Service: {{ include "valkey.fullname" . }}

--- a/valkey/templates/NOTES.txt
+++ b/valkey/templates/NOTES.txt
@@ -24,12 +24,24 @@ Sentinel promotes a replica when the master stops responding for
 {{ .Values.replica.sentinel.downAfterMilliseconds }}ms, so the master can be any pod. Clients must therefore
 ask Sentinel for the current master instead of connecting to a fixed pod:
 
-  $ valkey-cli -h {{ include "valkey.fullname" . }}-sentinel -p {{ .Values.replica.sentinel.service.port }}{{ if .Values.tls.enabled }} --tls{{- end }}{{ if .Values.auth.enabled }} -a <default password>{{ end }} \
+{{- if .Values.replica.sentinel.service.enabled }}
+{{- $sentinelHost := printf "%s-sentinel" (include "valkey.fullname" .) }}
+{{- $sentinelPort := .Values.replica.sentinel.service.port }}
+
+  $ valkey-cli -h {{ $sentinelHost }} -p {{ $sentinelPort }}{{ if .Values.tls.enabled }} --tls{{- end }}{{ if .Values.auth.enabled }} -a <default password>{{ end }} \
       SENTINEL get-master-addr-by-name {{ .Values.replica.sentinel.masterSet }}
 
 Most client libraries do this for you, e.g. in Python:
 
-  Sentinel([("{{ include "valkey.fullname" . }}-sentinel", {{ .Values.replica.sentinel.service.port }})]).master_for("{{ .Values.replica.sentinel.masterSet }}")
+  Sentinel([("{{ $sentinelHost }}", {{ $sentinelPort }})]).master_for("{{ .Values.replica.sentinel.masterSet }}")
+{{- else }}
+
+The Sentinel service is disabled (replica.sentinel.service.enabled), so address
+the Sentinels through the headless service instead:
+{{- range $i := until (add (int .Values.replica.replicas) 1 | int) }}
+  {{ include "valkey.fullname" $ }}-{{ $i }}.{{ include "valkey.headlessServiceName" $ }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:{{ $.Values.replica.sentinel.port }}
+{{- end }}
+{{- end }}
 
 ⚠️  The {{ include "valkey.fullname" . }} service load balances across ALL pods in this mode,
     so writes sent to it may hit a replica and fail with -READONLY.

--- a/valkey/templates/NOTES.txt
+++ b/valkey/templates/NOTES.txt
@@ -18,14 +18,14 @@ App version:  {{ .Chart.AppVersion }}
 
 Your Valkey deployment is running in REPLICATION mode with Sentinel:
 - {{ add (int .Values.replica.replicas) 1 }} Valkey pods, 1 of them the master at any time
-- {{ add (int .Values.replica.replicas) 1 }} Sentinels (one per pod), quorum {{ .Values.replica.sentinel.quorum }}
+- {{ .Values.replica.sentinel.replicas }} Sentinels in a separate StatefulSet, quorum {{ .Values.replica.sentinel.quorum }}
 
 Sentinel promotes a replica when the master stops responding for
 {{ .Values.replica.sentinel.downAfterMilliseconds }}ms, so the master can be any pod. Clients must therefore
 ask Sentinel for the current master instead of connecting to a fixed pod:
 
 {{- if .Values.replica.sentinel.service.enabled }}
-{{- $sentinelHost := printf "%s-sentinel" (include "valkey.fullname" .) }}
+{{- $sentinelHost := include "valkey.sentinel.fullname" . }}
 {{- $sentinelPort := .Values.replica.sentinel.service.port }}
 
   $ valkey-cli -h {{ $sentinelHost }} -p {{ $sentinelPort }}{{ if .Values.tls.enabled }} --tls{{- end }} --user sentinel -a <sentinel password> \
@@ -39,8 +39,8 @@ Most client libraries do this for you, e.g. in Python:
 
 The Sentinel service is disabled (replica.sentinel.service.enabled), so address
 the Sentinels through the headless service instead:
-{{- range $i := until (add (int .Values.replica.replicas) 1 | int) }}
-  {{ include "valkey.fullname" $ }}-{{ $i }}.{{ include "valkey.headlessServiceName" $ }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:{{ $.Values.replica.sentinel.port }}
+{{- range $i := until (int .Values.replica.sentinel.replicas) }}
+  {{ include "valkey.sentinel.fullname" $ }}-{{ $i }}.{{ include "valkey.sentinel.headlessServiceName" $ }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}:{{ $.Values.replica.sentinel.port }}
 {{- end }}
 {{- end }}
 

--- a/valkey/templates/NOTES.txt
+++ b/valkey/templates/NOTES.txt
@@ -28,12 +28,13 @@ ask Sentinel for the current master instead of connecting to a fixed pod:
 {{- $sentinelHost := printf "%s-sentinel" (include "valkey.fullname" .) }}
 {{- $sentinelPort := .Values.replica.sentinel.service.port }}
 
-  $ valkey-cli -h {{ $sentinelHost }} -p {{ $sentinelPort }}{{ if .Values.tls.enabled }} --tls{{- end }}{{ if .Values.auth.enabled }} -a <default password>{{ end }} \
+  $ valkey-cli -h {{ $sentinelHost }} -p {{ $sentinelPort }}{{ if .Values.tls.enabled }} --tls{{- end }} --user sentinel -a <sentinel password> \
       SENTINEL get-master-addr-by-name {{ .Values.replica.sentinel.masterSet }}
 
 Most client libraries do this for you, e.g. in Python:
 
-  Sentinel([("{{ $sentinelHost }}", {{ $sentinelPort }})]).master_for("{{ .Values.replica.sentinel.masterSet }}")
+  Sentinel([("{{ $sentinelHost }}", {{ $sentinelPort }})],
+           sentinel_kwargs={"username": "sentinel", "password": "<sentinel password>"}).master_for("{{ .Values.replica.sentinel.masterSet }}")
 {{- else }}
 
 The Sentinel service is disabled (replica.sentinel.service.enabled), so address

--- a/valkey/templates/NOTES.txt
+++ b/valkey/templates/NOTES.txt
@@ -28,7 +28,7 @@ ask Sentinel for the current master instead of connecting to a fixed pod:
 {{- $sentinelHost := include "valkey.sentinel.fullname" . }}
 {{- $sentinelPort := .Values.replica.sentinel.service.port }}
 
-  $ valkey-cli -h {{ $sentinelHost }} -p {{ $sentinelPort }}{{ if .Values.tls.enabled }} --tls{{- end }} --user sentinel -a <sentinel password> \
+  $ valkey-cli -h {{ $sentinelHost }} -p {{ $sentinelPort }}{{ include "valkey.cli.tlsFlagsHint" . }} --user sentinel -a <sentinel password> \
       SENTINEL get-master-addr-by-name {{ .Values.replica.sentinel.masterSet }}
 
 Most client libraries do this for you, e.g. in Python:
@@ -64,20 +64,20 @@ READ Operations (Load-balanced across all pods):
   Port:    {{ .Values.replica.service.port }}
 
 1) In-cluster access:
-   $ valkey-cli -h {{ include "valkey.fullname" . }}-read -p {{ .Values.replica.service.port }}{{ if .Values.tls.enabled }} --tls{{- end }} GET key
+   $ valkey-cli -h {{ include "valkey.fullname" . }}-read -p {{ .Values.replica.service.port }}{{ include "valkey.cli.tlsFlagsHint" . }} GET key
 
 2) Local access via kubectl port-forward:
    $ kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "valkey.fullname" . }}-read 6379:{{ .Values.replica.service.port }}
-   $ valkey-cli -h 127.0.0.1 -p 6379{{ if .Values.tls.enabled }} --tls{{- end }} GET key
+   $ valkey-cli -h 127.0.0.1 -p 6379{{ include "valkey.cli.tlsFlagsHint" . }} GET key
 {{ if eq .Values.replica.service.type "LoadBalancer" }}
 3) External access (LoadBalancer):
    $ export SERVICE_IP=$(kubectl -n {{ .Release.Namespace }} get svc {{ include "valkey.fullname" . }}-read -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-   $ valkey-cli -h $SERVICE_IP -p {{ .Values.replica.service.port }}{{ if .Values.tls.enabled }} --tls{{- end }} GET key
+   $ valkey-cli -h $SERVICE_IP -p {{ .Values.replica.service.port }}{{ include "valkey.cli.tlsFlagsHint" . }} GET key
 {{ else if eq .Values.replica.service.type "NodePort" }}
 3) External access (NodePort):
    $ export NODE_PORT=$(kubectl -n {{ .Release.Namespace }} get svc {{ include "valkey.fullname" . }}-read -o jsonpath='{.spec.ports[0].nodePort}')
    $ export NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
-   $ valkey-cli -h $NODE_IP -p $NODE_PORT{{ if .Values.tls.enabled }} --tls{{- end }} GET key
+   $ valkey-cli -h $NODE_IP -p $NODE_PORT{{ include "valkey.cli.tlsFlagsHint" . }} GET key
 {{ end }}
 {{- end }}
 
@@ -97,18 +97,18 @@ Direct Pod Access:
 WRITE Operations (resolve the master via Sentinel first):
 
 1) In-cluster access:
-  $ MASTER=$(valkey-cli -h {{ include "valkey.sentinel.fullname" . }} -p {{ .Values.replica.sentinel.service.port }}{{ if .Values.tls.enabled }} --tls{{- end }} --user sentinel -a <sentinel password> --raw \
+  $ MASTER=$(valkey-cli -h {{ include "valkey.sentinel.fullname" . }} -p {{ .Values.replica.sentinel.service.port }}{{ include "valkey.cli.tlsFlagsHint" . }} --user sentinel -a <sentinel password> --raw \
       SENTINEL get-master-addr-by-name {{ .Values.replica.sentinel.masterSet }} | tr '\n' ' ')
   $ set -- $MASTER
-  $ valkey-cli -h "$1" -p "$2"{{ if .Values.tls.enabled }} --tls{{- end }}{{ if .Values.auth.enabled }} --user <Valkey user> -a <Valkey password>{{ end }} PING
+  $ valkey-cli -h "$1" -p "$2"{{ include "valkey.cli.tlsFlagsHint" . }}{{ if .Values.auth.enabled }} --user <Valkey user> -a <Valkey password>{{ end }} PING
 
 2) Local access:
   $ MASTER=$(kubectl -n {{ .Release.Namespace }} exec {{ include "valkey.sentinel.fullname" . }}-0 -- \
-      env REDISCLI_AUTH=<sentinel password> valkey-cli{{ if .Values.tls.enabled }} --tls{{- end }} --user sentinel -p {{ .Values.replica.sentinel.port }} --raw \
+      env REDISCLI_AUTH=<sentinel password> valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} --user sentinel -p {{ .Values.replica.sentinel.port }} --raw \
       SENTINEL get-master-addr-by-name {{ .Values.replica.sentinel.masterSet }} | tr '\n' ' ')
   $ set -- $MASTER
   $ kubectl -n {{ .Release.Namespace }} port-forward "pod/${1%%.*}" "6379:$2"
-  $ valkey-cli -h 127.0.0.1 -p 6379{{ if .Values.tls.enabled }} --tls{{- end }}{{ if .Values.auth.enabled }} --user <Valkey user> -a <Valkey password>{{ end }} SET key value
+  $ valkey-cli -h 127.0.0.1 -p 6379{{ include "valkey.cli.tlsFlagsHint" . }}{{ if .Values.auth.enabled }} --user <Valkey user> -a <Valkey password>{{ end }} SET key value
 {{- else }}
 WRITE Operations (Master only):
   Service: {{ include "valkey.fullname" . }}
@@ -116,11 +116,11 @@ WRITE Operations (Master only):
   Port:    {{ .Values.service.port }}
 
 1) In-cluster access:
-  $ valkey-cli -h {{ include "valkey.fullname" . }} -p {{ .Values.service.port }}{{ if .Values.tls.enabled }} --tls{{- end }} PING
+  $ valkey-cli -h {{ include "valkey.fullname" . }} -p {{ .Values.service.port }}{{ include "valkey.cli.tlsFlagsHint" . }} PING
 
 2) Local access:
   $ kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "valkey.fullname" . }} 6379:{{ .Values.service.port }}
-  $ valkey-cli -h 127.0.0.1 -p 6379{{ if .Values.tls.enabled }} --tls{{- end }} SET key value
+  $ valkey-cli -h 127.0.0.1 -p 6379{{ include "valkey.cli.tlsFlagsHint" . }} SET key value
 {{- end }}
 {{- else }}
 ================================================================================
@@ -133,22 +133,22 @@ Port:         {{ .Values.service.port }}
 
 1) In-cluster access
    From another Pod:
-   $ valkey-cli -h {{ include "valkey.fullname" . }} -p {{ .Values.service.port }}{{ if .Values.tls.enabled }} --tls{{- end }} PING
+   $ valkey-cli -h {{ include "valkey.fullname" . }} -p {{ .Values.service.port }}{{ include "valkey.cli.tlsFlagsHint" . }} PING
 
 2) Local access via kubectl port-forward
    $ kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "valkey.fullname" . }} 6379:{{ .Values.service.port }}
    In another terminal:
-   $ valkey-cli -h 127.0.0.1 -p 6379{{ if .Values.tls.enabled }} --tls{{- end }} PING
+   $ valkey-cli -h 127.0.0.1 -p 6379{{ include "valkey.cli.tlsFlagsHint" . }} PING
 {{- end }}
 {{ if eq .Values.service.type "LoadBalancer" }}
 3) External access (LoadBalancer)
    $ export SERVICE_IP=$(kubectl -n {{ .Release.Namespace }} get svc {{ include "valkey.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-   $ valkey-cli -h $SERVICE_IP -p {{ .Values.service.port }}{{ if .Values.tls.enabled }} --tls{{- end }} PING
+   $ valkey-cli -h $SERVICE_IP -p {{ .Values.service.port }}{{ include "valkey.cli.tlsFlagsHint" . }} PING
 {{ else if eq .Values.service.type "NodePort" }}
 3) External access (NodePort)
    $ export NODE_PORT=$(kubectl -n {{ .Release.Namespace }} get svc {{ include "valkey.fullname" . }} -o jsonpath='{.spec.ports[0].nodePort}')
    $ export NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
-   $ valkey-cli -h $NODE_IP -p $NODE_PORT{{ if .Values.tls.enabled }} --tls{{- end }} PING
+   $ valkey-cli -h $NODE_IP -p $NODE_PORT{{ include "valkey.cli.tlsFlagsHint" . }} PING
 {{ end }}
 
 {{ if .Values.auth.enabled }}
@@ -162,9 +162,9 @@ Port:         {{ .Values.service.port }}
 ✅ Quick test
 {{- if .Values.replica.sentinel.enabled }}
 Resolve the current master using the WRITE Operations commands above, then run:
-$ valkey-cli -h <master host> -p <master port>{{ if .Values.tls.enabled }} --tls{{- end }}{{ if .Values.auth.enabled }} --user <user> -a <password>{{ end }}
+$ valkey-cli -h <master host> -p <master port>{{ include "valkey.cli.tlsFlagsHint" . }}{{ if .Values.auth.enabled }} --user <user> -a <password>{{ end }}
 {{- else }}
-$ valkey-cli -h {{ include "valkey.fullname" . }} -p {{ .Values.service.port }}{{ if .Values.tls.enabled }} --tls{{- end }}{{ if .Values.auth.enabled }} --user <user> -a <password>{{ end }}
+$ valkey-cli -h {{ include "valkey.fullname" . }} -p {{ .Values.service.port }}{{ include "valkey.cli.tlsFlagsHint" . }}{{ if .Values.auth.enabled }} --user <user> -a <password>{{ end }}
 {{- end }}
 valkey> SET foo bar
 valkey> GET foo

--- a/valkey/templates/NOTES.txt
+++ b/valkey/templates/NOTES.txt
@@ -34,7 +34,13 @@ ask Sentinel for the current master instead of connecting to a fixed pod:
 Most client libraries do this for you, e.g. in Python:
 
   Sentinel([("{{ $sentinelHost }}", {{ $sentinelPort }})],
-           sentinel_kwargs={"username": "sentinel", "password": "<sentinel password>"}).master_for("{{ .Values.replica.sentinel.masterSet }}"{{ if .Values.auth.enabled }}, username="<Valkey user>", password="<Valkey password>"{{ end }})
+           sentinel_kwargs={"username": "sentinel", "password": "<sentinel password>"{{ include "valkey.python.tlsDictItems" . }}}{{ include "valkey.python.tlsKwargs" . }}
+           ).master_for("{{ .Values.replica.sentinel.masterSet }}"{{ if .Values.auth.enabled }}, username="<Valkey user>", password="<Valkey password>"{{ end }})
+{{- if .Values.tls.enabled }}
+
+  The options appear twice on purpose: the ones inside sentinel_kwargs reach
+  the Sentinels, the ones beside it reach the master they name.
+{{- end }}
 {{- else }}
 
 The Sentinel service is disabled (replica.sentinel.service.enabled), so address

--- a/valkey/templates/NOTES.txt
+++ b/valkey/templates/NOTES.txt
@@ -93,7 +93,24 @@ Direct Pod Access:
 {{- end }}
 {{- end }}
 
-{{ if .Values.replica.sentinel.enabled }}WRITE Operations (resolve the master via Sentinel first):{{ else }}WRITE Operations (Master only):{{ end }}
+{{- if .Values.replica.sentinel.enabled }}
+WRITE Operations (resolve the master via Sentinel first):
+
+1) In-cluster access:
+  $ MASTER=$(valkey-cli -h {{ include "valkey.sentinel.fullname" . }} -p {{ .Values.replica.sentinel.service.port }}{{ if .Values.tls.enabled }} --tls{{- end }} --user sentinel -a <sentinel password> --raw \
+      SENTINEL get-master-addr-by-name {{ .Values.replica.sentinel.masterSet }} | tr '\n' ' ')
+  $ set -- $MASTER
+  $ valkey-cli -h "$1" -p "$2"{{ if .Values.tls.enabled }} --tls{{- end }} PING
+
+2) Local access:
+  $ MASTER=$(kubectl -n {{ .Release.Namespace }} exec {{ include "valkey.sentinel.fullname" . }}-0 -- \
+      env REDISCLI_AUTH=<sentinel password> valkey-cli{{ if .Values.tls.enabled }} --tls{{- end }} --user sentinel -p {{ .Values.replica.sentinel.port }} --raw \
+      SENTINEL get-master-addr-by-name {{ .Values.replica.sentinel.masterSet }} | tr '\n' ' ')
+  $ set -- $MASTER
+  $ kubectl -n {{ .Release.Namespace }} port-forward "pod/${1%%.*}" "6379:$2"
+  $ valkey-cli -h 127.0.0.1 -p 6379{{ if .Values.tls.enabled }} --tls{{- end }} SET key value
+{{- else }}
+WRITE Operations (Master only):
   Service: {{ include "valkey.fullname" . }}
   Type:    {{ .Values.service.type }}
   Port:    {{ .Values.service.port }}
@@ -104,6 +121,7 @@ Direct Pod Access:
 2) Local access:
   $ kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "valkey.fullname" . }} 6379:{{ .Values.service.port }}
   $ valkey-cli -h 127.0.0.1 -p 6379{{ if .Values.tls.enabled }} --tls{{- end }} SET key value
+{{- end }}
 {{- else }}
 ================================================================================
 📦 STANDALONE MODE
@@ -142,7 +160,12 @@ Port:         {{ .Values.service.port }}
 {{ end }}
 
 ✅ Quick test
+{{- if .Values.replica.sentinel.enabled }}
+Resolve the current master using the WRITE Operations commands above, then run:
+$ valkey-cli -h <master host> -p <master port>{{ if .Values.tls.enabled }} --tls{{- end }}{{ if .Values.auth.enabled }} --user <user> -a <password>{{ end }}
+{{- else }}
 $ valkey-cli -h {{ include "valkey.fullname" . }} -p {{ .Values.service.port }}{{ if .Values.tls.enabled }} --tls{{- end }}{{ if .Values.auth.enabled }} --user <user> -a <password>{{ end }}
+{{- end }}
 valkey> SET foo bar
 valkey> GET foo
 "bar"

--- a/valkey/templates/NOTES.txt
+++ b/valkey/templates/NOTES.txt
@@ -34,7 +34,7 @@ ask Sentinel for the current master instead of connecting to a fixed pod:
 Most client libraries do this for you, e.g. in Python:
 
   Sentinel([("{{ $sentinelHost }}", {{ $sentinelPort }})],
-           sentinel_kwargs={"username": "sentinel", "password": "<sentinel password>"}).master_for("{{ .Values.replica.sentinel.masterSet }}")
+           sentinel_kwargs={"username": "sentinel", "password": "<sentinel password>"}).master_for("{{ .Values.replica.sentinel.masterSet }}"{{ if .Values.auth.enabled }}, username="<Valkey user>", password="<Valkey password>"{{ end }})
 {{- else }}
 
 The Sentinel service is disabled (replica.sentinel.service.enabled), so address

--- a/valkey/templates/NOTES.txt
+++ b/valkey/templates/NOTES.txt
@@ -11,6 +11,29 @@ Chart:        {{ .Chart.Name }} {{ .Chart.Version }}
 App version:  {{ .Chart.AppVersion }}
 
 {{- if .Values.replica.enabled }}
+{{- if .Values.replica.sentinel.enabled }}
+================================================================================
+🔄 HIGH AVAILABILITY MODE (Sentinel)
+================================================================================
+
+Your Valkey deployment is running in REPLICATION mode with Sentinel:
+- {{ add (int .Values.replica.replicas) 1 }} Valkey pods, 1 of them the master at any time
+- {{ add (int .Values.replica.replicas) 1 }} Sentinels (one per pod), quorum {{ .Values.replica.sentinel.quorum }}
+
+Sentinel promotes a replica when the master stops responding for
+{{ .Values.replica.sentinel.downAfterMilliseconds }}ms, so the master can be any pod. Clients must therefore
+ask Sentinel for the current master instead of connecting to a fixed pod:
+
+  $ valkey-cli -h {{ include "valkey.fullname" . }}-sentinel -p {{ .Values.replica.sentinel.service.port }}{{ if .Values.tls.enabled }} --tls{{- end }}{{ if .Values.auth.enabled }} -a <default password>{{ end }} \
+      SENTINEL get-master-addr-by-name {{ .Values.replica.sentinel.masterSet }}
+
+Most client libraries do this for you, e.g. in Python:
+
+  Sentinel([("{{ include "valkey.fullname" . }}-sentinel", {{ .Values.replica.sentinel.service.port }})]).master_for("{{ .Values.replica.sentinel.masterSet }}")
+
+⚠️  The {{ include "valkey.fullname" . }} service load balances across ALL pods in this mode,
+    so writes sent to it may hit a replica and fail with -READONLY.
+{{- else }}
 ================================================================================
 🔄 REPLICATION MODE
 ================================================================================
@@ -18,6 +41,7 @@ App version:  {{ .Chart.AppVersion }}
 Your Valkey deployment is running in REPLICATION mode:
 - 1 Master  ({{ include "valkey.fullname" . }}-0)
 - {{ .Values.replica.replicas }} Replica(s)
+{{- end }}
 
 {{- if .Values.replica.service.enabled }}
 
@@ -45,12 +69,18 @@ READ Operations (Load-balanced across all pods):
 {{- end }}
 
 Direct Pod Access:
+{{- if .Values.replica.sentinel.enabled }}
+{{- range $i := until (add (int .Values.replica.replicas) 1 | int) }}
+  Pod:     {{ include "valkey.fullname" $ }}-{{ $i }}.{{ include "valkey.headlessServiceName" $ }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}
+{{- end }}
+{{- else }}
   Master:  {{ include "valkey.fullname" . }}-0.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
 {{- range $i := until (int .Values.replica.replicas) }}
   Replica: {{ include "valkey.fullname" $ }}-{{ add $i 1 }}.{{ include "valkey.headlessServiceName" $ }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}
 {{- end }}
+{{- end }}
 
-WRITE Operations (Master only):
+{{ if .Values.replica.sentinel.enabled }}WRITE Operations (resolve the master via Sentinel first):{{ else }}WRITE Operations (Master only):{{ end }}
   Service: {{ include "valkey.fullname" . }}
   Type:    {{ .Values.service.type }}
   Port:    {{ .Values.service.port }}

--- a/valkey/templates/_helpers.tpl
+++ b/valkey/templates/_helpers.tpl
@@ -220,6 +220,9 @@ Validate sentinel configuration
     {{- fail (printf "replica.sentinel.preStopFailoverTimeoutSeconds (%d) must be lower than replica.terminationGracePeriodSeconds (%d), otherwise the pod is killed while the graceful failover is still running." (int .Values.replica.sentinel.preStopFailoverTimeoutSeconds) (int .Values.replica.terminationGracePeriodSeconds)) }}
   {{- end }}
   {{- if .Values.auth.enabled }}
+    {{- if and (not .Values.replica.sentinel.password) (not .Values.auth.usersExistingSecret) }}
+      {{- fail "replica.sentinel.password is required when Sentinel authentication is enabled, unless auth.usersExistingSecret supplies replica.sentinel.passwordKey." }}
+    {{- end }}
     {{- $monitorUser := .Values.replica.sentinel.monitorUser | default .Values.replica.replicationUser }}
     {{- if not (hasKey .Values.auth.aclUsers $monitorUser) }}
       {{- fail (printf "Sentinel monitor user '%s' must be defined in auth.aclUsers. Sentinel needs it to reach the monitored Valkey nodes." $monitorUser) }}
@@ -265,4 +268,3 @@ enabled, so callers should guard with `with`.
 {{- toYaml $probes -}}
 {{- end -}}
 {{- end -}}
-

--- a/valkey/templates/_helpers.tpl
+++ b/valkey/templates/_helpers.tpl
@@ -222,10 +222,10 @@ Validate sentinel configuration
   {{- if and .Values.replica.sentinel.preStopFailover (ge (int .Values.replica.sentinel.preStopFailoverTimeoutSeconds) (int .Values.replica.terminationGracePeriodSeconds)) }}
     {{- fail (printf "replica.sentinel.preStopFailoverTimeoutSeconds (%d) must be lower than replica.terminationGracePeriodSeconds (%d), otherwise the pod is killed while the graceful failover is still running." (int .Values.replica.sentinel.preStopFailoverTimeoutSeconds) (int .Values.replica.terminationGracePeriodSeconds)) }}
   {{- end }}
+  {{- if and (not .Values.replica.sentinel.password) (not .Values.auth.usersExistingSecret) }}
+    {{- fail "replica.sentinel.password is required when Sentinel is enabled, unless auth.usersExistingSecret supplies replica.sentinel.passwordKey." }}
+  {{- end }}
   {{- if .Values.auth.enabled }}
-    {{- if and (not .Values.replica.sentinel.password) (not .Values.auth.usersExistingSecret) }}
-      {{- fail "replica.sentinel.password is required when Sentinel authentication is enabled, unless auth.usersExistingSecret supplies replica.sentinel.passwordKey." }}
-    {{- end }}
     {{- $monitorUser := .Values.replica.sentinel.monitorUser | default .Values.replica.replicationUser }}
     {{- if not (hasKey .Values.auth.aclUsers $monitorUser) }}
       {{- fail (printf "Sentinel monitor user '%s' must be defined in auth.aclUsers. Sentinel needs it to reach the monitored Valkey nodes." $monitorUser) }}

--- a/valkey/templates/_helpers.tpl
+++ b/valkey/templates/_helpers.tpl
@@ -219,6 +219,18 @@ valkey-cli TLS flags shared by the Sentinel scripts and probes
 {{- end -}}
 
 {{/*
+valkey-cli TLS flags for the commands printed after an install. Those run from
+a shell rather than inside a chart pod, so the files are the operator's own
+copies of what tls.existingSecret holds, and the names are shown as
+placeholders instead of the paths mounted into the containers.
+*/}}
+{{- define "valkey.cli.tlsFlagsHint" -}}
+{{- if .Values.tls.enabled }} --tls --cacert <{{ .Values.tls.caPublicKey }}>
+{{- if .Values.tls.requireClientCertificate }} --cert <{{ .Values.tls.serverPublicKey }}> --key <{{ .Values.tls.serverKey }}>{{ end }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Validate sentinel configuration
 */}}
 {{- define "valkey.validateSentinelConfig" -}}

--- a/valkey/templates/_helpers.tpl
+++ b/valkey/templates/_helpers.tpl
@@ -128,6 +128,9 @@ Check if there are any users with inline passwords
     {{- $hasInlinePasswords = true -}}
   {{- end -}}
 {{- end -}}
+{{- if and .Values.replica.enabled .Values.replica.sentinel.enabled .Values.replica.sentinel.password -}}
+  {{- $hasInlinePasswords = true -}}
+{{- end -}}
 {{- $hasInlinePasswords -}}
 {{- end -}}
 

--- a/valkey/templates/_helpers.tpl
+++ b/valkey/templates/_helpers.tpl
@@ -170,6 +170,23 @@ Headless service name for replication
 {{- end -}}
 
 {{/*
+Stable names and selectors for the independent Sentinel StatefulSet.
+*/}}
+{{- define "valkey.sentinel.fullname" -}}
+{{- printf "%s-sentinel" (include "valkey.fullname" . | trunc 54 | trimSuffix "-") -}}
+{{- end -}}
+
+{{- define "valkey.sentinel.headlessServiceName" -}}
+{{- printf "%s-headless" (include "valkey.sentinel.fullname" . | trunc 54 | trimSuffix "-") -}}
+{{- end -}}
+
+{{- define "valkey.sentinel.selectorLabels" -}}
+app.kubernetes.io/name: {{ printf "%s-sentinel" (include "valkey.name" . | trunc 54 | trimSuffix "-") }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: sentinel
+{{- end -}}
+
+{{/*
 Validate replica persistence configuration
 */}}
 {{- define "valkey.validateReplicaPersistence" -}}
@@ -209,15 +226,18 @@ Validate sentinel configuration
   {{- if not .Values.replica.enabled }}
     {{- fail "Sentinel requires replication. Please set replica.enabled=true along with replica.sentinel.enabled=true" }}
   {{- end }}
-  {{- $pods := add (int .Values.replica.replicas) 1 }}
-  {{- if lt $pods 3 }}
-    {{- fail (printf "Sentinel requires at least 3 pods to form a quorum, replica.replicas=%d gives %d. Please set replica.replicas to 2 or more." (int .Values.replica.replicas) $pods) }}
+  {{- $sentinels := int .Values.replica.sentinel.replicas }}
+  {{- if lt (int .Values.replica.replicas) 1 }}
+    {{- fail "Sentinel requires at least one Valkey replica. Please set replica.replicas to 1 or more." }}
+  {{- end }}
+  {{- if lt $sentinels 3 }}
+    {{- fail (printf "Sentinel requires at least 3 instances to form a quorum. Please set replica.sentinel.replicas to 3 or more (currently %d)." $sentinels) }}
   {{- end }}
   {{- if lt (int .Values.replica.sentinel.quorum) 2 }}
     {{- fail "replica.sentinel.quorum must be at least 2, a quorum of 1 allows a single Sentinel to trigger a failover on its own." }}
   {{- end }}
-  {{- if gt (int .Values.replica.sentinel.quorum) $pods }}
-    {{- fail (printf "replica.sentinel.quorum (%d) cannot be greater than the number of Sentinels (%d)." (int .Values.replica.sentinel.quorum) $pods) }}
+  {{- if gt (int .Values.replica.sentinel.quorum) $sentinels }}
+    {{- fail (printf "replica.sentinel.quorum (%d) cannot be greater than replica.sentinel.replicas (%d)." (int .Values.replica.sentinel.quorum) $sentinels) }}
   {{- end }}
   {{- if and .Values.replica.sentinel.preStopFailover (ge (int .Values.replica.sentinel.preStopFailoverTimeoutSeconds) (int .Values.replica.terminationGracePeriodSeconds)) }}
     {{- fail (printf "replica.sentinel.preStopFailoverTimeoutSeconds (%d) must be lower than replica.terminationGracePeriodSeconds (%d), otherwise the pod is killed while the graceful failover is still running." (int .Values.replica.sentinel.preStopFailoverTimeoutSeconds) (int .Values.replica.terminationGracePeriodSeconds)) }}

--- a/valkey/templates/_helpers.tpl
+++ b/valkey/templates/_helpers.tpl
@@ -216,6 +216,9 @@ Validate sentinel configuration
   {{- if gt (int .Values.replica.sentinel.quorum) $pods }}
     {{- fail (printf "replica.sentinel.quorum (%d) cannot be greater than the number of Sentinels (%d)." (int .Values.replica.sentinel.quorum) $pods) }}
   {{- end }}
+  {{- if and .Values.replica.sentinel.preStopFailover (ge (int .Values.replica.sentinel.preStopFailoverTimeoutSeconds) (int .Values.replica.terminationGracePeriodSeconds)) }}
+    {{- fail (printf "replica.sentinel.preStopFailoverTimeoutSeconds (%d) must be lower than replica.terminationGracePeriodSeconds (%d), otherwise the pod is killed while the graceful failover is still running." (int .Values.replica.sentinel.preStopFailoverTimeoutSeconds) (int .Values.replica.terminationGracePeriodSeconds)) }}
+  {{- end }}
   {{- if .Values.auth.enabled }}
     {{- $monitorUser := .Values.replica.sentinel.monitorUser | default .Values.replica.replicationUser }}
     {{- if not (hasKey .Values.auth.aclUsers $monitorUser) }}

--- a/valkey/templates/_helpers.tpl
+++ b/valkey/templates/_helpers.tpl
@@ -242,6 +242,11 @@ Validate sentinel configuration
   {{- if and .Values.replica.sentinel.preStopFailover (ge (int .Values.replica.sentinel.preStopFailoverTimeoutSeconds) (int .Values.replica.terminationGracePeriodSeconds)) }}
     {{- fail (printf "replica.sentinel.preStopFailoverTimeoutSeconds (%d) must be lower than replica.terminationGracePeriodSeconds (%d), otherwise the pod is killed while the graceful failover is still running." (int .Values.replica.sentinel.preStopFailoverTimeoutSeconds) (int .Values.replica.terminationGracePeriodSeconds)) }}
   {{- end }}
+  {{- $bootstrapWait := int .Values.replica.sentinel.initialTopologyWaitSeconds }}
+  {{- $sentinelStartup := int .Values.replica.sentinel.startupTimeoutSeconds }}
+  {{- if lt $bootstrapWait (add $sentinelStartup 30) }}
+    {{- fail (printf "replica.sentinel.initialTopologyWaitSeconds (%d) must be at least 30s above replica.sentinel.startupTimeoutSeconds (%d), which is %d. A pod with no recorded topology has nothing to be told until the Sentinels finish that discovery and bootstrap a master, so a shorter wait leaves the init container exiting just before the answer arrives." $bootstrapWait $sentinelStartup (add $sentinelStartup 30)) }}
+  {{- end }}
   {{- if and (not .Values.replica.sentinel.password) (not .Values.auth.usersExistingSecret) }}
     {{- fail "replica.sentinel.password is required when Sentinel is enabled, unless auth.usersExistingSecret supplies replica.sentinel.passwordKey." }}
   {{- end }}

--- a/valkey/templates/_helpers.tpl
+++ b/valkey/templates/_helpers.tpl
@@ -231,6 +231,24 @@ placeholders instead of the paths mounted into the containers.
 {{- end -}}
 
 {{/*
+TLS options for the Python example printed after an install. The Sentinel
+connection and the connection to the master are separate, so the same options
+have to be given twice: once inside sentinel_kwargs and once beside it.
+*/}}
+{{- define "valkey.python.tlsDictItems" -}}
+{{- if .Values.tls.enabled }}, "ssl": True, "ssl_ca_certs": "<{{ .Values.tls.caPublicKey }}>"
+{{- if .Values.tls.requireClientCertificate }}, "ssl_certfile": "<{{ .Values.tls.serverPublicKey }}>", "ssl_keyfile": "<{{ .Values.tls.serverKey }}>"{{ end }}
+{{- end }}
+{{- end -}}
+
+{{- define "valkey.python.tlsKwargs" -}}
+{{- if .Values.tls.enabled }},
+           ssl=True, ssl_ca_certs="<{{ .Values.tls.caPublicKey }}>"
+{{- if .Values.tls.requireClientCertificate }}, ssl_certfile="<{{ .Values.tls.serverPublicKey }}>", ssl_keyfile="<{{ .Values.tls.serverKey }}>"{{ end }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Validate sentinel configuration
 */}}
 {{- define "valkey.validateSentinelConfig" -}}

--- a/valkey/templates/_helpers.tpl
+++ b/valkey/templates/_helpers.tpl
@@ -189,6 +189,43 @@ Validate replica authentication configuration
 {{- end -}}
 
 {{/*
+valkey-cli TLS flags shared by the Sentinel scripts and probes
+*/}}
+{{- define "valkey.sentinel.cliTlsFlags" -}}
+{{- if .Values.tls.enabled -}}
+--tls --cacert /tls/{{ .Values.tls.caPublicKey }}
+{{- if .Values.tls.requireClientCertificate }} --cert /tls/{{ .Values.tls.serverPublicKey }} --key /tls/{{ .Values.tls.serverKey }}{{ end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate sentinel configuration
+*/}}
+{{- define "valkey.validateSentinelConfig" -}}
+{{- if .Values.replica.sentinel.enabled }}
+  {{- if not .Values.replica.enabled }}
+    {{- fail "Sentinel requires replication. Please set replica.enabled=true along with replica.sentinel.enabled=true" }}
+  {{- end }}
+  {{- $pods := add (int .Values.replica.replicas) 1 }}
+  {{- if lt $pods 3 }}
+    {{- fail (printf "Sentinel requires at least 3 pods to form a quorum, replica.replicas=%d gives %d. Please set replica.replicas to 2 or more." (int .Values.replica.replicas) $pods) }}
+  {{- end }}
+  {{- if lt (int .Values.replica.sentinel.quorum) 2 }}
+    {{- fail "replica.sentinel.quorum must be at least 2, a quorum of 1 allows a single Sentinel to trigger a failover on its own." }}
+  {{- end }}
+  {{- if gt (int .Values.replica.sentinel.quorum) $pods }}
+    {{- fail (printf "replica.sentinel.quorum (%d) cannot be greater than the number of Sentinels (%d)." (int .Values.replica.sentinel.quorum) $pods) }}
+  {{- end }}
+  {{- if .Values.auth.enabled }}
+    {{- $monitorUser := .Values.replica.sentinel.monitorUser | default .Values.replica.replicationUser }}
+    {{- if not (hasKey .Values.auth.aclUsers $monitorUser) }}
+      {{- fail (printf "Sentinel monitor user '%s' must be defined in auth.aclUsers. Sentinel needs it to reach the monitored Valkey nodes." $monitorUser) }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Render the Valkey server container health probes (startupProbe, livenessProbe,
 readinessProbe). Each probe is gated on its own `enabled` flag. When a probe's
 `customProbe` map is set it replaces the default handler and timing entirely;

--- a/valkey/templates/deploy_valkey.yaml
+++ b/valkey/templates/deploy_valkey.yaml
@@ -3,6 +3,7 @@
 {{- $storage := .Values.dataStorage }}
 {{- $createPVC := and $storage.enabled (not (empty $storage.requestedSize)) (empty $storage.persistentVolumeClaimName) }}
 {{- include "valkey.validateAuthConfig" . }}
+{{- include "valkey.validateSentinelConfig" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -60,6 +60,10 @@ data:
 
       printf '%s' "$password"
     }
+
+    escape_config_arg() {
+      printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+    }
     {{- end }}
 
     # Clean old log if requested
@@ -275,12 +279,13 @@ data:
       {{- $replUser := index .Values.auth.aclUsers $replUsername }}
       {{- $replPasswordKey := $replUser.passwordKey | default $replUsername }}
       REPL_PASSWORD=$(get_user_password "{{ $replUsername }}" "{{ $replPasswordKey }}") || exit 1
+      REPL_PASSWORD_ESCAPED=$(escape_config_arg "$REPL_PASSWORD")
 
       # Write masterauth configuration
       {
         echo ""
         echo "# Master authentication"
-        printf '%s\n' "masterauth $REPL_PASSWORD"
+        printf '%s\n' "masterauth \"$REPL_PASSWORD_ESCAPED\""
         echo "masteruser {{ $replUsername }}"
       } >>"$VALKEY_CONFIG_TMP"
       log "Configured masterauth with user {{ $replUsername }}"

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -187,14 +187,12 @@ data:
     # Without this, a pod that lost its volume would fall back to the pod index
     # and pod-0 would come back as a second writable master after a failover.
     master_from_sentinels() {
-      {{- if .Values.auth.enabled }}
-      sentinel_password=$(get_user_password "sentinel" "{{ .Values.replica.sentinel.passwordKey }}") || return 1
-      {{- end }}
+      sentinel_password=$(cat /sentinel-auth/existing-password 2>/dev/null || cat /sentinel-auth/inline-password 2>/dev/null) || return 1
       i=0
       while [ "$i" -lt {{ add (int .Values.replica.replicas) 1 }} ]; do
         peer="{{ include "valkey.fullname" . }}-${i}.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
         if [ "$peer" != "$SELF_HOST" ]; then
-          addr=$({{ if .Values.auth.enabled }}REDISCLI_AUTH="$sentinel_password" {{ end }}valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} {{ if .Values.auth.enabled }}--user sentinel {{ end }}\
+          addr=$(REDISCLI_AUTH="$sentinel_password" valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} --user sentinel \
             -t 2 -h "$peer" -p {{ .Values.replica.sentinel.port }} \
             sentinel get-master-addr-by-name {{ .Values.replica.sentinel.masterSet }} 2>/dev/null || true)
           host=$(echo "$addr" | sed -n 1p)
@@ -219,13 +217,9 @@ data:
       # Sentinel owns the topology: keep whatever it last wrote.
       log "Restoring replication target chosen by Sentinel: $SAVED_REPLICAOF"
       REPLICATION_TARGET="$SAVED_REPLICAOF"
-    elif [ "$HAS_PREVIOUS_CONFIG" = "true" ]; then
-      # A complete config from a previous run without a replicaof directive:
-      # this pod was the master and stays the master.
-      log "This pod (index $POD_INDEX) was the master before the restart, staying MASTER"
     else
-      # No usable local state: this is either a first boot or a pod that lost
-      # its volume.
+      # A persisted master role may be stale after this pod was unavailable, so
+      # ask the running Sentinels before trusting it or bootstrapping by index.
       DISCOVERED=$(master_from_sentinels || true)
       if [ -n "$DISCOVERED" ]; then
         FOUND_HOST=${DISCOVERED% *}
@@ -236,6 +230,8 @@ data:
           log "Sentinel reports $FOUND_HOST:$FOUND_PORT as the master, starting as REPLICA"
           REPLICATION_TARGET="replicaof $FOUND_HOST $FOUND_PORT"
         fi
+      elif [ "$HAS_PREVIOUS_CONFIG" = "true" ]; then
+        log "No Sentinel answered; this pod was the master before the restart, staying MASTER"
       elif [ "$POD_INDEX" = "0" ]; then
         log "Bootstrapping cluster, this pod (index $POD_INDEX) starts as MASTER"
       else

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -22,6 +22,12 @@ data:
     VALKEY_CONFIG_TMP="${VALKEY_CONFIG}.tmp"
 
     LOGFILE="/data/init.log"
+    {{- if and .Values.replica.enabled .Values.replica.sentinel.enabled }}
+    # Credential free record of the master this pod last followed. It is the
+    # only durable topology left once the config moved to a memory backed
+    # volume, and it is what breaks the cold start deadlock below.
+    MASTER_MARKER="/data/conf/last-master"
+    {{- end }}
     DATA_DIR="$(dirname "$VALKEY_CONFIG")"
 
     # Logging function (outputs to stderr and file)
@@ -211,8 +217,38 @@ data:
         REPLICATION_TARGET="replicaof $FOUND_HOST $FOUND_PORT"
       fi
     else
-      log "No Sentinel answered; refusing to start without a confirmed replication role"
-      exit 1
+      # Nothing answered. On a whole cluster cold start every Sentinel is also
+      # starting, and a Sentinel cannot name a master until a Valkey node is
+      # up, so waiting for one here deadlocks until Sentinel gives up and
+      # assumes pod-0, which discards the writes of the node that really was
+      # the master. Come up in the last role recorded on the data volume
+      # instead: the Sentinels are still scanning and will find the master.
+      MARKED=""
+      if [ -f "$MASTER_MARKER" ]; then
+        MARKED=$(head -n 1 "$MASTER_MARKER" | tr -d '\r')
+      fi
+      MARKED_HOST=${MARKED%% *}
+      MARKED_PORT=${MARKED##* }
+      if [ -n "$MARKED_HOST" ] && echo "$MARKED_PORT" | grep -qE "^[0-9]+$"; then
+        if [ "$MARKED_HOST" = "$SELF_HOST" ]; then
+          log "No Sentinel answered; last recorded master is this pod, starting as MASTER"
+        else
+          log "No Sentinel answered; last recorded master is $MARKED_HOST:$MARKED_PORT, starting as REPLICA"
+          REPLICATION_TARGET="replicaof $MARKED_HOST $MARKED_PORT"
+        fi
+      else
+        log "No Sentinel answered and no recorded topology; refusing to start without a confirmed replication role"
+        exit 1
+      fi
+    fi
+
+    # Record the master this pod is about to follow. Host and port only, never
+    # a credential, so it is safe to keep on the data volume.
+    mkdir -p "$(dirname "$MASTER_MARKER")"
+    if [ -n "$REPLICATION_TARGET" ]; then
+      printf '%s %s\n' "$(echo "$REPLICATION_TARGET" | awk '{print $2}')" "$(echo "$REPLICATION_TARGET" | awk '{print $3}')" > "$MASTER_MARKER"
+    else
+      printf '%s %s\n' "$SELF_HOST" "$MASTER_PORT" > "$MASTER_MARKER"
     fi
     {{- else }}
     if [ "$POD_INDEX" = "0" ]; then

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -397,11 +397,17 @@ data:
       else
       MARKED=""
       if [ -f "$MASTER_MARKER" ]; then
-        MARKED=$(head -n 1 "$MASTER_MARKER" | tr -d '\r')
+        # read fails on a line with no closing newline, which is what a record
+        # interrupted mid write looks like. Taking it would mean replicating
+        # from a truncated port such as "6", which no node is listening on.
+        IFS= read -r MARKED < "$MASTER_MARKER" || MARKED=""
+        MARKED=$(printf '%s' "$MARKED" | tr -d '\r')
       fi
       MARKED_HOST=${MARKED%% *}
       MARKED_PORT=${MARKED##* }
-      if [ -n "$MARKED_HOST" ] && echo "$MARKED_PORT" | grep -qE "^[0-9]+$"; then
+      if [ -n "$MARKED_HOST" ] && [ "$MARKED_HOST" != "$MARKED_PORT" ] &&
+         echo "$MARKED_PORT" | grep -qE "^[0-9]+$" &&
+         [ "$MARKED_PORT" -ge 1 ] && [ "$MARKED_PORT" -le 65535 ]; then
         if [ "$MARKED_HOST" = "$SELF_HOST" ]; then
           log "No Sentinel answered; last recorded master is this pod, starting as MASTER"
         else
@@ -448,10 +454,16 @@ data:
     # a credential, so it is safe to keep on the data volume.
     mkdir -p "$(dirname "$MASTER_MARKER")"
     if [ -n "$REPLICATION_TARGET" ]; then
-      printf '%s %s\n' "$(echo "$REPLICATION_TARGET" | awk '{print $2}')" "$(echo "$REPLICATION_TARGET" | awk '{print $3}')" > "$MASTER_MARKER"
+      MARKER_HOST=$(echo "$REPLICATION_TARGET" | awk '{print $2}')
+      MARKER_PORT=$(echo "$REPLICATION_TARGET" | awk '{print $3}')
     else
-      printf '%s %s\n' "$SELF_HOST" "$MASTER_PORT" > "$MASTER_MARKER"
+      MARKER_HOST="$SELF_HOST"
+      MARKER_PORT="$MASTER_PORT"
     fi
+    # Written under a temporary name and renamed, so that a pod killed here
+    # leaves the previous record rather than an empty or half written one.
+    printf '%s %s\n' "$MARKER_HOST" "$MARKER_PORT" > "$MASTER_MARKER.tmp"
+    mv "$MASTER_MARKER.tmp" "$MASTER_MARKER"
     {{- else }}
     if [ "$POD_INDEX" = "0" ]; then
       log "This pod (index $POD_INDEX) is configured as MASTER"

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -1,3 +1,9 @@
+{{- $pods := add (int .Values.replica.replicas) 1 }}
+{{- $initReplUser := .Values.replica.replicationUser }}
+{{- $initReplKey := $initReplUser }}
+{{- if and .Values.auth.enabled (hasKey .Values.auth.aclUsers $initReplUser) }}
+{{- $initReplKey = (index .Values.auth.aclUsers $initReplUser).passwordKey | default $initReplUser }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -300,6 +306,37 @@ data:
       [ -n "$host" ] && echo "$port" | grep -qE "^[0-9]+$" || return 1
       printf '%s %s\n' "$host" "$port"
     }
+
+    # Ask the Valkey nodes that are already running which of them is the master.
+    # A node that answers is better evidence than a record written before this
+    # pod went away: a pod that was down across a failover still has its own
+    # name in that record, and coming back writable next to the node that was
+    # promoted leaves two masters, which nothing can reconcile afterwards.
+    master_from_running_nodes() {
+      {{- if .Values.auth.enabled }}
+      repl_password=$(get_user_password "{{ $initReplUser }}" "{{ $initReplKey }}") || return 1
+      {{- end }}
+      i=0
+      while [ "$i" -lt "{{ $pods }}" ]; do
+        node="{{ include "valkey.fullname" . }}-${i}.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+        i=$((i + 1))
+        if [ "$node" = "$SELF_HOST" ]; then
+          continue
+        fi
+        {{- if .Values.auth.enabled }}
+        info=$(REDISCLI_AUTH="$repl_password" valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} --user "{{ $initReplUser }}" \
+          -t 2 -h "$node" -p {{ .Values.service.port }} info replication 2>/dev/null | tr -d '\r' || true)
+        {{- else }}
+        info=$(valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
+          -t 2 -h "$node" -p {{ .Values.service.port }} info replication 2>/dev/null | tr -d '\r' || true)
+        {{- end }}
+        if [ "$(echo "$info" | sed -n 's/^role://p')" = "master" ]; then
+          printf '%s %s\n' "$node" "{{ .Values.service.port }}"
+          return 0
+        fi
+      done
+      return 1
+    }
     {{- end }}
 
     # Determine the replication target for this pod.
@@ -324,6 +361,16 @@ data:
       # assumes pod-0, which discards the writes of the node that really was
       # the master. Come up in the last role recorded on the data volume
       # instead: the Sentinels are still scanning and will find the master.
+      # A node that is already up outranks the record, whichever way the record
+      # points: it settles a stale record that names this pod, and it avoids
+      # attaching to a node that has itself been demoted since.
+      RUNNING=$(master_from_running_nodes || true)
+      if [ -n "$RUNNING" ]; then
+        RUNNING_HOST=${RUNNING%% *}
+        RUNNING_PORT=${RUNNING##* }
+        log "No Sentinel answered, but $RUNNING_HOST:$RUNNING_PORT is already up as the master, starting as REPLICA"
+        REPLICATION_TARGET="replicaof $RUNNING_HOST $RUNNING_PORT"
+      else
       MARKED=""
       if [ -f "$MASTER_MARKER" ]; then
         MARKED=$(head -n 1 "$MASTER_MARKER" | tr -d '\r')
@@ -340,6 +387,7 @@ data:
       else
         log "No Sentinel answered and no recorded topology; refusing to start without a confirmed replication role"
         exit 1
+      fi
       fi
     fi
 

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -188,14 +188,13 @@ data:
     # and pod-0 would come back as a second writable master after a failover.
     master_from_sentinels() {
       {{- if .Values.auth.enabled }}
-      {{- $defaultUser := index .Values.auth.aclUsers "default" }}
-      sentinel_password=$(get_user_password "default" "{{ $defaultUser.passwordKey | default "default" }}") || return 1
+      sentinel_password=$(get_user_password "sentinel" "{{ .Values.replica.sentinel.passwordKey }}") || return 1
       {{- end }}
       i=0
       while [ "$i" -lt {{ add (int .Values.replica.replicas) 1 }} ]; do
         peer="{{ include "valkey.fullname" . }}-${i}.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
         if [ "$peer" != "$SELF_HOST" ]; then
-          addr=$({{ if .Values.auth.enabled }}REDISCLI_AUTH="$sentinel_password" {{ end }}valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
+          addr=$({{ if .Values.auth.enabled }}REDISCLI_AUTH="$sentinel_password" {{ end }}valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} {{ if .Values.auth.enabled }}--user sentinel {{ end }}\
             -t 2 -h "$peer" -p {{ .Values.replica.sentinel.port }} \
             sentinel get-master-addr-by-name {{ .Values.replica.sentinel.masterSet }} 2>/dev/null || true)
           host=$(echo "$addr" | sed -n 1p)
@@ -335,4 +334,3 @@ data:
 
     # Publish the finished config atomically.
     mv "$VALKEY_CONFIG_TMP" "$VALKEY_CONFIG"
-

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -16,7 +16,8 @@ data:
     # failover that happened after this pod started. An abrupt restart would
     # then come back with the pre-failover topology and could hand writes to a
     # node that had already been demoted. Mirroring the replicaof line onto the
-    # data volume keeps the record within about two intervals of reality.
+    # data volume keeps the record one interval behind a demotion, and two
+    # behind a promotion, for the reason given at the check below.
     #
     # It reads the config Valkey maintains rather than asking the server, so it
     # needs no credentials and no TLS material.
@@ -44,7 +45,12 @@ data:
         # No replicaof line means this pod is the master.
         host="$SELF"
         port="{{ .Values.service.port }}"
-        while IFS= read -r cfg_line || [ -n "$cfg_line" ]; do
+        # A line without a closing newline is the tail of a file still being
+        # rewritten, and a truncated "replicaof host po" would record a port
+        # that was never configured, so unterminated input is left for the next
+        # tick. Valkey always ends the rewritten config with a newline, so this
+        # only ever discards a partial read.
+        while IFS= read -r cfg_line; do
           # The trailing "" keeps $1 defined for blank and whitespace only lines.
           set -- $cfg_line ""
           case "$1" in
@@ -64,14 +70,19 @@ data:
           ""|*[!0-9]*) continue ;;
         esac
         [ -n "$host" ] || continue
-        # A config rewrite truncates the file and fills it again, so a tick can
-        # read it mid rewrite and miss the replicaof line that is still there.
-        # Only a reading that two consecutive ticks agree on is recorded, which
-        # a torn read cannot be.
-        if [ "$pending" != "$host $port" ]; then
+        # A rewrite truncates the file before filling it again, so a tick can
+        # read a prefix of it and find no replicaof line, which is exactly what
+        # a promotion looks like. Recording that wrongly is the direction that
+        # loses data, because the pod would come back writable, so this pod
+        # naming itself has to hold for two ticks. A replicaof line is recorded
+        # at once: a torn read can drop it but cannot invent one, and coming
+        # back as a replica of a node that is not the master costs a resync,
+        # not the writes.
+        if [ "$host" = "$SELF" ] && [ "$pending" != "$host $port" ]; then
           pending="$host $port"
           continue
         fi
+        pending="$host $port"
         current=""
         if [ -f "$MARKER" ]; then
           IFS= read -r current < "$MARKER" || current=""

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -1,8 +1,8 @@
 {{- $pods := add (int .Values.replica.replicas) 1 }}
-{{- $initReplUser := .Values.replica.replicationUser }}
-{{- $initReplKey := $initReplUser }}
-{{- if and .Values.auth.enabled (hasKey .Values.auth.aclUsers $initReplUser) }}
-{{- $initReplKey = (index .Values.auth.aclUsers $initReplUser).passwordKey | default $initReplUser }}
+{{- $initMonitorUser := .Values.replica.sentinel.monitorUser | default .Values.replica.replicationUser }}
+{{- $initMonitorKey := $initMonitorUser }}
+{{- if and .Values.auth.enabled (hasKey .Values.auth.aclUsers $initMonitorUser) }}
+{{- $initMonitorKey = (index .Values.auth.aclUsers $initMonitorUser).passwordKey | default $initMonitorUser }}
 {{- end }}
 apiVersion: v1
 kind: ConfigMap
@@ -314,7 +314,11 @@ data:
     # promoted leaves two masters, which nothing can reconcile afterwards.
     master_from_running_nodes() {
       {{- if .Values.auth.enabled }}
-      repl_password=$(get_user_password "{{ $initReplUser }}" "{{ $initReplKey }}") || return 1
+      # As the user Sentinel itself monitors with, not the replication user:
+      # the documented minimum for a replication user is +psync +replconf
+      # +ping, which cannot run INFO, while the monitor user already has to be
+      # allowed INFO for Sentinel to work at all.
+      monitor_password=$(get_user_password "{{ $initMonitorUser }}" "{{ $initMonitorKey }}") || return 1
       {{- end }}
       i=0
       while [ "$i" -lt "{{ $pods }}" ]; do
@@ -324,8 +328,16 @@ data:
           continue
         fi
         {{- if .Values.auth.enabled }}
-        info=$(REDISCLI_AUTH="$repl_password" valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} --user "{{ $initReplUser }}" \
+        info=$(REDISCLI_AUTH="$monitor_password" valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} --user "{{ $initMonitorUser }}" \
           -t 2 -h "$node" -p {{ .Values.service.port }} info replication 2>/dev/null | tr -d '\r' || true)
+        case "$info" in
+          # valkey-cli prints the refusal and still exits 0, so without this the
+          # node would look like it is simply not the master.
+          *NOPERM*)
+            log "ERROR: {{ $initMonitorUser }} may not run INFO on $node, so this pod cannot tell which node is the master"
+            return 1
+            ;;
+        esac
         {{- else }}
         info=$(valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
           -t 2 -h "$node" -p {{ .Values.service.port }} info replication 2>/dev/null | tr -d '\r' || true)

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -11,14 +11,14 @@ data:
 
     # Default config paths
     VALKEY_CONFIG=${VALKEY_CONFIG_PATH:-/data/conf/valkey.conf}
+    # The config is assembled in a temporary file and moved into place at the
+    # very end, so that an interrupted run can never leave a half written config
+    # behind. The restart logic below reads the previous config to decide the
+    # replication role, and a truncated file would make it read the wrong one.
+    VALKEY_CONFIG_TMP="${VALKEY_CONFIG}.tmp"
 
     LOGFILE="/data/init.log"
     DATA_DIR="/data/conf"
-    {{- if and .Values.replica.enabled .Values.replica.sentinel.enabled }}
-    # Marker written after the first successful bootstrap. Its presence means the
-    # replication topology below is owned by Sentinel, not by the pod index.
-    BOOTSTRAP_MARKER="/data/conf/.bootstrapped"
-    {{- end }}
 
     # Logging function (outputs to stderr and file)
     log() {
@@ -79,13 +79,15 @@ data:
     # it before the config is regenerated, otherwise every restart would reset
     # the cluster to "pod-0 is master" and fight Sentinel.
     SAVED_REPLICAOF=""
+    HAS_PREVIOUS_CONFIG=false
     if [ -f "$VALKEY_CONFIG" ]; then
+      HAS_PREVIOUS_CONFIG=true
       SAVED_REPLICAOF=$(grep -E "^[[:space:]]*(replicaof|slaveof)[[:space:]]" "$VALKEY_CONFIG" | tail -n 1 || true)
     fi
     {{- end }}
 
     mkdir -p "$DATA_DIR"
-    rm -f "$VALKEY_CONFIG"
+    rm -f "$VALKEY_CONFIG_TMP"
 
 
     # Base valkey.conf
@@ -109,7 +111,7 @@ data:
       echo "protected-mode no"
       echo "bind * -::*"
       echo "dir /data"
-    } >>"$VALKEY_CONFIG"
+    } >>"$VALKEY_CONFIG_TMP"
 
     {{- if .Values.auth.enabled }}
     # Create secure directory for ACL file
@@ -117,7 +119,7 @@ data:
     mkdir -p /etc/valkey
 
     # Set aclfile path in valkey.conf
-    echo "aclfile /etc/valkey/users.acl" >>"$VALKEY_CONFIG"
+    echo "aclfile /etc/valkey/users.acl" >>"$VALKEY_CONFIG_TMP"
 
     # Remove or reset existing ACL file if present (it may be read-only from previous run)
     log "Preparing ACL file at /etc/valkey/users.acl"
@@ -176,7 +178,7 @@ data:
       echo "# Replication announce configuration"
       echo "replica-announce-ip {{ include "valkey.fullname" . }}-$POD_INDEX.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
       echo "replica-announce-port {{ .Values.service.port }}"
-    } >>"$VALKEY_CONFIG"
+    } >>"$VALKEY_CONFIG_TMP"
 
     # Determine the replication target for this pod.
     REPLICATION_TARGET=""
@@ -185,8 +187,9 @@ data:
       # Sentinel owns the topology: keep whatever it last wrote.
       log "Restoring replication target chosen by Sentinel: $SAVED_REPLICAOF"
       REPLICATION_TARGET="$SAVED_REPLICAOF"
-    elif [ -f "$BOOTSTRAP_MARKER" ]; then
-      # Already bootstrapped and no replicaof on disk: this pod is the master.
+    elif [ "$HAS_PREVIOUS_CONFIG" = "true" ]; then
+      # A complete config from a previous run without a replicaof directive:
+      # this pod was the master and stays the master.
       log "This pod (index $POD_INDEX) was the master before the restart, staying MASTER"
     elif [ "$POD_INDEX" = "0" ]; then
       log "Bootstrapping cluster, this pod (index $POD_INDEX) starts as MASTER"
@@ -208,7 +211,7 @@ data:
         echo ""
         echo "# Replica Configuration"
         echo "$REPLICATION_TARGET"
-      } >>"$VALKEY_CONFIG"
+      } >>"$VALKEY_CONFIG_TMP"
     fi
 
     {{- if .Values.replica.sentinel.enabled }}
@@ -230,7 +233,7 @@ data:
         echo "# Diskless replication"
         echo "repl-diskless-sync yes"
         echo "repl-diskless-sync-delay 5"
-      } >>"$VALKEY_CONFIG"
+      } >>"$VALKEY_CONFIG_TMP"
       {{- end }}
 
       {{- if .Values.auth.enabled }}
@@ -246,7 +249,7 @@ data:
         echo "# Master authentication"
         echo "masterauth $REPL_PASSWORD"
         echo "masteruser {{ $replUsername }}"
-      } >>"$VALKEY_CONFIG"
+      } >>"$VALKEY_CONFIG_TMP"
       log "Configured masterauth with user {{ $replUsername }}"
       {{- end }}
 
@@ -256,7 +259,7 @@ data:
         echo ""
         echo "# TLS for replication"
         echo "tls-replication yes"
-      } >>"$VALKEY_CONFIG"
+      } >>"$VALKEY_CONFIG_TMP"
       log "Enabled TLS for replication"
       {{- end }}
     fi
@@ -268,7 +271,7 @@ data:
       echo "# Minimum replicas for write operations"
       echo "min-replicas-to-write {{ .Values.replica.minReplicasToWrite }}"
       echo "min-replicas-max-lag {{ .Values.replica.minReplicasMaxLag }}"
-    } >>"$VALKEY_CONFIG"
+    } >>"$VALKEY_CONFIG_TMP"
     log "Configured write safety: require {{ .Values.replica.minReplicasToWrite }} replicas with max {{ .Values.replica.minReplicasMaxLag }}s lag"
     {{- end }}
     {{- end }}
@@ -276,14 +279,13 @@ data:
     # Append extra configs if present
     if [ -f /usr/local/etc/valkey/valkey.conf ]; then
       log "Appending /usr/local/etc/valkey/valkey.conf"
-      cat /usr/local/etc/valkey/valkey.conf >>"$VALKEY_CONFIG"
+      cat /usr/local/etc/valkey/valkey.conf >>"$VALKEY_CONFIG_TMP"
     fi
     if [ -d /extravalkeyconfigs ]; then
       log "Appending files in /extravalkeyconfigs/"
-      cat /extravalkeyconfigs/* >>"$VALKEY_CONFIG"
+      cat /extravalkeyconfigs/* >>"$VALKEY_CONFIG_TMP"
     fi
-    {{- if and .Values.replica.enabled .Values.replica.sentinel.enabled }}
 
-    touch "$BOOTSTRAP_MARKER"
-    {{- end }}
+    # Publish the finished config atomically.
+    mv "$VALKEY_CONFIG_TMP" "$VALKEY_CONFIG"
 

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -45,6 +45,7 @@ data:
       set -f
       pending=""
       cfg_line=""
+      write_failed=""
       while :; do
         sleep {{ .Values.replica.sentinel.masterRecordRefreshSeconds }}
         [ -f "$CONF" ] || continue
@@ -94,8 +95,19 @@ data:
           IFS= read -r current < "$MARKER" || current=""
         fi
         if [ "$current" != "$host $port" ]; then
-          mkdir -p /data/conf 2>/dev/null || true
-          printf '%s %s\n' "$host" "$port" > "$MARKER" 2>/dev/null || true
+          # Write and rename, so that a cold start can never read half a record,
+          # and say so when it fails. A record that cannot be updated keeps
+          # naming this pod after it has been demoted, and that is what a cold
+          # start would come back on. The next tick retries, because the record
+          # still does not match, so one complaint per outage is enough.
+          if mkdir -p /data/conf 2>/dev/null &&
+             printf '%s %s\n' "$host" "$port" > "$MARKER.tmp" 2>/dev/null &&
+             mv "$MARKER.tmp" "$MARKER" 2>/dev/null; then
+            write_failed=""
+          elif [ -z "$write_failed" ]; then
+            write_failed="yes"
+            echo "$(date) ERROR: cannot record the master as $host $port in $MARKER, a cold start would fall back on the last record written" >&2
+          fi
         fi
       done
     }

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -14,6 +14,11 @@ data:
 
     LOGFILE="/data/init.log"
     DATA_DIR="/data/conf"
+    {{- if and .Values.replica.enabled .Values.replica.sentinel.enabled }}
+    # Marker written after the first successful bootstrap. Its presence means the
+    # replication topology below is owned by Sentinel, not by the pod index.
+    BOOTSTRAP_MARKER="/data/conf/.bootstrapped"
+    {{- end }}
 
     # Logging function (outputs to stderr and file)
     log() {
@@ -67,6 +72,18 @@ data:
     fi
 
     log "Creating configuration in $DATA_DIR..."
+    {{- if and .Values.replica.enabled .Values.replica.sentinel.enabled }}
+
+    # Sentinel rewrites valkey.conf via CONFIG REWRITE whenever the topology
+    # changes, so the replication target on disk is the source of truth. Capture
+    # it before the config is regenerated, otherwise every restart would reset
+    # the cluster to "pod-0 is master" and fight Sentinel.
+    SAVED_REPLICAOF=""
+    if [ -f "$VALKEY_CONFIG" ]; then
+      SAVED_REPLICAOF=$(grep -E "^[[:space:]]*(replicaof|slaveof)[[:space:]]" "$VALKEY_CONFIG" | tail -n 1 || true)
+    fi
+    {{- end }}
+
     mkdir -p "$DATA_DIR"
     rm -f "$VALKEY_CONFIG"
 
@@ -149,39 +166,72 @@ data:
 
     # Use POD_INDEX from Kubernetes metadata
     POD_INDEX=${POD_INDEX:-0}
-    IS_MASTER=false
+    MASTER_HOST="{{ include "valkey.fullname" . }}-0.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+    MASTER_PORT="{{ .Values.service.port }}"
 
-    # Check if this is pod-0 (master)
+    # Every pod announces a stable hostname so that peers (and Sentinel) address
+    # it by DNS name instead of a pod IP that changes on every reschedule.
+    {
+      echo ""
+      echo "# Replication announce configuration"
+      echo "replica-announce-ip {{ include "valkey.fullname" . }}-$POD_INDEX.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+      echo "replica-announce-port {{ .Values.service.port }}"
+    } >>"$VALKEY_CONFIG"
+
+    # Determine the replication target for this pod.
+    REPLICATION_TARGET=""
+    {{- if .Values.replica.sentinel.enabled }}
+    if [ -n "$SAVED_REPLICAOF" ]; then
+      # Sentinel owns the topology: keep whatever it last wrote.
+      log "Restoring replication target chosen by Sentinel: $SAVED_REPLICAOF"
+      REPLICATION_TARGET="$SAVED_REPLICAOF"
+    elif [ -f "$BOOTSTRAP_MARKER" ]; then
+      # Already bootstrapped and no replicaof on disk: this pod is the master.
+      log "This pod (index $POD_INDEX) was the master before the restart, staying MASTER"
+    elif [ "$POD_INDEX" = "0" ]; then
+      log "Bootstrapping cluster, this pod (index $POD_INDEX) starts as MASTER"
+    else
+      log "Bootstrapping cluster, this pod (index $POD_INDEX) starts as REPLICA of $MASTER_HOST:$MASTER_PORT"
+      REPLICATION_TARGET="replicaof $MASTER_HOST $MASTER_PORT"
+    fi
+    {{- else }}
     if [ "$POD_INDEX" = "0" ]; then
-      IS_MASTER=true
       log "This pod (index $POD_INDEX) is configured as MASTER"
     else
-      log "This pod (index $POD_INDEX) is configured as REPLICA"
+      log "This pod (index $POD_INDEX) is configured as REPLICA of $MASTER_HOST:$MASTER_PORT"
+      REPLICATION_TARGET="replicaof $MASTER_HOST $MASTER_PORT"
     fi
+    {{- end }}
 
-    # Configure replica settings
-    if [ "$IS_MASTER" = "false" ]; then
-      MASTER_HOST="{{ include "valkey.fullname" . }}-0.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
-      MASTER_PORT="{{ .Values.service.port }}"
-
-      log "Configuring replica to follow master at $MASTER_HOST:$MASTER_PORT"
-
+    if [ -n "$REPLICATION_TARGET" ]; then
       {
         echo ""
         echo "# Replica Configuration"
-        echo "replicaof $MASTER_HOST $MASTER_PORT"
-        echo "replica-announce-ip {{ include "valkey.fullname" . }}-$POD_INDEX.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
-        {{- if .Values.replica.disklessSync }}
+        echo "$REPLICATION_TARGET"
+      } >>"$VALKEY_CONFIG"
+    fi
+
+    {{- if .Values.replica.sentinel.enabled }}
+    # In Sentinel mode the replica-side settings are written on every pod,
+    # because any pod can be demoted to a replica by a failover.
+    CONFIGURE_REPLICA_SETTINGS=true
+    {{- else }}
+    CONFIGURE_REPLICA_SETTINGS=false
+    if [ -n "$REPLICATION_TARGET" ]; then
+      CONFIGURE_REPLICA_SETTINGS=true
+    fi
+    {{- end }}
+
+    if [ "$CONFIGURE_REPLICA_SETTINGS" = "true" ]; then
+      log "Configuring replica settings"
+      {{- if .Values.replica.disklessSync }}
+      {
         echo ""
         echo "# Diskless replication"
         echo "repl-diskless-sync yes"
         echo "repl-diskless-sync-delay 5"
-        {{- end }}
-        {{- if .Values.auth.enabled }}
-        echo ""
-        echo "# Master authentication"
-        {{- end }}
       } >>"$VALKEY_CONFIG"
+      {{- end }}
 
       {{- if .Values.auth.enabled }}
       # Get the password for the replication user
@@ -191,8 +241,12 @@ data:
       REPL_PASSWORD=$(get_user_password "{{ $replUsername }}" "{{ $replPasswordKey }}") || exit 1
 
       # Write masterauth configuration
-      echo "masterauth $REPL_PASSWORD" >>"$VALKEY_CONFIG"
-      echo "masteruser {{ $replUsername }}" >>"$VALKEY_CONFIG"
+      {
+        echo ""
+        echo "# Master authentication"
+        echo "masterauth $REPL_PASSWORD"
+        echo "masteruser {{ $replUsername }}"
+      } >>"$VALKEY_CONFIG"
       log "Configured masterauth with user {{ $replUsername }}"
       {{- end }}
 
@@ -228,4 +282,8 @@ data:
       log "Appending files in /extravalkeyconfigs/"
       cat /extravalkeyconfigs/* >>"$VALKEY_CONFIG"
     fi
+    {{- if and .Values.replica.enabled .Values.replica.sentinel.enabled }}
+
+    touch "$BOOTSTRAP_MARKER"
+    {{- end }}
 

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -58,7 +58,7 @@ data:
       fi
       {{- end }}
 
-      echo "$password"
+      printf '%s' "$password"
     }
     {{- end }}
 
@@ -143,8 +143,8 @@ data:
     PASSWORD=$(get_user_password "{{ $username }}" "{{ $passwordKey }}") || exit 1
 
     # Hash the password and write ACL entry
-    PASSHASH=$(echo -n "$PASSWORD" | sha256sum | cut -f 1 -d " ")
-    echo "user {{ $username }} on #$PASSHASH {{ $user.permissions }}" >> /etc/valkey/users.acl
+    PASSHASH=$(printf '%s' "$PASSWORD" | sha256sum | cut -f 1 -d " ")
+    printf '%s\n' "user {{ $username }} on #$PASSHASH {{ $user.permissions }}" >> /etc/valkey/users.acl
 
     {{- end }}
     {{- end }}
@@ -293,7 +293,7 @@ data:
       {
         echo ""
         echo "# Master authentication"
-        echo "masterauth $REPL_PASSWORD"
+        printf '%s\n' "masterauth $REPL_PASSWORD"
         echo "masteruser {{ $replUsername }}"
       } >>"$VALKEY_CONFIG_TMP"
       log "Configured masterauth with user {{ $replUsername }}"

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -5,6 +5,54 @@ metadata:
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
 data:
+{{- if and .Values.replica.enabled .Values.replica.sentinel.enabled }}
+  valkey-start.sh: |-
+    #!/bin/sh
+    # Starts the server, and keeps the credential free record of the current
+    # master fresh while it runs.
+    #
+    # Sentinel persists a promotion by making the server rewrite its config, and
+    # that config is on a memory backed volume, so nothing on disk would show a
+    # failover that happened after this pod started. An abrupt restart would
+    # then come back with the pre-failover topology and could hand writes to a
+    # node that had already been demoted. Mirroring the replicaof line onto the
+    # data volume keeps the record at most one interval behind reality.
+    #
+    # It reads the config Valkey maintains rather than asking the server, so it
+    # needs no credentials and no TLS material.
+    set -eu
+
+    CONF="${VALKEY_CONFIG_PATH:-/valkey-conf/valkey.conf}"
+    MARKER="/data/conf/last-master"
+    SELF="{{ include "valkey.fullname" . }}-${POD_INDEX:-0}.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+
+    track_master() {
+      while :; do
+        sleep {{ .Values.replica.sentinel.masterRecordRefreshSeconds }}
+        [ -f "$CONF" ] || continue
+        line=$(grep -E "^[[:space:]]*(replicaof|slaveof)[[:space:]]" "$CONF" | tail -n 1 || true)
+        if [ -n "$line" ]; then
+          host=$(echo "$line" | awk '{print $2}')
+          port=$(echo "$line" | awk '{print $3}')
+        else
+          host="$SELF"
+          port="{{ .Values.service.port }}"
+        fi
+        if [ -n "$host" ] && echo "$port" | grep -qE "^[0-9]+$"; then
+          current=""
+          [ -f "$MARKER" ] && current=$(cat "$MARKER" 2>/dev/null || true)
+          if [ "$current" != "$host $port" ]; then
+            mkdir -p /data/conf 2>/dev/null || true
+            printf '%s %s\n' "$host" "$port" > "$MARKER" 2>/dev/null || true
+          fi
+        fi
+      done
+    }
+
+    track_master &
+    exec valkey-server "$@"
+{{- end }}
+
   init.sh: |-
     #!/bin/sh
     set -eu

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -16,10 +16,16 @@ data:
     # failover that happened after this pod started. An abrupt restart would
     # then come back with the pre-failover topology and could hand writes to a
     # node that had already been demoted. Mirroring the replicaof line onto the
-    # data volume keeps the record at most one interval behind reality.
+    # data volume keeps the record within about two intervals of reality.
     #
     # It reads the config Valkey maintains rather than asking the server, so it
     # needs no credentials and no TLS material.
+    #
+    # Valkey rewrites the config at the moment Sentinel changes this pod's role,
+    # so the loop below runs once a second by default to keep the record close
+    # to the promotion that it describes. Everything it does on a tick where
+    # nothing changed is a shell builtin, so the only process it starts per tick
+    # is the sleep itself.
     set -eu
 
     CONF="${VALKEY_CONFIG_PATH:-/valkey-conf/valkey.conf}"
@@ -27,24 +33,52 @@ data:
     SELF="{{ include "valkey.fullname" . }}-${POD_INDEX:-0}.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
 
     track_master() {
+      # Word splitting is what parses each config line, so keep globbing off:
+      # an unrelated directive holding a * must not expand against the cwd.
+      set -f
+      pending=""
+      cfg_line=""
       while :; do
         sleep {{ .Values.replica.sentinel.masterRecordRefreshSeconds }}
         [ -f "$CONF" ] || continue
-        line=$(grep -E "^[[:space:]]*(replicaof|slaveof)[[:space:]]" "$CONF" | tail -n 1 || true)
-        if [ -n "$line" ]; then
-          host=$(echo "$line" | awk '{print $2}')
-          port=$(echo "$line" | awk '{print $3}')
-        else
-          host="$SELF"
-          port="{{ .Values.service.port }}"
+        # No replicaof line means this pod is the master.
+        host="$SELF"
+        port="{{ .Values.service.port }}"
+        while IFS= read -r cfg_line || [ -n "$cfg_line" ]; do
+          # The trailing "" keeps $1 defined for blank and whitespace only lines.
+          set -- $cfg_line ""
+          case "$1" in
+            replicaof|slaveof)
+              if [ "${2:-}" = "no" ] && [ "${3:-}" = "one" ]; then
+                # Valkey spells "this node is a master" as "replicaof no one".
+                host="$SELF"
+                port="{{ .Values.service.port }}"
+              else
+                host="${2:-}"
+                port="${3:-}"
+              fi
+              ;;
+          esac
+        done < "$CONF"
+        case "$port" in
+          ""|*[!0-9]*) continue ;;
+        esac
+        [ -n "$host" ] || continue
+        # A config rewrite truncates the file and fills it again, so a tick can
+        # read it mid rewrite and miss the replicaof line that is still there.
+        # Only a reading that two consecutive ticks agree on is recorded, which
+        # a torn read cannot be.
+        if [ "$pending" != "$host $port" ]; then
+          pending="$host $port"
+          continue
         fi
-        if [ -n "$host" ] && echo "$port" | grep -qE "^[0-9]+$"; then
-          current=""
-          [ -f "$MARKER" ] && current=$(cat "$MARKER" 2>/dev/null || true)
-          if [ "$current" != "$host $port" ]; then
-            mkdir -p /data/conf 2>/dev/null || true
-            printf '%s %s\n' "$host" "$port" > "$MARKER" 2>/dev/null || true
-          fi
+        current=""
+        if [ -f "$MARKER" ]; then
+          IFS= read -r current < "$MARKER" || current=""
+        fi
+        if [ "$current" != "$host $port" ]; then
+          mkdir -p /data/conf 2>/dev/null || true
+          printf '%s %s\n' "$host" "$port" > "$MARKER" 2>/dev/null || true
         fi
       done
     }

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -78,15 +78,11 @@ data:
     log "Creating configuration in $DATA_DIR..."
     {{- if and .Values.replica.enabled .Values.replica.sentinel.enabled }}
 
-    # Sentinel rewrites valkey.conf via CONFIG REWRITE whenever the topology
-    # changes, so the replication target on disk is the source of truth. Capture
-    # it before the config is regenerated, otherwise every restart would reset
-    # the cluster to "pod-0 is master" and fight Sentinel.
-    SAVED_REPLICAOF=""
+    # A previous configuration means this pod may have missed a failover while
+    # it was offline, so Sentinel must confirm its role before it starts again.
     HAS_PREVIOUS_CONFIG=false
     if [ -f "$VALKEY_CONFIG" ]; then
       HAS_PREVIOUS_CONFIG=true
-      SAVED_REPLICAOF=$(grep -E "^[[:space:]]*(replicaof|slaveof)[[:space:]]" "$VALKEY_CONFIG" | tail -n 1 || true)
     fi
     {{- end }}
 
@@ -220,12 +216,9 @@ data:
         log "Sentinel reports $FOUND_HOST:$FOUND_PORT as the master, starting as REPLICA"
         REPLICATION_TARGET="replicaof $FOUND_HOST $FOUND_PORT"
       fi
-    elif [ -n "$SAVED_REPLICAOF" ]; then
-      # If no Sentinel answers, retain the last topology it persisted.
-      log "No Sentinel answered; restoring the saved replication target: $SAVED_REPLICAOF"
-      REPLICATION_TARGET="$SAVED_REPLICAOF"
     elif [ "$HAS_PREVIOUS_CONFIG" = "true" ]; then
-      log "No Sentinel answered; this pod was the master before the restart, staying MASTER"
+      log "No Sentinel answered; refusing to start with a potentially stale replication role"
+      exit 1
     elif [ "$POD_INDEX" = "0" ]; then
       log "Bootstrapping cluster, this pod (index $POD_INDEX) starts as MASTER"
     else

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -208,31 +208,29 @@ data:
     # Determine the replication target for this pod.
     REPLICATION_TARGET=""
     {{- if .Values.replica.sentinel.enabled }}
-    if [ -n "$SAVED_REPLICAOF" ]; then
-      # Sentinel owns the topology: keep whatever it last wrote.
-      log "Restoring replication target chosen by Sentinel: $SAVED_REPLICAOF"
-      REPLICATION_TARGET="$SAVED_REPLICAOF"
-    else
-      # A persisted master role may be stale after this pod was unavailable, so
-      # ask the running Sentinels before trusting it or bootstrapping by index.
-      DISCOVERED=$(master_from_sentinels || true)
-      if [ -n "$DISCOVERED" ]; then
-        FOUND_HOST=${DISCOVERED% *}
-        FOUND_PORT=${DISCOVERED#* }
-        if [ "$FOUND_HOST" = "$SELF_HOST" ]; then
-          log "Sentinel reports this pod as the master, starting as MASTER"
-        else
-          log "Sentinel reports $FOUND_HOST:$FOUND_PORT as the master, starting as REPLICA"
-          REPLICATION_TARGET="replicaof $FOUND_HOST $FOUND_PORT"
-        fi
-      elif [ "$HAS_PREVIOUS_CONFIG" = "true" ]; then
-        log "No Sentinel answered; this pod was the master before the restart, staying MASTER"
-      elif [ "$POD_INDEX" = "0" ]; then
-        log "Bootstrapping cluster, this pod (index $POD_INDEX) starts as MASTER"
+    # Persisted topology may be stale if this pod was offline during failover,
+    # so prefer the current master reported by Sentinel.
+    DISCOVERED=$(master_from_sentinels || true)
+    if [ -n "$DISCOVERED" ]; then
+      FOUND_HOST=${DISCOVERED% *}
+      FOUND_PORT=${DISCOVERED#* }
+      if [ "$FOUND_HOST" = "$SELF_HOST" ]; then
+        log "Sentinel reports this pod as the master, starting as MASTER"
       else
-        log "Bootstrapping cluster, this pod (index $POD_INDEX) starts as REPLICA of $MASTER_HOST:$MASTER_PORT"
-        REPLICATION_TARGET="replicaof $MASTER_HOST $MASTER_PORT"
+        log "Sentinel reports $FOUND_HOST:$FOUND_PORT as the master, starting as REPLICA"
+        REPLICATION_TARGET="replicaof $FOUND_HOST $FOUND_PORT"
       fi
+    elif [ -n "$SAVED_REPLICAOF" ]; then
+      # If no Sentinel answers, retain the last topology it persisted.
+      log "No Sentinel answered; restoring the saved replication target: $SAVED_REPLICAOF"
+      REPLICATION_TARGET="$SAVED_REPLICAOF"
+    elif [ "$HAS_PREVIOUS_CONFIG" = "true" ]; then
+      log "No Sentinel answered; this pod was the master before the restart, staying MASTER"
+    elif [ "$POD_INDEX" = "0" ]; then
+      log "Bootstrapping cluster, this pod (index $POD_INDEX) starts as MASTER"
+    else
+      log "Bootstrapping cluster, this pod (index $POD_INDEX) starts as REPLICA of $MASTER_HOST:$MASTER_PORT"
+      REPLICATION_TARGET="replicaof $MASTER_HOST $MASTER_PORT"
     fi
     {{- else }}
     if [ "$POD_INDEX" = "0" ]; then

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -76,16 +76,6 @@ data:
     fi
 
     log "Creating configuration in $DATA_DIR..."
-    {{- if and .Values.replica.enabled .Values.replica.sentinel.enabled }}
-
-    # A previous configuration means this pod may have missed a failover while
-    # it was offline, so Sentinel must confirm its role before it starts again.
-    HAS_PREVIOUS_CONFIG=false
-    if [ -f "$VALKEY_CONFIG" ]; then
-      HAS_PREVIOUS_CONFIG=true
-    fi
-    {{- end }}
-
     mkdir -p "$DATA_DIR"
     rm -f "$VALKEY_CONFIG_TMP"
 
@@ -216,14 +206,9 @@ data:
         log "Sentinel reports $FOUND_HOST:$FOUND_PORT as the master, starting as REPLICA"
         REPLICATION_TARGET="replicaof $FOUND_HOST $FOUND_PORT"
       fi
-    elif [ "$HAS_PREVIOUS_CONFIG" = "true" ]; then
-      log "No Sentinel answered; refusing to start with a potentially stale replication role"
-      exit 1
-    elif [ "$POD_INDEX" = "0" ]; then
-      log "Bootstrapping cluster, this pod (index $POD_INDEX) starts as MASTER"
     else
-      log "Bootstrapping cluster, this pod (index $POD_INDEX) starts as REPLICA of $MASTER_HOST:$MASTER_PORT"
-      REPLICATION_TARGET="replicaof $MASTER_HOST $MASTER_PORT"
+      log "No Sentinel answered; refusing to start without a confirmed replication role"
+      exit 1
     fi
     {{- else }}
     if [ "$POD_INDEX" = "0" ]; then

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -10,7 +10,11 @@ data:
     set -eu
 
     # Default config paths
-    VALKEY_CONFIG=${VALKEY_CONFIG_PATH:-/data/conf/valkey.conf}
+    # The config lives on a memory backed emptyDir, not on the data volume: it
+    # carries the replication credentials in plain text, and CONFIG REWRITE puts
+    # them back on every failover even if this script never wrote them, so the
+    # file itself has to stay off persistent storage.
+    VALKEY_CONFIG=${VALKEY_CONFIG_PATH:-/valkey-conf/valkey.conf}
     # The config is assembled in a temporary file and moved into place at the
     # very end, so that an interrupted run can never leave a half written config
     # behind. The restart logic below reads the previous config to decide the
@@ -18,7 +22,7 @@ data:
     VALKEY_CONFIG_TMP="${VALKEY_CONFIG}.tmp"
 
     LOGFILE="/data/init.log"
-    DATA_DIR="/data/conf"
+    DATA_DIR="$(dirname "$VALKEY_CONFIG")"
 
     # Logging function (outputs to stderr and file)
     log() {

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -161,6 +161,14 @@ data:
       fi
       {{- end }}
 
+      # An empty value in the secret would otherwise be hashed into the ACL,
+      # and the hash of an empty password is the same everywhere, so the user
+      # would be open to anyone who can reach the port.
+      if [ -z "$password" ]; then
+        log "ERROR: The password for user $username is empty"
+        return 1
+      fi
+
       printf '%s' "$password"
     }
 

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -188,25 +188,16 @@ data:
     # and pod-0 would come back as a second writable master after a failover.
     master_from_sentinels() {
       sentinel_password=$(cat /sentinel-auth/existing-password 2>/dev/null || cat /sentinel-auth/inline-password 2>/dev/null) || return 1
-      i=0
-      while [ "$i" -lt {{ add (int .Values.replica.replicas) 1 }} ]; do
-        peer="{{ include "valkey.fullname" . }}-${i}.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
-        if [ "$peer" != "$SELF_HOST" ]; then
-          addr=$(REDISCLI_AUTH="$sentinel_password" valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} --user sentinel \
-            -t 2 -h "$peer" -p {{ .Values.replica.sentinel.port }} \
-            sentinel get-master-addr-by-name {{ .Values.replica.sentinel.masterSet }} 2>/dev/null || true)
-          host=$(echo "$addr" | sed -n 1p)
-          port=$(echo "$addr" | sed -n 2p)
-          # Reject anything that is not a complete host/port pair, an error
-          # reply would otherwise be turned into a bogus replication target.
-          if [ -n "$host" ] && echo "$port" | grep -qE "^[0-9]+$"; then
-            printf '%s %s\n' "$host" "$port"
-            return 0
-          fi
-        fi
-        i=$((i + 1))
-      done
-      return 1
+      peer="{{ include "valkey.sentinel.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+      addr=$(REDISCLI_AUTH="$sentinel_password" valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} --user sentinel \
+        -t 2 -h "$peer" -p {{ .Values.replica.sentinel.port }} \
+        sentinel get-master-addr-by-name {{ .Values.replica.sentinel.masterSet }} 2>/dev/null || true)
+      host=$(echo "$addr" | sed -n 1p)
+      port=$(echo "$addr" | sed -n 2p)
+      # Reject anything that is not a complete host/port pair, an error reply
+      # would otherwise be turned into a bogus replication target.
+      [ -n "$host" ] && echo "$port" | grep -qE "^[0-9]+$" || return 1
+      printf '%s %s\n' "$host" "$port"
     }
     {{- end }}
 

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -104,9 +104,9 @@ data:
       echo "tls-auth-clients no"
       {{- end }}
       echo "port 0"
-      echo "tls-port 6379"
+      echo "tls-port {{ .Values.service.port }}"
 {{- else }}
-      echo "port 6379"
+      echo "port {{ .Values.service.port }}"
 {{- end }}
       echo "protected-mode no"
       echo "bind * -::*"
@@ -180,6 +180,39 @@ data:
       echo "replica-announce-port {{ .Values.service.port }}"
     } >>"$VALKEY_CONFIG_TMP"
 
+    {{- if .Values.replica.sentinel.enabled }}
+    SELF_HOST="{{ include "valkey.fullname" . }}-$POD_INDEX.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+
+    # Ask the Sentinels that are already running which node is the master.
+    # Without this, a pod that lost its volume would fall back to the pod index
+    # and pod-0 would come back as a second writable master after a failover.
+    master_from_sentinels() {
+      {{- if .Values.auth.enabled }}
+      {{- $defaultUser := index .Values.auth.aclUsers "default" }}
+      sentinel_password=$(get_user_password "default" "{{ $defaultUser.passwordKey | default "default" }}") || return 1
+      {{- end }}
+      i=0
+      while [ "$i" -lt {{ add (int .Values.replica.replicas) 1 }} ]; do
+        peer="{{ include "valkey.fullname" . }}-${i}.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+        if [ "$peer" != "$SELF_HOST" ]; then
+          addr=$({{ if .Values.auth.enabled }}REDISCLI_AUTH="$sentinel_password" {{ end }}valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
+            -t 2 -h "$peer" -p {{ .Values.replica.sentinel.port }} \
+            sentinel get-master-addr-by-name {{ .Values.replica.sentinel.masterSet }} 2>/dev/null || true)
+          host=$(echo "$addr" | sed -n 1p)
+          port=$(echo "$addr" | sed -n 2p)
+          # Reject anything that is not a complete host/port pair, an error
+          # reply would otherwise be turned into a bogus replication target.
+          if [ -n "$host" ] && echo "$port" | grep -qE "^[0-9]+$"; then
+            printf '%s %s\n' "$host" "$port"
+            return 0
+          fi
+        fi
+        i=$((i + 1))
+      done
+      return 1
+    }
+    {{- end }}
+
     # Determine the replication target for this pod.
     REPLICATION_TARGET=""
     {{- if .Values.replica.sentinel.enabled }}
@@ -191,11 +224,25 @@ data:
       # A complete config from a previous run without a replicaof directive:
       # this pod was the master and stays the master.
       log "This pod (index $POD_INDEX) was the master before the restart, staying MASTER"
-    elif [ "$POD_INDEX" = "0" ]; then
-      log "Bootstrapping cluster, this pod (index $POD_INDEX) starts as MASTER"
     else
-      log "Bootstrapping cluster, this pod (index $POD_INDEX) starts as REPLICA of $MASTER_HOST:$MASTER_PORT"
-      REPLICATION_TARGET="replicaof $MASTER_HOST $MASTER_PORT"
+      # No usable local state: this is either a first boot or a pod that lost
+      # its volume.
+      DISCOVERED=$(master_from_sentinels || true)
+      if [ -n "$DISCOVERED" ]; then
+        FOUND_HOST=${DISCOVERED% *}
+        FOUND_PORT=${DISCOVERED#* }
+        if [ "$FOUND_HOST" = "$SELF_HOST" ]; then
+          log "Sentinel reports this pod as the master, starting as MASTER"
+        else
+          log "Sentinel reports $FOUND_HOST:$FOUND_PORT as the master, starting as REPLICA"
+          REPLICATION_TARGET="replicaof $FOUND_HOST $FOUND_PORT"
+        fi
+      elif [ "$POD_INDEX" = "0" ]; then
+        log "Bootstrapping cluster, this pod (index $POD_INDEX) starts as MASTER"
+      else
+        log "Bootstrapping cluster, this pod (index $POD_INDEX) starts as REPLICA of $MASTER_HOST:$MASTER_PORT"
+        REPLICATION_TARGET="replicaof $MASTER_HOST $MASTER_PORT"
+      fi
     fi
     {{- else }}
     if [ "$POD_INDEX" = "0" ]; then

--- a/valkey/templates/init_config.yaml
+++ b/valkey/templates/init_config.yaml
@@ -397,8 +397,37 @@ data:
           REPLICATION_TARGET="replicaof $MARKED_HOST $MARKED_PORT"
         fi
       else
-        log "No Sentinel answered and no recorded topology; refusing to start without a confirmed replication role"
-        exit 1
+        # Nothing anywhere: a fresh install, or a pod that lost its volume. The
+        # Sentinels are still running their own discovery and bootstrap a master
+        # once replica.sentinel.startupTimeoutSeconds expires, and this pod only
+        # has to be around to be told. Exiting here instead leaves the init
+        # container crash looping until a retry happens to land after that, so
+        # wait for the answer rather than for the next backoff.
+        WAITED=0
+        while [ "$WAITED" -lt "{{ .Values.replica.sentinel.initialTopologyWaitSeconds }}" ]; do
+          sleep 5
+          WAITED=$((WAITED + 5))
+          DISCOVERED=$(master_from_sentinels || true)
+          if [ -z "$DISCOVERED" ]; then
+            DISCOVERED=$(master_from_running_nodes || true)
+          fi
+          if [ -n "$DISCOVERED" ]; then
+            break
+          fi
+          log "Waiting for a Sentinel or a running node to report the topology, ${WAITED}s of {{ .Values.replica.sentinel.initialTopologyWaitSeconds }}s"
+        done
+        if [ -z "$DISCOVERED" ]; then
+          log "No Sentinel answered and no recorded topology; refusing to start without a confirmed replication role"
+          exit 1
+        fi
+        FOUND_HOST=${DISCOVERED% *}
+        FOUND_PORT=${DISCOVERED#* }
+        if [ "$FOUND_HOST" = "$SELF_HOST" ]; then
+          log "Sentinel reports this pod as the master, starting as MASTER"
+        else
+          log "Sentinel reports $FOUND_HOST:$FOUND_PORT as the master, starting as REPLICA"
+          REPLICATION_TARGET="replicaof $FOUND_HOST $FOUND_PORT"
+        fi
       fi
       fi
     fi

--- a/valkey/templates/secret.yaml
+++ b/valkey/templates/secret.yaml
@@ -8,6 +8,9 @@ metadata:
     {{- include "valkey.labels" . | nindent 4 }}
 type: Opaque
 data:
+  {{- if and .Values.replica.enabled .Values.replica.sentinel.enabled .Values.replica.sentinel.password }}
+  sentinel-password: {{ .Values.replica.sentinel.password | b64enc }}
+  {{- end }}
   {{- range $username, $user := .Values.auth.aclUsers }}
     {{- if $user.password }}
   {{ $username }}-password: {{ $user.password | b64enc }}

--- a/valkey/templates/secret.yaml
+++ b/valkey/templates/secret.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.auth.enabled }}
-{{- if or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig }}
+{{- if or (and .Values.auth.enabled (or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig)) (and .Values.replica.enabled .Values.replica.sentinel.enabled .Values.replica.sentinel.password) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,6 +10,7 @@ data:
   {{- if and .Values.replica.enabled .Values.replica.sentinel.enabled .Values.replica.sentinel.password }}
   sentinel-password: {{ .Values.replica.sentinel.password | b64enc }}
   {{- end }}
+  {{- if .Values.auth.enabled }}
   {{- range $username, $user := .Values.auth.aclUsers }}
     {{- if $user.password }}
   {{ $username }}-password: {{ $user.password | b64enc }}

--- a/valkey/templates/sentinel-configmap.yaml
+++ b/valkey/templates/sentinel-configmap.yaml
@@ -63,21 +63,25 @@ data:
     MONITOR_PASSWORD=$(get_user_password "{{ $monitorUser }}" "{{ $monitorPasswordKey }}") || exit 1
     {{- end }}
 
-    # Credentials are passed as arguments and never written to the log.
+    # The password goes through REDISCLI_AUTH rather than an argument, so that
+    # it does not show up in the process list of the pod.
     sentinel_cli() {
+      {{- if .Values.auth.enabled }}
+      REDISCLI_AUTH="$DEFAULT_PASSWORD" \
+      {{- end }}
       valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
-        {{- if .Values.auth.enabled }}
-        -a "$DEFAULT_PASSWORD" --no-auth-warning \
-        {{- end }}
-        -p "{{ $sentinelPort }}" "$@"
+        -t 2 -p "{{ $sentinelPort }}" "$@"
     }
 
     valkey_cli() {
+      {{- if .Values.auth.enabled }}
+      REDISCLI_AUTH="$MONITOR_PASSWORD" \
+      {{- end }}
       valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
         {{- if .Values.auth.enabled }}
-        --user "{{ $monitorUser }}" -a "$MONITOR_PASSWORD" --no-auth-warning \
+        --user "{{ $monitorUser }}" \
         {{- end }}
-        -p "{{ .Values.service.port }}" "$@"
+        -t 2 -p "{{ .Values.service.port }}" "$@"
     }
 
     # Ask the Sentinels that are already running. They hold the authoritative
@@ -89,9 +93,13 @@ data:
         peer="{{ include "valkey.fullname" . }}-${i}.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
         if [ "$peer" != "$SELF_HOST" ]; then
           addr=$(sentinel_cli -h "$peer" sentinel get-master-addr-by-name "$MASTER_SET" 2>/dev/null || true)
-          if [ -n "$addr" ]; then
-            log "Sentinel $peer reports the master as $(echo "$addr" | tr '\n' ' ')"
-            echo "$addr"
+          host=$(echo "$addr" | sed -n 1p)
+          port=$(echo "$addr" | sed -n 2p)
+          # A peer that does not know this master set answers with an error or a
+          # single line, which would otherwise become a broken monitor directive.
+          if [ -n "$host" ] && echo "$port" | grep -qE "^[0-9]+$"; then
+            log "Sentinel $peer reports the master as $host:$port"
+            printf '%s\n%s\n' "$host" "$port"
             return 0
           fi
         fi
@@ -118,7 +126,7 @@ data:
 
       host=$(echo "$info" | sed -n 's/^master_host://p')
       port=$(echo "$info" | sed -n 's/^master_port://p')
-      if [ -n "$host" ] && [ -n "$port" ]; then
+      if [ -n "$host" ] && echo "$port" | grep -qE "^[0-9]+$"; then
         log "The local Valkey node replicates from $host:$port"
         printf '%s\n%s\n' "$host" "$port"
         return 0
@@ -138,9 +146,11 @@ data:
 
     MASTER_HOST="$DEFAULT_MASTER_HOST"
     DISCOVERED=$(master_from_peers || master_from_local_node || true)
-    if [ -n "$DISCOVERED" ]; then
-      MASTER_HOST=$(echo "$DISCOVERED" | sed -n 1p)
-      MASTER_PORT=$(echo "$DISCOVERED" | sed -n 2p)
+    DISCOVERED_HOST=$(echo "$DISCOVERED" | sed -n 1p)
+    DISCOVERED_PORT=$(echo "$DISCOVERED" | sed -n 2p)
+    if [ -n "$DISCOVERED_HOST" ] && [ -n "$DISCOVERED_PORT" ]; then
+      MASTER_HOST="$DISCOVERED_HOST"
+      MASTER_PORT="$DISCOVERED_PORT"
     else
       log "No Sentinel peer or Valkey node answered, bootstrapping with $MASTER_HOST as master"
     fi
@@ -235,11 +245,8 @@ data:
     fi
     {{- end }}
 
-    REPLY=$(valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
-      {{- if .Values.auth.enabled }}
-      -a "$PASSWORD" --no-auth-warning \
-      {{- end }}
-      -p {{ $sentinelPort }} ping)
+    REPLY=$({{ if .Values.auth.enabled }}REDISCLI_AUTH="$PASSWORD" {{ end }}valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
+      -t 2 -p {{ $sentinelPort }} ping)
 
     [ "$REPLY" = "PONG" ]
   {{- if .Values.replica.sentinel.preStopFailover }}
@@ -283,11 +290,14 @@ data:
     {{- end }}
 
     local_role() {
+      {{- if .Values.auth.enabled }}
+      REDISCLI_AUTH="$MONITOR_PASSWORD" \
+      {{- end }}
       valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
         {{- if .Values.auth.enabled }}
-        --user "{{ $monitorUser }}" -a "$MONITOR_PASSWORD" --no-auth-warning \
+        --user "{{ $monitorUser }}" \
         {{- end }}
-        -p {{ .Values.service.port }} info replication 2>/dev/null | sed -n 's/^role://p' | tr -d '\r' || true
+        -t 2 -p {{ .Values.service.port }} info replication 2>/dev/null | sed -n 's/^role://p' | tr -d '\r' || true
     }
 
     if [ "$(local_role)" != "master" ]; then
@@ -296,11 +306,8 @@ data:
     fi
 
     log "This pod is the master, asking Sentinel to fail over before shutting down"
-    valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
-      {{- if .Values.auth.enabled }}
-      -a "$DEFAULT_PASSWORD" --no-auth-warning \
-      {{- end }}
-      -p {{ $sentinelPort }} sentinel failover {{ $masterSet }} >/dev/null 2>&1 || {
+    {{ if .Values.auth.enabled }}REDISCLI_AUTH="$DEFAULT_PASSWORD" {{ end }}valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
+      -t 2 -p {{ $sentinelPort }} sentinel failover {{ $masterSet }} >/dev/null 2>&1 || {
         log "WARN: the failover request failed, continuing with the shutdown"
         exit 0
       }

--- a/valkey/templates/sentinel-configmap.yaml
+++ b/valkey/templates/sentinel-configmap.yaml
@@ -177,17 +177,26 @@ data:
 
     # Sentinel has a dedicated identity. Valkey application credentials must
     # never gain Sentinel administration privileges as a side effect.
+    escape_config_arg() {
+      printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+    }
+
     SENTINEL_PASSHASH=$(printf '%s' "$SENTINEL_PASSWORD" | sha256sum | cut -f 1 -d " ")
+    SENTINEL_PASSHASH_ESCAPED=$(escape_config_arg "$SENTINEL_PASSHASH")
+    SENTINEL_PASSWORD_ESCAPED=$(escape_config_arg "$SENTINEL_PASSWORD")
+    {{- if .Values.auth.enabled }}
+    MONITOR_PASSWORD_ESCAPED=$(escape_config_arg "$MONITOR_PASSWORD")
+    {{- end }}
     cat >> "$SENTINEL_CONF" << EOF
 
     user default off
-    user sentinel on #${SENTINEL_PASSHASH} ~* &* +@all
+    user sentinel on "#${SENTINEL_PASSHASH_ESCAPED}" ~* &* +@all
     sentinel sentinel-user sentinel
-    sentinel sentinel-pass ${SENTINEL_PASSWORD}
+    sentinel sentinel-pass "${SENTINEL_PASSWORD_ESCAPED}"
 
     {{- if .Values.auth.enabled }}
     # Credentials Sentinel uses to reach the monitored Valkey nodes.
-    sentinel auth-pass ${MASTER_SET} ${MONITOR_PASSWORD}
+    sentinel auth-pass ${MASTER_SET} "${MONITOR_PASSWORD_ESCAPED}"
     {{- end }}
     EOF
     {{- if .Values.auth.enabled }}
@@ -275,7 +284,7 @@ data:
 
     log "This pod is the master, asking Sentinel to fail over before shutting down"
     REDISCLI_AUTH="$SENTINEL_PASSWORD" valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} --user sentinel \
-      -t 2 -h {{ include "valkey.sentinel.fullname" . }} -p {{ $sentinelPort }} sentinel failover {{ $masterSet }} >/dev/null 2>&1 || {
+      -t 2 -h {{ include "valkey.sentinel.headlessServiceName" . }} -p {{ .Values.replica.sentinel.port }} sentinel failover {{ $masterSet }} >/dev/null 2>&1 || {
         log "WARN: the failover request failed, continuing with the shutdown"
         exit 0
       }

--- a/valkey/templates/sentinel-configmap.yaml
+++ b/valkey/templates/sentinel-configmap.yaml
@@ -266,7 +266,10 @@ data:
     MONITOR_PASSWORD=$(get_user_password "{{ $monitorUser }}" "{{ $monitorPasswordKey }}") || exit 0
     {{- end }}
 
-    local_role() {
+    # HOSTNAME is the pod name for a StatefulSet pod.
+    SELF_HOST="${HOSTNAME}.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+
+    local_info() {
       {{- if .Values.auth.enabled }}
       REDISCLI_AUTH="$MONITOR_PASSWORD" \
       {{- end }}
@@ -274,8 +277,34 @@ data:
         {{- if .Values.auth.enabled }}
         --user "{{ $monitorUser }}" \
         {{- end }}
-        -t 2 -p {{ .Values.service.port }} info replication 2>/dev/null | sed -n 's/^role://p' | tr -d '\r' || true
+        -t 2 -p {{ .Values.service.port }} info replication 2>/dev/null | tr -d '\r' || true
     }
+
+    local_role() {
+      local_info | sed -n 's/^role://p'
+    }
+
+    # Refresh the credential free master marker on the way out, whichever path
+    # this script takes, so a cold start has an accurate record to fall back
+    # on. This asks the local server rather than Sentinel: Kubernetes stops
+    # every pod at once, so a Sentinel may already be gone, while the local
+    # server is still up until preStop returns.
+    record_master() {
+      info=$(local_info)
+      role=$(echo "$info" | sed -n 's/^role://p')
+      if [ "$role" = "master" ]; then
+        host="$SELF_HOST"
+        port="{{ .Values.service.port }}"
+      else
+        host=$(echo "$info" | sed -n 's/^master_host://p')
+        port=$(echo "$info" | sed -n 's/^master_port://p')
+      fi
+      if [ -n "$host" ] && echo "$port" | grep -qE "^[0-9]+$"; then
+        mkdir -p /data/conf 2>/dev/null || true
+        printf '%s %s\n' "$host" "$port" > /data/conf/last-master 2>/dev/null || true
+      fi
+    }
+    trap record_master EXIT
 
     if [ "$(local_role)" != "master" ]; then
       log "This pod is not the master, shutting down"

--- a/valkey/templates/sentinel-configmap.yaml
+++ b/valkey/templates/sentinel-configmap.yaml
@@ -213,6 +213,63 @@ data:
     EOF
     {{- end }}
 
+    # Sentinel learns which nodes are replicas from the master's INFO, so a node
+    # that attached to another replica is invisible to it and is never
+    # reconfigured, not even by its own +fix-slave-config. A pod reaches that
+    # state when no Sentinel answered at startup and the topology it recorded
+    # named a node that has since been demoted. Left alone it keeps serving
+    # reads from a chain, and once the node it follows goes away it serves stale
+    # data indefinitely.
+    #
+    # Adopt exactly the nodes Sentinel does not list: one it does not know is
+    # not one it is in the middle of reconfiguring, so this cannot race it.
+    adopt_orphans() {
+      while :; do
+        sleep {{ .Values.replica.sentinel.orphanCheckSeconds }}
+        addr=$(sentinel_cli -h "$SELF_HOST" sentinel get-master-addr-by-name "$MASTER_SET" 2>/dev/null | tr -d '\r' || true)
+        current_host=$(echo "$addr" | sed -n 1p)
+        current_port=$(echo "$addr" | sed -n 2p)
+        if [ -z "$current_host" ] || ! echo "$current_port" | grep -qE "^[0-9]+$"; then
+          continue
+        fi
+        # Anything other than a plain "master" means Sentinel is failing over or
+        # has lost the master, and it is reconfiguring the nodes itself.
+        flags=$(sentinel_cli -h "$SELF_HOST" sentinel master "$MASTER_SET" 2>/dev/null | tr -d '\r' | sed -n '/^flags$/{n;p;}' || true)
+        if [ "$flags" != "master" ]; then
+          continue
+        fi
+        known=$(sentinel_cli -h "$SELF_HOST" sentinel replicas "$MASTER_SET" 2>/dev/null | tr -d '\r' | sed -n '/^name$/{n;p;}' | sed 's/:[0-9]*$//' || true)
+        i=0
+        while [ "$i" -lt "$VALKEY_PODS" ]; do
+          node="{{ include "valkey.fullname" . }}-${i}.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+          i=$((i + 1))
+          if [ "$node" = "$current_host" ]; then
+            continue
+          fi
+          if echo "$known" | grep -qx "$node"; then
+            continue
+          fi
+          info=$(valkey_cli -h "$node" info replication 2>/dev/null | tr -d '\r' || true)
+          role=$(echo "$info" | sed -n 's/^role://p')
+          # A node that answers as a master is not an orphan replica but a
+          # second writable node, which is a decision for Sentinel and for an
+          # operator, not for this loop.
+          if [ "$role" != "slave" ]; then
+            continue
+          fi
+          following=$(echo "$info" | sed -n 's/^master_host://p')
+          if [ "$following" = "$current_host" ]; then
+            continue
+          fi
+          log "Node $node follows $following, which Sentinel does not monitor; pointing it at $current_host:$current_port"
+          valkey_cli -h "$node" replicaof "$current_host" "$current_port" >/dev/null 2>&1 ||
+            log "Could not reconfigure $node"
+        done
+      done
+    }
+
+    adopt_orphans &
+
     log "Starting Sentinel"
     exec valkey-sentinel "$SENTINEL_CONF"
 

--- a/valkey/templates/sentinel-configmap.yaml
+++ b/valkey/templates/sentinel-configmap.yaml
@@ -386,8 +386,17 @@ data:
         port=$(echo "$info" | sed -n 's/^master_port://p')
       fi
       if [ -n "$host" ] && echo "$port" | grep -qE "^[0-9]+$"; then
-        mkdir -p /data/conf 2>/dev/null || true
-        printf '%s %s\n' "$host" "$port" > /data/conf/last-master 2>/dev/null || true
+        # Write and rename. This runs while the pod is being torn down, so a
+        # redirect straight onto the record can leave it empty, or half written
+        # if the node itself goes, and a cold start reads that record to decide
+        # whether it may come back as the master.
+        if mkdir -p /data/conf 2>/dev/null &&
+           printf '%s %s\n' "$host" "$port" > /data/conf/last-master.tmp 2>/dev/null &&
+           mv /data/conf/last-master.tmp /data/conf/last-master 2>/dev/null; then
+          log "Recorded $host:$port as the last known master"
+        else
+          log "WARN: could not record $host:$port, the last written record stands"
+        fi
       fi
     }
     trap record_master EXIT

--- a/valkey/templates/sentinel-configmap.yaml
+++ b/valkey/templates/sentinel-configmap.yaml
@@ -201,7 +201,7 @@ data:
     {{- if .Values.auth.enabled }}
     # Sentinel has a dedicated identity. Valkey application credentials must
     # never gain Sentinel administration privileges as a side effect.
-    SENTINEL_PASSHASH=$(echo -n "$SENTINEL_PASSWORD" | sha256sum | cut -f 1 -d " ")
+    SENTINEL_PASSHASH=$(printf '%s' "$SENTINEL_PASSWORD" | sha256sum | cut -f 1 -d " ")
     cat >> "$SENTINEL_CONF" << EOF
 
     user default off

--- a/valkey/templates/sentinel-configmap.yaml
+++ b/valkey/templates/sentinel-configmap.yaml
@@ -1,0 +1,314 @@
+{{- if and .Values.replica.enabled .Values.replica.sentinel.enabled }}
+{{- $sentinelPort := .Values.replica.sentinel.port }}
+{{- $masterSet := .Values.replica.sentinel.masterSet }}
+{{- $totalPods := add (int .Values.replica.replicas) 1 }}
+{{- $monitorUser := .Values.replica.sentinel.monitorUser | default .Values.replica.replicationUser }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "valkey.fullname" . }}-sentinel-scripts
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sentinel
+data:
+  sentinel-start.sh: |-
+    #!/bin/sh
+    # Generates sentinel.conf and starts Sentinel.
+    #
+    # This runs as the Sentinel container entrypoint rather than as an init
+    # container on purpose: discovering the current master requires the local
+    # Valkey server to be running, which is only true once the init containers
+    # have finished.
+    set -eu
+
+    SENTINEL_CONF="/sentinel-data/sentinel.conf"
+    MASTER_SET="{{ $masterSet }}"
+    MASTER_PORT="{{ .Values.service.port }}"
+    TOTAL_PODS="{{ $totalPods }}"
+    SELF_HOST="${POD_NAME}.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+    DEFAULT_MASTER_HOST="{{ include "valkey.fullname" . }}-0.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+
+    # Logging goes to stderr so that command substitutions stay clean.
+    log() {
+      echo "$(date) $1" >&2
+    }
+
+    {{- if .Values.auth.enabled }}
+    {{- $defaultUser := index .Values.auth.aclUsers "default" }}
+    {{- $defaultPasswordKey := $defaultUser.passwordKey | default "default" }}
+    {{- $monitorUserObj := index .Values.auth.aclUsers $monitorUser }}
+    {{- $monitorPasswordKey := $monitorUserObj.passwordKey | default $monitorUser }}
+
+    # Function to get password for a user
+    # Usage: get_user_password <username> [password_key]
+    get_user_password() {
+      username="$1"
+      password_key="${2:-$username}"
+
+      {{- if .Values.auth.usersExistingSecret }}
+      if [ -f "/valkey-users-secret/$password_key" ]; then
+        cat "/valkey-users-secret/$password_key"
+        return 0
+      fi
+      {{- end }}
+      if [ -f "/valkey-auth-secret/${username}-password" ]; then
+        cat "/valkey-auth-secret/${username}-password"
+        return 0
+      fi
+      log "ERROR: No password found for user $username"
+      return 1
+    }
+
+    DEFAULT_PASSWORD=$(get_user_password "default" "{{ $defaultPasswordKey }}") || exit 1
+    MONITOR_PASSWORD=$(get_user_password "{{ $monitorUser }}" "{{ $monitorPasswordKey }}") || exit 1
+    {{- end }}
+
+    # Credentials are passed as arguments and never written to the log.
+    sentinel_cli() {
+      valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
+        {{- if .Values.auth.enabled }}
+        -a "$DEFAULT_PASSWORD" --no-auth-warning \
+        {{- end }}
+        -p "{{ $sentinelPort }}" "$@"
+    }
+
+    valkey_cli() {
+      valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
+        {{- if .Values.auth.enabled }}
+        --user "{{ $monitorUser }}" -a "$MONITOR_PASSWORD" --no-auth-warning \
+        {{- end }}
+        -p "{{ .Values.service.port }}" "$@"
+    }
+
+    # Ask the Sentinels that are already running. They hold the authoritative
+    # view of the topology, which matters when this pod joins or rejoins a
+    # cluster that has already failed over away from pod-0.
+    master_from_peers() {
+      i=0
+      while [ "$i" -lt "$TOTAL_PODS" ]; do
+        peer="{{ include "valkey.fullname" . }}-${i}.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+        if [ "$peer" != "$SELF_HOST" ]; then
+          addr=$(sentinel_cli -h "$peer" sentinel get-master-addr-by-name "$MASTER_SET" 2>/dev/null || true)
+          if [ -n "$addr" ]; then
+            log "Sentinel $peer reports the master as $(echo "$addr" | tr '\n' ' ')"
+            echo "$addr"
+            return 0
+          fi
+        fi
+        i=$((i + 1))
+      done
+      return 1
+    }
+
+    # Fall back to the local Valkey server. After a full cluster restart no
+    # Sentinel is up yet, but every Valkey node has restored the replication
+    # target Sentinel last wrote, so the local node knows who the master is.
+    master_from_local_node() {
+      info=$(valkey_cli -h 127.0.0.1 info replication 2>/dev/null | tr -d '\r' || true)
+      if [ -z "$info" ]; then
+        return 1
+      fi
+
+      role=$(echo "$info" | sed -n 's/^role://p')
+      if [ "$role" = "master" ]; then
+        log "The local Valkey node is the master"
+        printf '%s\n%s\n' "$SELF_HOST" "$MASTER_PORT"
+        return 0
+      fi
+
+      host=$(echo "$info" | sed -n 's/^master_host://p')
+      port=$(echo "$info" | sed -n 's/^master_port://p')
+      if [ -n "$host" ] && [ -n "$port" ]; then
+        log "The local Valkey node replicates from $host:$port"
+        printf '%s\n%s\n' "$host" "$port"
+        return 0
+      fi
+      return 1
+    }
+
+    # The local Valkey container starts in parallel with this one.
+    WAITED=0
+    while [ "$WAITED" -lt "{{ .Values.replica.sentinel.startupTimeoutSeconds }}" ]; do
+      if valkey_cli -h 127.0.0.1 ping >/dev/null 2>&1; then
+        break
+      fi
+      sleep 1
+      WAITED=$((WAITED + 1))
+    done
+
+    MASTER_HOST="$DEFAULT_MASTER_HOST"
+    DISCOVERED=$(master_from_peers || master_from_local_node || true)
+    if [ -n "$DISCOVERED" ]; then
+      MASTER_HOST=$(echo "$DISCOVERED" | sed -n 1p)
+      MASTER_PORT=$(echo "$DISCOVERED" | sed -n 2p)
+    else
+      log "No Sentinel peer or Valkey node answered, bootstrapping with $MASTER_HOST as master"
+    fi
+
+    log "Writing $SENTINEL_CONF monitoring $MASTER_HOST:$MASTER_PORT"
+    rm -f "$SENTINEL_CONF"
+    cat > "$SENTINEL_CONF" << EOF
+    # Generated by the valkey Helm chart. Sentinel rewrites this file at runtime.
+    {{- if .Values.tls.enabled }}
+    port 0
+    tls-port {{ $sentinelPort }}
+    tls-cert-file /tls/{{ .Values.tls.serverPublicKey }}
+    tls-key-file /tls/{{ .Values.tls.serverKey }}
+    tls-ca-cert-file /tls/{{ .Values.tls.caPublicKey }}
+    {{- if .Values.tls.dhParamKey }}
+    tls-dh-params-file /tls/{{ .Values.tls.dhParamKey }}
+    {{- end }}
+    {{- if not .Values.tls.requireClientCertificate }}
+    tls-auth-clients no
+    {{- end }}
+    tls-replication yes
+    {{- else }}
+    port {{ $sentinelPort }}
+    {{- end }}
+    dir /sentinel-data
+    protected-mode no
+
+    # Address peers by DNS name, pod IPs change on every reschedule.
+    sentinel resolve-hostnames yes
+    sentinel announce-hostnames yes
+    sentinel announce-ip ${SELF_HOST}
+    sentinel announce-port {{ $sentinelPort }}
+
+    sentinel monitor ${MASTER_SET} ${MASTER_HOST} ${MASTER_PORT} {{ .Values.replica.sentinel.quorum }}
+    sentinel down-after-milliseconds ${MASTER_SET} {{ .Values.replica.sentinel.downAfterMilliseconds }}
+    sentinel failover-timeout ${MASTER_SET} {{ .Values.replica.sentinel.failoverTimeout }}
+    sentinel parallel-syncs ${MASTER_SET} {{ .Values.replica.sentinel.parallelSyncs }}
+    EOF
+
+    {{- if .Values.auth.enabled }}
+    # Sentinel's own ACL. It mirrors the Valkey 'default' user password so that
+    # the Sentinel port is never left unauthenticated, and the same credentials
+    # secure the Sentinel-to-Sentinel gossip.
+    DEFAULT_PASSHASH=$(echo -n "$DEFAULT_PASSWORD" | sha256sum | cut -f 1 -d " ")
+    cat >> "$SENTINEL_CONF" << EOF
+
+    user default on #${DEFAULT_PASSHASH} ~* &* +@all
+    sentinel sentinel-pass ${DEFAULT_PASSWORD}
+
+    # Credentials Sentinel uses to reach the monitored Valkey nodes.
+    sentinel auth-pass ${MASTER_SET} ${MONITOR_PASSWORD}
+    EOF
+    {{- if ne $monitorUser "default" }}
+    echo "sentinel auth-user ${MASTER_SET} {{ $monitorUser }}" >> "$SENTINEL_CONF"
+    {{- end }}
+    log "Configured the Sentinel ACL and the monitor credentials"
+    {{- end }}
+    {{- with .Values.replica.sentinel.extraConfig }}
+
+    cat >> "$SENTINEL_CONF" << 'EOF'
+
+    {{- tpl . $ | nindent 4 }}
+    EOF
+    {{- end }}
+
+    log "Starting Sentinel"
+    exec valkey-sentinel "$SENTINEL_CONF"
+
+  sentinel-ping.sh: |-
+    #!/bin/sh
+    # Health probe for the Sentinel container. It lives here rather than inline
+    # in the pod spec so that the credentials stay in the mounted secret.
+    set -eu
+
+    {{- if .Values.auth.enabled }}
+    {{- $defaultUser := index .Values.auth.aclUsers "default" }}
+    {{- $defaultPasswordKey := $defaultUser.passwordKey | default "default" }}
+    PASSWORD=""
+    {{- if .Values.auth.usersExistingSecret }}
+    if [ -f "/valkey-users-secret/{{ $defaultPasswordKey }}" ]; then
+      PASSWORD=$(cat "/valkey-users-secret/{{ $defaultPasswordKey }}")
+    fi
+    {{- end }}
+    if [ -z "$PASSWORD" ] && [ -f "/valkey-auth-secret/default-password" ]; then
+      PASSWORD=$(cat "/valkey-auth-secret/default-password")
+    fi
+    {{- end }}
+
+    REPLY=$(valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
+      {{- if .Values.auth.enabled }}
+      -a "$PASSWORD" --no-auth-warning \
+      {{- end }}
+      -p {{ $sentinelPort }} ping)
+
+    [ "$REPLY" = "PONG" ]
+  {{- if .Values.replica.sentinel.preStopFailover }}
+
+  sentinel-prestop.sh: |-
+    #!/bin/sh
+    # Runs in the Valkey container before it is terminated. When this pod is the
+    # master, ask Sentinel to promote a replica first, so that a rolling update
+    # does not leave clients writing to a pod that is about to disappear.
+    set -eu
+
+    log() {
+      echo "$(date) $1" >&2
+    }
+
+    {{- if .Values.auth.enabled }}
+    {{- $defaultUser := index .Values.auth.aclUsers "default" }}
+    {{- $defaultPasswordKey := $defaultUser.passwordKey | default "default" }}
+    {{- $monitorUserObj := index .Values.auth.aclUsers $monitorUser }}
+    {{- $monitorPasswordKey := $monitorUserObj.passwordKey | default $monitorUser }}
+
+    get_user_password() {
+      username="$1"
+      password_key="${2:-$username}"
+
+      {{- if .Values.auth.usersExistingSecret }}
+      if [ -f "/valkey-users-secret/$password_key" ]; then
+        cat "/valkey-users-secret/$password_key"
+        return 0
+      fi
+      {{- end }}
+      if [ -f "/valkey-auth-secret/${username}-password" ]; then
+        cat "/valkey-auth-secret/${username}-password"
+        return 0
+      fi
+      return 1
+    }
+
+    DEFAULT_PASSWORD=$(get_user_password "default" "{{ $defaultPasswordKey }}") || exit 0
+    MONITOR_PASSWORD=$(get_user_password "{{ $monitorUser }}" "{{ $monitorPasswordKey }}") || exit 0
+    {{- end }}
+
+    local_role() {
+      valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
+        {{- if .Values.auth.enabled }}
+        --user "{{ $monitorUser }}" -a "$MONITOR_PASSWORD" --no-auth-warning \
+        {{- end }}
+        -p {{ .Values.service.port }} info replication 2>/dev/null | sed -n 's/^role://p' | tr -d '\r' || true
+    }
+
+    if [ "$(local_role)" != "master" ]; then
+      log "This pod is not the master, shutting down"
+      exit 0
+    fi
+
+    log "This pod is the master, asking Sentinel to fail over before shutting down"
+    valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
+      {{- if .Values.auth.enabled }}
+      -a "$DEFAULT_PASSWORD" --no-auth-warning \
+      {{- end }}
+      -p {{ $sentinelPort }} sentinel failover {{ $masterSet }} >/dev/null 2>&1 || {
+        log "WARN: the failover request failed, continuing with the shutdown"
+        exit 0
+      }
+
+    WAITED=0
+    while [ "$WAITED" -lt "{{ .Values.replica.sentinel.preStopFailoverTimeoutSeconds }}" ]; do
+      if [ "$(local_role)" != "master" ]; then
+        log "Failover complete after ${WAITED}s"
+        exit 0
+      fi
+      sleep 1
+      WAITED=$((WAITED + 1))
+    done
+
+    log "WARN: still the master after ${WAITED}s, continuing with the shutdown"
+  {{- end }}
+{{- end }}

--- a/valkey/templates/sentinel-configmap.yaml
+++ b/valkey/templates/sentinel-configmap.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.replica.enabled .Values.replica.sentinel.enabled }}
 {{- $sentinelPort := .Values.replica.sentinel.port }}
 {{- $masterSet := .Values.replica.sentinel.masterSet }}
-{{- $totalPods := add (int .Values.replica.replicas) 1 }}
+{{- $valkeyPods := add (int .Values.replica.replicas) 1 }}
 {{- $monitorUser := .Values.replica.sentinel.monitorUser | default .Values.replica.replicationUser }}
 apiVersion: v1
 kind: ConfigMap
@@ -15,17 +15,16 @@ data:
     #!/bin/sh
     # Generates sentinel.conf and starts Sentinel.
     #
-    # This runs as the Sentinel container entrypoint rather than as an init
-    # container on purpose: discovering the current master requires the local
-    # Valkey server to be running, which is only true once the init containers
-    # have finished.
+    # This runs as the Sentinel container entrypoint so it can discover the
+    # current master from running Sentinel peers or the Valkey nodes.
     set -eu
 
     SENTINEL_CONF="/sentinel-data/sentinel.conf"
     MASTER_SET="{{ $masterSet }}"
     MASTER_PORT="{{ .Values.service.port }}"
-    TOTAL_PODS="{{ $totalPods }}"
-    SELF_HOST="${POD_NAME}.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+    VALKEY_PODS="{{ $valkeyPods }}"
+    SELF_HOST="${POD_NAME}.{{ include "valkey.sentinel.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+    SENTINEL_HOST="{{ include "valkey.sentinel.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
     DEFAULT_MASTER_HOST="{{ include "valkey.fullname" . }}-0.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
 
     # Logging goes to stderr so that command substitutions stay clean.
@@ -85,56 +84,48 @@ data:
     # view of the topology, which matters when this pod joins or rejoins a
     # cluster that has already failed over away from pod-0.
     master_from_peers() {
+      addr=$(sentinel_cli -h "$SENTINEL_HOST" sentinel get-master-addr-by-name "$MASTER_SET" 2>/dev/null || true)
+      host=$(echo "$addr" | sed -n 1p)
+      port=$(echo "$addr" | sed -n 2p)
+      # A peer that does not know this master set answers with an error or a
+      # single line, which would otherwise become a broken monitor directive.
+      [ -n "$host" ] && echo "$port" | grep -qE "^[0-9]+$" || return 1
+      log "A Sentinel peer reports the master as $host:$port"
+      printf '%s\n%s\n' "$host" "$port"
+    }
+
+    # After a full Sentinel restart, inspect the Valkey pods. Their persisted
+    # replication configuration records the topology from the last failover.
+    master_from_valkey_nodes() {
       i=0
-      while [ "$i" -lt "$TOTAL_PODS" ]; do
-        peer="{{ include "valkey.fullname" . }}-${i}.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
-        if [ "$peer" != "$SELF_HOST" ]; then
-          addr=$(sentinel_cli -h "$peer" sentinel get-master-addr-by-name "$MASTER_SET" 2>/dev/null || true)
-          host=$(echo "$addr" | sed -n 1p)
-          port=$(echo "$addr" | sed -n 2p)
-          # A peer that does not know this master set answers with an error or a
-          # single line, which would otherwise become a broken monitor directive.
-          if [ -n "$host" ] && echo "$port" | grep -qE "^[0-9]+$"; then
-            log "Sentinel $peer reports the master as $host:$port"
-            printf '%s\n%s\n' "$host" "$port"
-            return 0
-          fi
+      while [ "$i" -lt "$VALKEY_PODS" ]; do
+        node="{{ include "valkey.fullname" . }}-${i}.{{ include "valkey.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+        info=$(valkey_cli -h "$node" info replication 2>/dev/null | tr -d '\r' || true)
+        role=$(echo "$info" | sed -n 's/^role://p')
+        if [ "$role" = "master" ]; then
+          log "Valkey node $node is the master"
+          printf '%s\n%s\n' "$node" "$MASTER_PORT"
+          return 0
+        fi
+
+        host=$(echo "$info" | sed -n 's/^master_host://p')
+        port=$(echo "$info" | sed -n 's/^master_port://p')
+        if [ -n "$host" ] && echo "$port" | grep -qE "^[0-9]+$"; then
+          log "Valkey node $node reports the master as $host:$port"
+          printf '%s\n%s\n' "$host" "$port"
+          return 0
         fi
         i=$((i + 1))
       done
       return 1
     }
 
-    # Fall back to the local Valkey server. After a full cluster restart no
-    # Sentinel is up yet, but every Valkey node has restored the replication
-    # target Sentinel last wrote, so the local node knows who the master is.
-    master_from_local_node() {
-      info=$(valkey_cli -h 127.0.0.1 info replication 2>/dev/null | tr -d '\r' || true)
-      if [ -z "$info" ]; then
-        return 1
-      fi
-
-      role=$(echo "$info" | sed -n 's/^role://p')
-      if [ "$role" = "master" ]; then
-        log "The local Valkey node is the master"
-        printf '%s\n%s\n' "$SELF_HOST" "$MASTER_PORT"
-        return 0
-      fi
-
-      host=$(echo "$info" | sed -n 's/^master_host://p')
-      port=$(echo "$info" | sed -n 's/^master_port://p')
-      if [ -n "$host" ] && echo "$port" | grep -qE "^[0-9]+$"; then
-        log "The local Valkey node replicates from $host:$port"
-        printf '%s\n%s\n' "$host" "$port"
-        return 0
-      fi
-      return 1
-    }
-
-    # The local Valkey container starts in parallel with this one.
+    # Give the Valkey StatefulSet time to start during a fresh installation.
     WAITED=0
+    DISCOVERED=""
     while [ "$WAITED" -lt "{{ .Values.replica.sentinel.startupTimeoutSeconds }}" ]; do
-      if valkey_cli -h 127.0.0.1 ping >/dev/null 2>&1; then
+      DISCOVERED=$(master_from_peers || master_from_valkey_nodes || true)
+      if [ -n "$DISCOVERED" ]; then
         break
       fi
       sleep 1
@@ -142,14 +133,13 @@ data:
     done
 
     MASTER_HOST="$DEFAULT_MASTER_HOST"
-    DISCOVERED=$(master_from_peers || master_from_local_node || true)
     DISCOVERED_HOST=$(echo "$DISCOVERED" | sed -n 1p)
     DISCOVERED_PORT=$(echo "$DISCOVERED" | sed -n 2p)
     if [ -n "$DISCOVERED_HOST" ] && [ -n "$DISCOVERED_PORT" ]; then
       MASTER_HOST="$DISCOVERED_HOST"
       MASTER_PORT="$DISCOVERED_PORT"
     else
-      log "No Sentinel peer or Valkey node answered, bootstrapping with $MASTER_HOST as master"
+      log "No Sentinel peer or Valkey node answered within ${WAITED}s, bootstrapping with $MASTER_HOST as master"
     fi
 
     log "Writing $SENTINEL_CONF monitoring $MASTER_HOST:$MASTER_PORT"
@@ -285,7 +275,7 @@ data:
 
     log "This pod is the master, asking Sentinel to fail over before shutting down"
     REDISCLI_AUTH="$SENTINEL_PASSWORD" valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} --user sentinel \
-      -t 2 -p {{ $sentinelPort }} sentinel failover {{ $masterSet }} >/dev/null 2>&1 || {
+      -t 2 -h {{ include "valkey.sentinel.fullname" . }} -p {{ $sentinelPort }} sentinel failover {{ $masterSet }} >/dev/null 2>&1 || {
         log "WARN: the failover request failed, continuing with the shutdown"
         exit 0
       }

--- a/valkey/templates/sentinel-configmap.yaml
+++ b/valkey/templates/sentinel-configmap.yaml
@@ -33,6 +33,13 @@ data:
     }
 
     SENTINEL_PASSWORD=$(cat /sentinel-auth/existing-password 2>/dev/null || cat /sentinel-auth/inline-password 2>/dev/null) || exit 1
+    # This password is hashed into an ACL user that can run every Sentinel
+    # command. An empty one hashes to a value that is the same in every
+    # installation, so it would hand that user to anyone who can reach the port.
+    if [ -z "$SENTINEL_PASSWORD" ]; then
+      log "ERROR: The Sentinel password is empty"
+      exit 1
+    fi
     {{- if .Values.auth.enabled }}
     {{- $monitorUserObj := index .Values.auth.aclUsers $monitorUser }}
     {{- $monitorPasswordKey := $monitorUserObj.passwordKey | default $monitorUser }}
@@ -42,19 +49,28 @@ data:
     get_user_password() {
       username="$1"
       password_key="${2:-$username}"
+      password=""
 
       {{- if .Values.auth.usersExistingSecret }}
       if [ -f "/valkey-users-secret/$password_key" ]; then
-        cat "/valkey-users-secret/$password_key"
-        return 0
+        password=$(cat "/valkey-users-secret/$password_key")
+      elif [ -f "/valkey-auth-secret/${username}-password" ]; then
+        password=$(cat "/valkey-auth-secret/${username}-password")
+      fi
+      {{- else }}
+      if [ -f "/valkey-auth-secret/${username}-password" ]; then
+        password=$(cat "/valkey-auth-secret/${username}-password")
       fi
       {{- end }}
-      if [ -f "/valkey-auth-secret/${username}-password" ]; then
-        cat "/valkey-auth-secret/${username}-password"
-        return 0
+
+      # Empty counts as missing: it would go into sentinel auth-pass, and an
+      # empty credential is one every installation shares.
+      if [ -z "$password" ]; then
+        log "ERROR: No password, or an empty one, for user $username"
+        return 1
       fi
-      log "ERROR: No password found for user $username"
-      return 1
+
+      printf '%s' "$password"
     }
 
     MONITOR_PASSWORD=$(get_user_password "{{ $monitorUser }}" "{{ $monitorPasswordKey }}") || exit 1
@@ -299,6 +315,13 @@ data:
     }
 
     SENTINEL_PASSWORD=$(cat /sentinel-auth/existing-password 2>/dev/null || cat /sentinel-auth/inline-password 2>/dev/null) || exit 0
+    # Nothing to authenticate with. Leave without asking for a failover rather
+    # than sending Sentinel commands with an empty credential, and without
+    # holding up the shutdown.
+    if [ -z "$SENTINEL_PASSWORD" ]; then
+      log "No Sentinel password, skipping the failover request"
+      exit 0
+    fi
     {{- if .Values.auth.enabled }}
     {{- $monitorUserObj := index .Values.auth.aclUsers $monitorUser }}
     {{- $monitorPasswordKey := $monitorUserObj.passwordKey | default $monitorUser }}
@@ -306,18 +329,24 @@ data:
     get_user_password() {
       username="$1"
       password_key="${2:-$username}"
+      password=""
 
       {{- if .Values.auth.usersExistingSecret }}
       if [ -f "/valkey-users-secret/$password_key" ]; then
-        cat "/valkey-users-secret/$password_key"
-        return 0
+        password=$(cat "/valkey-users-secret/$password_key")
+      elif [ -f "/valkey-auth-secret/${username}-password" ]; then
+        password=$(cat "/valkey-auth-secret/${username}-password")
+      fi
+      {{- else }}
+      if [ -f "/valkey-auth-secret/${username}-password" ]; then
+        password=$(cat "/valkey-auth-secret/${username}-password")
       fi
       {{- end }}
-      if [ -f "/valkey-auth-secret/${username}-password" ]; then
-        cat "/valkey-auth-secret/${username}-password"
-        return 0
-      fi
-      return 1
+
+      # Empty counts as missing here too, so the caller leaves rather than
+      # authenticating to the node with a credential everyone shares.
+      [ -n "$password" ] || return 1
+      printf '%s' "$password"
     }
 
     MONITOR_PASSWORD=$(get_user_password "{{ $monitorUser }}" "{{ $monitorPasswordKey }}") || exit 0

--- a/valkey/templates/sentinel-configmap.yaml
+++ b/valkey/templates/sentinel-configmap.yaml
@@ -34,8 +34,6 @@ data:
     }
 
     {{- if .Values.auth.enabled }}
-    {{- $defaultUser := index .Values.auth.aclUsers "default" }}
-    {{- $defaultPasswordKey := $defaultUser.passwordKey | default "default" }}
     {{- $monitorUserObj := index .Values.auth.aclUsers $monitorUser }}
     {{- $monitorPasswordKey := $monitorUserObj.passwordKey | default $monitorUser }}
 
@@ -59,7 +57,7 @@ data:
       return 1
     }
 
-    DEFAULT_PASSWORD=$(get_user_password "default" "{{ $defaultPasswordKey }}") || exit 1
+    SENTINEL_PASSWORD=$(get_user_password "sentinel" "{{ .Values.replica.sentinel.passwordKey }}") || exit 1
     MONITOR_PASSWORD=$(get_user_password "{{ $monitorUser }}" "{{ $monitorPasswordKey }}") || exit 1
     {{- end }}
 
@@ -67,10 +65,14 @@ data:
     # it does not show up in the process list of the pod.
     sentinel_cli() {
       {{- if .Values.auth.enabled }}
-      REDISCLI_AUTH="$DEFAULT_PASSWORD" \
-      {{- end }}
+      REDISCLI_AUTH="$SENTINEL_PASSWORD" \
+      valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
+        --user sentinel \
+        -t 2 -p "{{ $sentinelPort }}" "$@"
+      {{- else }}
       valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
         -t 2 -p "{{ $sentinelPort }}" "$@"
+      {{- end }}
     }
 
     valkey_cli() {
@@ -197,14 +199,15 @@ data:
     EOF
 
     {{- if .Values.auth.enabled }}
-    # Sentinel's own ACL. It mirrors the Valkey 'default' user password so that
-    # the Sentinel port is never left unauthenticated, and the same credentials
-    # secure the Sentinel-to-Sentinel gossip.
-    DEFAULT_PASSHASH=$(echo -n "$DEFAULT_PASSWORD" | sha256sum | cut -f 1 -d " ")
+    # Sentinel has a dedicated identity. Valkey application credentials must
+    # never gain Sentinel administration privileges as a side effect.
+    SENTINEL_PASSHASH=$(echo -n "$SENTINEL_PASSWORD" | sha256sum | cut -f 1 -d " ")
     cat >> "$SENTINEL_CONF" << EOF
 
-    user default on #${DEFAULT_PASSHASH} ~* &* +@all
-    sentinel sentinel-pass ${DEFAULT_PASSWORD}
+    user default off
+    user sentinel on #${SENTINEL_PASSHASH} ~* &* +@all
+    sentinel sentinel-user sentinel
+    sentinel sentinel-pass ${SENTINEL_PASSWORD}
 
     # Credentials Sentinel uses to reach the monitored Valkey nodes.
     sentinel auth-pass ${MASTER_SET} ${MONITOR_PASSWORD}
@@ -232,20 +235,18 @@ data:
     set -eu
 
     {{- if .Values.auth.enabled }}
-    {{- $defaultUser := index .Values.auth.aclUsers "default" }}
-    {{- $defaultPasswordKey := $defaultUser.passwordKey | default "default" }}
     PASSWORD=""
     {{- if .Values.auth.usersExistingSecret }}
-    if [ -f "/valkey-users-secret/{{ $defaultPasswordKey }}" ]; then
-      PASSWORD=$(cat "/valkey-users-secret/{{ $defaultPasswordKey }}")
+    if [ -f "/valkey-users-secret/{{ .Values.replica.sentinel.passwordKey }}" ]; then
+      PASSWORD=$(cat "/valkey-users-secret/{{ .Values.replica.sentinel.passwordKey }}")
     fi
     {{- end }}
-    if [ -z "$PASSWORD" ] && [ -f "/valkey-auth-secret/default-password" ]; then
-      PASSWORD=$(cat "/valkey-auth-secret/default-password")
+    if [ -z "$PASSWORD" ] && [ -f "/valkey-auth-secret/sentinel-password" ]; then
+      PASSWORD=$(cat "/valkey-auth-secret/sentinel-password")
     fi
     {{- end }}
 
-    REPLY=$({{ if .Values.auth.enabled }}REDISCLI_AUTH="$PASSWORD" {{ end }}valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
+    REPLY=$({{ if .Values.auth.enabled }}REDISCLI_AUTH="$PASSWORD" {{ end }}valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} {{ if .Values.auth.enabled }}--user sentinel {{ end }}\
       -t 2 -p {{ $sentinelPort }} ping)
 
     [ "$REPLY" = "PONG" ]
@@ -263,8 +264,6 @@ data:
     }
 
     {{- if .Values.auth.enabled }}
-    {{- $defaultUser := index .Values.auth.aclUsers "default" }}
-    {{- $defaultPasswordKey := $defaultUser.passwordKey | default "default" }}
     {{- $monitorUserObj := index .Values.auth.aclUsers $monitorUser }}
     {{- $monitorPasswordKey := $monitorUserObj.passwordKey | default $monitorUser }}
 
@@ -285,7 +284,7 @@ data:
       return 1
     }
 
-    DEFAULT_PASSWORD=$(get_user_password "default" "{{ $defaultPasswordKey }}") || exit 0
+    SENTINEL_PASSWORD=$(get_user_password "sentinel" "{{ .Values.replica.sentinel.passwordKey }}") || exit 0
     MONITOR_PASSWORD=$(get_user_password "{{ $monitorUser }}" "{{ $monitorPasswordKey }}") || exit 0
     {{- end }}
 
@@ -306,7 +305,7 @@ data:
     fi
 
     log "This pod is the master, asking Sentinel to fail over before shutting down"
-    {{ if .Values.auth.enabled }}REDISCLI_AUTH="$DEFAULT_PASSWORD" {{ end }}valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
+    {{ if .Values.auth.enabled }}REDISCLI_AUTH="$SENTINEL_PASSWORD" {{ end }}valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} {{ if .Values.auth.enabled }}--user sentinel {{ end }}\
       -t 2 -p {{ $sentinelPort }} sentinel failover {{ $masterSet }} >/dev/null 2>&1 || {
         log "WARN: the failover request failed, continuing with the shutdown"
         exit 0

--- a/valkey/templates/sentinel-configmap.yaml
+++ b/valkey/templates/sentinel-configmap.yaml
@@ -33,6 +33,7 @@ data:
       echo "$(date) $1" >&2
     }
 
+    SENTINEL_PASSWORD=$(cat /sentinel-auth/existing-password 2>/dev/null || cat /sentinel-auth/inline-password 2>/dev/null) || exit 1
     {{- if .Values.auth.enabled }}
     {{- $monitorUserObj := index .Values.auth.aclUsers $monitorUser }}
     {{- $monitorPasswordKey := $monitorUserObj.passwordKey | default $monitorUser }}
@@ -57,22 +58,16 @@ data:
       return 1
     }
 
-    SENTINEL_PASSWORD=$(get_user_password "sentinel" "{{ .Values.replica.sentinel.passwordKey }}") || exit 1
     MONITOR_PASSWORD=$(get_user_password "{{ $monitorUser }}" "{{ $monitorPasswordKey }}") || exit 1
     {{- end }}
 
     # The password goes through REDISCLI_AUTH rather than an argument, so that
     # it does not show up in the process list of the pod.
     sentinel_cli() {
-      {{- if .Values.auth.enabled }}
       REDISCLI_AUTH="$SENTINEL_PASSWORD" \
       valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
         --user sentinel \
         -t 2 -p "{{ $sentinelPort }}" "$@"
-      {{- else }}
-      valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} \
-        -t 2 -p "{{ $sentinelPort }}" "$@"
-      {{- end }}
     }
 
     valkey_cli() {
@@ -178,14 +173,6 @@ data:
     port {{ $sentinelPort }}
     {{- end }}
     dir /sentinel-data
-    {{- if not .Values.auth.enabled }}
-    # Sentinel peers connect over the pod network, which protected mode rejects
-    # while no password is configured. Note that this leaves the Sentinel port
-    # open to anything that can reach it, exactly like the Valkey port itself
-    # when auth is disabled. Enable auth to require credentials on both.
-    protected-mode no
-    {{- end }}
-
     # Address peers by DNS name, pod IPs change on every reschedule.
     sentinel resolve-hostnames yes
     sentinel announce-hostnames yes
@@ -198,7 +185,6 @@ data:
     sentinel parallel-syncs ${MASTER_SET} {{ .Values.replica.sentinel.parallelSyncs }}
     EOF
 
-    {{- if .Values.auth.enabled }}
     # Sentinel has a dedicated identity. Valkey application credentials must
     # never gain Sentinel administration privileges as a side effect.
     SENTINEL_PASSHASH=$(printf '%s' "$SENTINEL_PASSWORD" | sha256sum | cut -f 1 -d " ")
@@ -209,9 +195,12 @@ data:
     sentinel sentinel-user sentinel
     sentinel sentinel-pass ${SENTINEL_PASSWORD}
 
+    {{- if .Values.auth.enabled }}
     # Credentials Sentinel uses to reach the monitored Valkey nodes.
     sentinel auth-pass ${MASTER_SET} ${MONITOR_PASSWORD}
+    {{- end }}
     EOF
+    {{- if .Values.auth.enabled }}
     {{- if ne $monitorUser "default" }}
     echo "sentinel auth-user ${MASTER_SET} {{ $monitorUser }}" >> "$SENTINEL_CONF"
     {{- end }}
@@ -234,19 +223,9 @@ data:
     # in the pod spec so that the credentials stay in the mounted secret.
     set -eu
 
-    {{- if .Values.auth.enabled }}
-    PASSWORD=""
-    {{- if .Values.auth.usersExistingSecret }}
-    if [ -f "/valkey-users-secret/{{ .Values.replica.sentinel.passwordKey }}" ]; then
-      PASSWORD=$(cat "/valkey-users-secret/{{ .Values.replica.sentinel.passwordKey }}")
-    fi
-    {{- end }}
-    if [ -z "$PASSWORD" ] && [ -f "/valkey-auth-secret/sentinel-password" ]; then
-      PASSWORD=$(cat "/valkey-auth-secret/sentinel-password")
-    fi
-    {{- end }}
+    PASSWORD=$(cat /sentinel-auth/existing-password 2>/dev/null || cat /sentinel-auth/inline-password 2>/dev/null)
 
-    REPLY=$({{ if .Values.auth.enabled }}REDISCLI_AUTH="$PASSWORD" {{ end }}valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} {{ if .Values.auth.enabled }}--user sentinel {{ end }}\
+    REPLY=$(REDISCLI_AUTH="$PASSWORD" valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} --user sentinel \
       -t 2 -p {{ $sentinelPort }} ping)
 
     [ "$REPLY" = "PONG" ]
@@ -263,6 +242,7 @@ data:
       echo "$(date) $1" >&2
     }
 
+    SENTINEL_PASSWORD=$(cat /sentinel-auth/existing-password 2>/dev/null || cat /sentinel-auth/inline-password 2>/dev/null) || exit 0
     {{- if .Values.auth.enabled }}
     {{- $monitorUserObj := index .Values.auth.aclUsers $monitorUser }}
     {{- $monitorPasswordKey := $monitorUserObj.passwordKey | default $monitorUser }}
@@ -284,7 +264,6 @@ data:
       return 1
     }
 
-    SENTINEL_PASSWORD=$(get_user_password "sentinel" "{{ .Values.replica.sentinel.passwordKey }}") || exit 0
     MONITOR_PASSWORD=$(get_user_password "{{ $monitorUser }}" "{{ $monitorPasswordKey }}") || exit 0
     {{- end }}
 
@@ -305,7 +284,7 @@ data:
     fi
 
     log "This pod is the master, asking Sentinel to fail over before shutting down"
-    {{ if .Values.auth.enabled }}REDISCLI_AUTH="$SENTINEL_PASSWORD" {{ end }}valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} {{ if .Values.auth.enabled }}--user sentinel {{ end }}\
+    REDISCLI_AUTH="$SENTINEL_PASSWORD" valkey-cli {{ include "valkey.sentinel.cliTlsFlags" . }} --user sentinel \
       -t 2 -p {{ $sentinelPort }} sentinel failover {{ $masterSet }} >/dev/null 2>&1 || {
         log "WARN: the failover request failed, continuing with the shutdown"
         exit 0

--- a/valkey/templates/sentinel-configmap.yaml
+++ b/valkey/templates/sentinel-configmap.yaml
@@ -166,7 +166,13 @@ data:
     port {{ $sentinelPort }}
     {{- end }}
     dir /sentinel-data
+    {{- if not .Values.auth.enabled }}
+    # Sentinel peers connect over the pod network, which protected mode rejects
+    # while no password is configured. Note that this leaves the Sentinel port
+    # open to anything that can reach it, exactly like the Valkey port itself
+    # when auth is disabled. Enable auth to require credentials on both.
     protected-mode no
+    {{- end }}
 
     # Address peers by DNS name, pod IPs change on every reschedule.
     sentinel resolve-hostnames yes

--- a/valkey/templates/sentinel-headless-service.yaml
+++ b/valkey/templates/sentinel-headless-service.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.replica.enabled .Values.replica.sentinel.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "valkey.sentinel.headlessServiceName" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sentinel
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: sentinel
+      port: {{ .Values.replica.sentinel.port }}
+      targetPort: sentinel
+      protocol: TCP
+  selector:
+    {{- include "valkey.sentinel.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/valkey/templates/sentinel-service.yaml
+++ b/valkey/templates/sentinel-service.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.replica.enabled .Values.replica.sentinel.enabled .Values.replica.sentinel.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "valkey.fullname" . }}-sentinel
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sentinel
+  {{- with .Values.replica.sentinel.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.replica.sentinel.service.type }}
+  {{- if .Values.replica.sentinel.service.clusterIP }}
+  clusterIP: {{ .Values.replica.sentinel.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.replica.sentinel.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.replica.sentinel.service.loadBalancerClass }}
+  {{- end }}
+  {{- if .Values.replica.sentinel.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ .Values.replica.sentinel.service.loadBalancerSourceRanges }}
+  {{- end }}
+  ports:
+    - name: sentinel
+      port: {{ .Values.replica.sentinel.service.port }}
+      targetPort: sentinel
+      protocol: TCP
+      {{- if and (eq .Values.replica.sentinel.service.type "NodePort") .Values.replica.sentinel.service.nodePort }}
+      nodePort: {{ .Values.replica.sentinel.service.nodePort }}
+      {{- end }}
+      {{- if .Values.replica.sentinel.service.appProtocol }}
+      appProtocol: {{ .Values.replica.sentinel.service.appProtocol }}
+      {{- end }}
+  selector:
+    {{- include "valkey.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/valkey/templates/sentinel-service.yaml
+++ b/valkey/templates/sentinel-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "valkey.fullname" . }}-sentinel
+  name: {{ include "valkey.sentinel.fullname" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
     app.kubernetes.io/component: sentinel
@@ -34,5 +34,5 @@ spec:
       appProtocol: {{ .Values.replica.sentinel.service.appProtocol }}
       {{- end }}
   selector:
-    {{- include "valkey.selectorLabels" . | nindent 4 }}
+    {{- include "valkey.sentinel.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/valkey/templates/sentinel-service.yaml
+++ b/valkey/templates/sentinel-service.yaml
@@ -18,8 +18,9 @@ spec:
   {{- if .Values.replica.sentinel.service.loadBalancerClass }}
   loadBalancerClass: {{ .Values.replica.sentinel.service.loadBalancerClass }}
   {{- end }}
-  {{- if .Values.replica.sentinel.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges: {{ .Values.replica.sentinel.service.loadBalancerSourceRanges }}
+  {{- with .Values.replica.sentinel.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   ports:
     - name: sentinel

--- a/valkey/templates/sentinel-statefulset.yaml
+++ b/valkey/templates/sentinel-statefulset.yaml
@@ -125,8 +125,11 @@ spec:
             {{- end }}
       volumes:
         {{- if not .Values.replica.sentinel.persistence.enabled }}
+        # Memory backed: Sentinel rewrites its own credentials into
+        # sentinel.conf, so a disk backed emptyDir would put them on the node.
         - name: sentinel-data
-          emptyDir: {}
+          emptyDir:
+            medium: Memory
         {{- end }}
         - name: sentinel-scripts
           configMap:

--- a/valkey/templates/sentinel-statefulset.yaml
+++ b/valkey/templates/sentinel-statefulset.yaml
@@ -1,0 +1,191 @@
+{{- if and .Values.replica.enabled .Values.replica.sentinel.enabled }}
+{{- include "valkey.validateAuthConfig" . }}
+{{- include "valkey.validateReplicaAuth" . }}
+{{- include "valkey.validateSentinelConfig" . }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "valkey.sentinel.fullname" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sentinel
+  {{- with .Values.workloadAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  serviceName: {{ include "valkey.sentinel.headlessServiceName" . }}
+  replicas: {{ .Values.replica.sentinel.replicas }}
+  podManagementPolicy: Parallel
+  {{- if .Values.replica.sentinel.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml .Values.replica.sentinel.persistentVolumeClaimRetentionPolicy | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "valkey.sentinel.selectorLabels" . | nindent 6 }}
+  {{- if .Values.replica.sentinel.persistence.enabled }}
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: sentinel-data
+      spec:
+        accessModes: {{ toYaml .Values.replica.sentinel.persistence.accessModes | nindent 10 }}
+        {{- if .Values.replica.sentinel.persistence.storageClass }}
+        storageClassName: {{ .Values.replica.sentinel.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.replica.sentinel.persistence.size | quote }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "valkey.sentinel.selectorLabels" . | nindent 8 }}
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        checksum/sentinelconfig: {{ include (print $.Template.BasePath "/sentinel-configmap.yaml") . | sha256sum | trunc 32 | quote }}
+    spec:
+      {{- (include "valkey.imagePullSecrets" .) | nindent 6 }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      serviceAccountName: {{ include "valkey.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName | quote }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: sentinel
+          image: {{ include "valkey.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: [ "/sentinel-scripts/sentinel-start.sh" ]
+          {{- with (default .Values.securityContext .Values.replica.sentinel.securityContext) }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          ports:
+            - name: sentinel
+              containerPort: {{ .Values.replica.sentinel.port }}
+              protocol: TCP
+          startupProbe:
+            exec:
+              command: [ "/sentinel-scripts/sentinel-ping.sh" ]
+            periodSeconds: 5
+            failureThreshold: {{ div (add .Values.replica.sentinel.startupTimeoutSeconds 30) 5 }}
+          livenessProbe:
+            exec:
+              command: [ "/sentinel-scripts/sentinel-ping.sh" ]
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: [ "/sentinel-scripts/sentinel-ping.sh" ]
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.replica.sentinel.resources | nindent 12 }}
+          volumeMounts:
+            - name: sentinel-data
+              mountPath: /sentinel-data
+            - name: sentinel-scripts
+              mountPath: /sentinel-scripts
+            - name: sentinel-auth
+              mountPath: /sentinel-auth
+              readOnly: true
+            {{- if .Values.tls.enabled }}
+            - name: {{ include "valkey.fullname" . }}-tls
+              mountPath: /tls
+            {{- end }}
+            {{- if .Values.auth.enabled }}
+            {{- if .Values.auth.usersExistingSecret }}
+            - name: valkey-users-secret
+              mountPath: /valkey-users-secret
+              readOnly: true
+            {{- end }}
+            {{- if or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig }}
+            - name: valkey-auth-secret
+              mountPath: /valkey-auth-secret
+              readOnly: true
+            {{- end }}
+            {{- end }}
+      volumes:
+        {{- if not .Values.replica.sentinel.persistence.enabled }}
+        - name: sentinel-data
+          emptyDir: {}
+        {{- end }}
+        - name: sentinel-scripts
+          configMap:
+            name: {{ include "valkey.fullname" . }}-sentinel-scripts
+            defaultMode: 0555
+        - name: sentinel-auth
+          projected:
+            defaultMode: 0400
+            sources:
+              {{- if .Values.auth.usersExistingSecret }}
+              - secret:
+                  name: {{ tpl .Values.auth.usersExistingSecret . }}
+                  optional: true
+                  items:
+                    - key: {{ .Values.replica.sentinel.passwordKey }}
+                      path: existing-password
+              {{- end }}
+              {{- if .Values.replica.sentinel.password }}
+              - secret:
+                  name: {{ include "valkey.fullname" . }}-auth
+                  optional: true
+                  items:
+                    - key: sentinel-password
+                      path: inline-password
+              {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: {{ include "valkey.fullname" . }}-tls
+          secret:
+            secretName: {{ required "An existing secret is required to enable TLS" .Values.tls.existingSecret }}
+            defaultMode: 0400
+        {{- end }}
+        {{- if .Values.auth.enabled }}
+        {{- if .Values.auth.usersExistingSecret }}
+        - name: valkey-users-secret
+          secret:
+            secretName: {{ tpl .Values.auth.usersExistingSecret . }}
+            defaultMode: 0400
+        {{- end }}
+        {{- if or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig }}
+        - name: valkey-auth-secret
+          secret:
+            secretName: {{ include "valkey.fullname" . }}-auth
+            defaultMode: 0400
+        {{- end }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/valkey/templates/service-headless.yaml
+++ b/valkey/templates/service-headless.yaml
@@ -15,6 +15,12 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: tcp
       protocol: TCP
+    {{- if .Values.replica.sentinel.enabled }}
+    - name: sentinel
+      port: {{ .Values.replica.sentinel.port }}
+      targetPort: sentinel
+      protocol: TCP
+    {{- end }}
   selector:
     {{- include "valkey.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/valkey/templates/service-headless.yaml
+++ b/valkey/templates/service-headless.yaml
@@ -15,12 +15,6 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: tcp
       protocol: TCP
-    {{- if .Values.replica.sentinel.enabled }}
-    - name: sentinel
-      port: {{ .Values.replica.sentinel.port }}
-      targetPort: sentinel
-      protocol: TCP
-    {{- end }}
   selector:
     {{- include "valkey.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/valkey/templates/service.yaml
+++ b/valkey/templates/service.yaml
@@ -4,7 +4,14 @@ metadata:
   name: {{ include "valkey.fullname" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
+    {{- if .Values.replica.sentinel.enabled }}
+    # Not "primary": with Sentinel the master can be any pod, and a Service
+    # cannot select on a role that changes, so this one reaches every node.
+    # Writes belong at the address Sentinel names, or at the HAProxy service.
+    app.kubernetes.io/component: nodes
+    {{- else }}
     app.kubernetes.io/component: primary
+    {{- end }}
   {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/valkey/templates/service.yaml
+++ b/valkey/templates/service.yaml
@@ -33,6 +33,6 @@ spec:
       {{- end }}
   selector:
     {{- include "valkey.selectorLabels" . | nindent 4 }}
-    {{- if .Values.replica.enabled }}
+    {{- if and .Values.replica.enabled (not .Values.replica.sentinel.enabled) }}
     statefulset.kubernetes.io/pod-name: {{ include "valkey.fullname" . }}-0
     {{- end }}

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -16,7 +16,9 @@ metadata:
 spec:
   serviceName: {{ include "valkey.fullname" . }}-headless
   replicas: {{ add (int .Values.replica.replicas) 1 }}
-  {{- if .Values.replica.sentinel.enabled }}
+  {{- if .Values.replica.podManagementPolicy }}
+  podManagementPolicy: {{ .Values.replica.podManagementPolicy }}
+  {{- else if .Values.replica.sentinel.enabled }}
   # Sentinel forms its quorum from the pods themselves, so they have to be able
   # to come up together instead of waiting for pod-0 to become ready first.
   podManagementPolicy: Parallel
@@ -80,6 +82,7 @@ spec:
         {{- end }}
     spec:
       {{- (include "valkey.imagePullSecrets" .) | nindent 6 }}
+      terminationGracePeriodSeconds: {{ .Values.replica.terminationGracePeriodSeconds }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
       serviceAccountName: {{ include "valkey.serviceAccountName" . }}
       {{- if .Values.priorityClassName }}
@@ -233,7 +236,9 @@ spec:
             exec:
               command: [ "/sentinel-scripts/sentinel-ping.sh" ]
             periodSeconds: 5
-            failureThreshold: {{ div (add .Values.replica.sentinel.startupTimeoutSeconds 10) 5 }}
+            # Covers the wait for the local Valkey server plus the peer discovery
+            # that follows it, both bounded by startupTimeoutSeconds.
+            failureThreshold: {{ div (add (mul .Values.replica.sentinel.startupTimeoutSeconds 2) 30) 5 }}
           livenessProbe:
             exec:
               command: [ "/sentinel-scripts/sentinel-ping.sh" ]

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -94,6 +94,14 @@ spec:
               mountPath: /sentinel-auth
               readOnly: true
             {{- end }}
+            {{- if and .Values.tls.enabled .Values.replica.sentinel.enabled }}
+            # This container asks Sentinel which node is the master, and over
+            # TLS that query needs the CA to verify the answer. Without Sentinel
+            # it makes no connection at all, so it gets no key material.
+            - name: {{ include "valkey.fullname" . }}-tls
+              mountPath: /tls
+              readOnly: true
+            {{- end }}
             {{- if .Values.valkeyConfig }}
             - name: valkey-config
               mountPath: /usr/local/etc/valkey/valkey.conf

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -112,6 +112,11 @@ spec:
               mountPath: /data
             - name: scripts
               mountPath: /scripts
+            {{- if .Values.replica.sentinel.enabled }}
+            - name: sentinel-auth
+              mountPath: /sentinel-auth
+              readOnly: true
+            {{- end }}
             {{- if .Values.valkeyConfig }}
             - name: valkey-config
               mountPath: /usr/local/etc/valkey/valkey.conf
@@ -182,6 +187,9 @@ spec:
             {{- if and .Values.replica.sentinel.enabled .Values.replica.sentinel.preStopFailover }}
             - name: sentinel-scripts
               mountPath: /sentinel-scripts
+            - name: sentinel-auth
+              mountPath: /sentinel-auth
+              readOnly: true
             {{- end }}
             {{- if .Values.tls.enabled }}
             - name: {{ include "valkey.fullname" . }}-tls
@@ -254,6 +262,9 @@ spec:
               mountPath: /sentinel-data
             - name: sentinel-scripts
               mountPath: /sentinel-scripts
+            - name: sentinel-auth
+              mountPath: /sentinel-auth
+              readOnly: true
             {{- if .Values.tls.enabled }}
             - name: {{ include "valkey.fullname" . }}-tls
               mountPath: /tls
@@ -343,6 +354,26 @@ spec:
           configMap:
             name: {{ include "valkey.fullname" . }}-sentinel-scripts
             defaultMode: 0555
+        - name: sentinel-auth
+          projected:
+            defaultMode: 0400
+            sources:
+              {{- if .Values.auth.usersExistingSecret }}
+              - secret:
+                  name: {{ tpl .Values.auth.usersExistingSecret . }}
+                  optional: true
+                  items:
+                    - key: {{ .Values.replica.sentinel.passwordKey }}
+                      path: existing-password
+              {{- end }}
+              {{- if .Values.replica.sentinel.password }}
+              - secret:
+                  name: {{ include "valkey.fullname" . }}-auth
+                  optional: true
+                  items:
+                    - key: sentinel-password
+                      path: inline-password
+              {{- end }}
         {{- if not .Values.replica.sentinel.persistence.enabled }}
         - name: sentinel-data
           emptyDir: {}

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -2,6 +2,7 @@
 {{- include "valkey.validateAuthConfig" . }}
 {{- include "valkey.validateReplicaPersistence" . }}
 {{- include "valkey.validateReplicaAuth" . }}
+{{- include "valkey.validateSentinelConfig" . }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -15,7 +16,13 @@ metadata:
 spec:
   serviceName: {{ include "valkey.fullname" . }}-headless
   replicas: {{ add (int .Values.replica.replicas) 1 }}
+  {{- if .Values.replica.sentinel.enabled }}
+  # Sentinel forms its quorum from the pods themselves, so they have to be able
+  # to come up together instead of waiting for pod-0 to become ready first.
+  podManagementPolicy: Parallel
+  {{- else }}
   podManagementPolicy: OrderedReady
+  {{- end }}
   {{- if .Values.replica.persistentVolumeClaimRetentionPolicy }}
   persistentVolumeClaimRetentionPolicy:
     {{- toYaml .Values.replica.persistentVolumeClaimRetentionPolicy | nindent 4 }}
@@ -24,7 +31,7 @@ spec:
     matchLabels:
       {{- include "valkey.selectorLabels" . | nindent 6 }}
   volumeClaimTemplates:
-  - apiVersion: v1	
+  - apiVersion: v1
     kind: PersistentVolumeClaim
     metadata:
       name: valkey-data
@@ -36,6 +43,20 @@ spec:
       resources:
         requests:
           storage: {{ .Values.replica.persistence.size | quote }}
+  {{- if and .Values.replica.sentinel.enabled .Values.replica.sentinel.persistence.enabled }}
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: sentinel-data
+    spec:
+      accessModes: {{ toYaml .Values.replica.sentinel.persistence.accessModes | nindent 8 }}
+      {{- if .Values.replica.sentinel.persistence.storageClass }}
+      storageClassName: {{ .Values.replica.sentinel.persistence.storageClass | quote }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.replica.sentinel.persistence.size | quote }}
+  {{- end }}
   template:
     metadata:
       labels:
@@ -53,6 +74,9 @@ spec:
         checksum/initconfig: {{ include (print $.Template.BasePath "/init_config.yaml") . | sha256sum | trunc 32 | quote }}
         {{- if .Values.valkeyConfig }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 32 | quote }}
+        {{- end }}
+        {{- if .Values.replica.sentinel.enabled }}
+        checksum/sentinelconfig: {{ include (print $.Template.BasePath "/sentinel-configmap.yaml") . | sha256sum | trunc 32 | quote }}
         {{- end }}
     spec:
       {{- (include "valkey.imagePullSecrets" .) | nindent 6 }}
@@ -141,11 +165,21 @@ spec:
           {{- with (include "valkey.healthProbes" .) }}
           {{- . | nindent 10 }}
           {{- end }}
+          {{- if and .Values.replica.sentinel.enabled .Values.replica.sentinel.preStopFailover }}
+          lifecycle:
+            preStop:
+              exec:
+                command: [ "/sentinel-scripts/sentinel-prestop.sh" ]
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: valkey-data
               mountPath: /data
+            {{- if and .Values.replica.sentinel.enabled .Values.replica.sentinel.preStopFailover }}
+            - name: sentinel-scripts
+              mountPath: /sentinel-scripts
+            {{- end }}
             {{- if .Values.tls.enabled }}
             - name: {{ include "valkey.fullname" . }}-tls
               mountPath: /tls
@@ -153,6 +187,18 @@ spec:
             {{- if .Values.auth.enabled }}
             - name: valkey-acl
               mountPath: /etc/valkey
+            {{- if and .Values.replica.sentinel.enabled .Values.replica.sentinel.preStopFailover }}
+            {{- if .Values.auth.usersExistingSecret }}
+            - name: valkey-users-secret
+              mountPath: /valkey-users-secret
+              readOnly: true
+            {{- end }}
+            {{- if or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig }}
+            - name: valkey-auth-secret
+              mountPath: /valkey-auth-secret
+              readOnly: true
+            {{- end }}
+            {{- end }}
             {{- end }}
             {{- range $secret := .Values.extraValkeySecrets }}
             - name: {{ $secret.name }}-valkey
@@ -165,6 +211,61 @@ spec:
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+        {{- if .Values.replica.sentinel.enabled }}
+        - name: sentinel
+          image: {{ include "valkey.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: [ "/sentinel-scripts/sentinel-start.sh" ]
+          {{- with (default .Values.securityContext .Values.replica.sentinel.securityContext) }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          ports:
+            - name: sentinel
+              containerPort: {{ .Values.replica.sentinel.port }}
+              protocol: TCP
+          startupProbe:
+            exec:
+              command: [ "/sentinel-scripts/sentinel-ping.sh" ]
+            periodSeconds: 5
+            failureThreshold: {{ div (add .Values.replica.sentinel.startupTimeoutSeconds 10) 5 }}
+          livenessProbe:
+            exec:
+              command: [ "/sentinel-scripts/sentinel-ping.sh" ]
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: [ "/sentinel-scripts/sentinel-ping.sh" ]
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.replica.sentinel.resources | nindent 12 }}
+          volumeMounts:
+            - name: sentinel-data
+              mountPath: /sentinel-data
+            - name: sentinel-scripts
+              mountPath: /sentinel-scripts
+            {{- if .Values.tls.enabled }}
+            - name: {{ include "valkey.fullname" . }}-tls
+              mountPath: /tls
+            {{- end }}
+            {{- if .Values.auth.enabled }}
+            {{- if .Values.auth.usersExistingSecret }}
+            - name: valkey-users-secret
+              mountPath: /valkey-users-secret
+              readOnly: true
+            {{- end }}
+            {{- if or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig }}
+            - name: valkey-auth-secret
+              mountPath: /valkey-auth-secret
+              readOnly: true
+            {{- end }}
+            {{- end }}
+        {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           image: {{ include "valkey.metrics.exporter.image" . }}
@@ -232,6 +333,16 @@ spec:
           configMap:
             name: {{ include "valkey.fullname" . }}-init-scripts
             defaultMode: 0555
+        {{- if .Values.replica.sentinel.enabled }}
+        - name: sentinel-scripts
+          configMap:
+            name: {{ include "valkey.fullname" . }}-sentinel-scripts
+            defaultMode: 0555
+        {{- if not .Values.replica.sentinel.persistence.enabled }}
+        - name: sentinel-data
+          emptyDir: {}
+        {{- end }}
+        {{- end }}
         {{- if .Values.auth.enabled }}
         - name: valkey-acl
           emptyDir:

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -85,6 +85,8 @@ spec:
           volumeMounts:
             - name: valkey-data
               mountPath: /data
+            - name: valkey-conf
+              mountPath: /valkey-conf
             - name: scripts
               mountPath: /scripts
             {{- if .Values.replica.sentinel.enabled }}
@@ -127,7 +129,7 @@ spec:
           image: {{ include "valkey.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: [ "valkey-server" ]
-          args: [ "/data/conf/valkey.conf" ]
+          args: [ "/valkey-conf/valkey.conf" ]
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           env:
@@ -159,6 +161,8 @@ spec:
           volumeMounts:
             - name: valkey-data
               mountPath: /data
+            - name: valkey-conf
+              mountPath: /valkey-conf
             {{- if and .Values.replica.sentinel.enabled .Values.replica.sentinel.preStopFailover }}
             - name: sentinel-scripts
               mountPath: /sentinel-scripts
@@ -260,6 +264,12 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       volumes:
+        # Holds valkey.conf. Memory backed because the file carries the
+        # replication credentials in plain text, and CONFIG REWRITE rewrites
+        # them into it whenever Sentinel changes the topology.
+        - name: valkey-conf
+          emptyDir:
+            medium: Memory
         - name: scripts
           configMap:
             name: {{ include "valkey.fullname" . }}-init-scripts

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -16,15 +16,7 @@ metadata:
 spec:
   serviceName: {{ include "valkey.fullname" . }}-headless
   replicas: {{ add (int .Values.replica.replicas) 1 }}
-  {{- if .Values.replica.podManagementPolicy }}
-  podManagementPolicy: {{ .Values.replica.podManagementPolicy }}
-  {{- else if .Values.replica.sentinel.enabled }}
-  # Sentinel forms its quorum from the pods themselves, so they have to be able
-  # to come up together instead of waiting for pod-0 to become ready first.
-  podManagementPolicy: Parallel
-  {{- else }}
   podManagementPolicy: OrderedReady
-  {{- end }}
   {{- if .Values.replica.persistentVolumeClaimRetentionPolicy }}
   persistentVolumeClaimRetentionPolicy:
     {{- toYaml .Values.replica.persistentVolumeClaimRetentionPolicy | nindent 4 }}
@@ -45,20 +37,6 @@ spec:
       resources:
         requests:
           storage: {{ .Values.replica.persistence.size | quote }}
-  {{- if and .Values.replica.sentinel.enabled .Values.replica.sentinel.persistence.enabled }}
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      name: sentinel-data
-    spec:
-      accessModes: {{ toYaml .Values.replica.sentinel.persistence.accessModes | nindent 8 }}
-      {{- if .Values.replica.sentinel.persistence.storageClass }}
-      storageClassName: {{ .Values.replica.sentinel.persistence.storageClass | quote }}
-      {{- end }}
-      resources:
-        requests:
-          storage: {{ .Values.replica.sentinel.persistence.size | quote }}
-  {{- end }}
   template:
     metadata:
       labels:
@@ -76,9 +54,6 @@ spec:
         checksum/initconfig: {{ include (print $.Template.BasePath "/init_config.yaml") . | sha256sum | trunc 32 | quote }}
         {{- if .Values.valkeyConfig }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 32 | quote }}
-        {{- end }}
-        {{- if .Values.replica.sentinel.enabled }}
-        checksum/sentinelconfig: {{ include (print $.Template.BasePath "/sentinel-configmap.yaml") . | sha256sum | trunc 32 | quote }}
         {{- end }}
     spec:
       {{- (include "valkey.imagePullSecrets" .) | nindent 6 }}
@@ -222,66 +197,6 @@ spec:
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-        {{- if .Values.replica.sentinel.enabled }}
-        - name: sentinel
-          image: {{ include "valkey.image" . }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: [ "/sentinel-scripts/sentinel-start.sh" ]
-          {{- with (default .Values.securityContext .Values.replica.sentinel.securityContext) }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-          ports:
-            - name: sentinel
-              containerPort: {{ .Values.replica.sentinel.port }}
-              protocol: TCP
-          startupProbe:
-            exec:
-              command: [ "/sentinel-scripts/sentinel-ping.sh" ]
-            periodSeconds: 5
-            # Covers the wait for the local Valkey server plus the peer discovery
-            # that follows it, both bounded by startupTimeoutSeconds.
-            failureThreshold: {{ div (add (mul .Values.replica.sentinel.startupTimeoutSeconds 2) 30) 5 }}
-          livenessProbe:
-            exec:
-              command: [ "/sentinel-scripts/sentinel-ping.sh" ]
-            periodSeconds: 10
-          readinessProbe:
-            exec:
-              command: [ "/sentinel-scripts/sentinel-ping.sh" ]
-            periodSeconds: 10
-          resources:
-            {{- toYaml .Values.replica.sentinel.resources | nindent 12 }}
-          volumeMounts:
-            - name: sentinel-data
-              mountPath: /sentinel-data
-            - name: sentinel-scripts
-              mountPath: /sentinel-scripts
-            - name: sentinel-auth
-              mountPath: /sentinel-auth
-              readOnly: true
-            {{- if .Values.tls.enabled }}
-            - name: {{ include "valkey.fullname" . }}-tls
-              mountPath: /tls
-            {{- end }}
-            {{- if .Values.auth.enabled }}
-            {{- if .Values.auth.usersExistingSecret }}
-            - name: valkey-users-secret
-              mountPath: /valkey-users-secret
-              readOnly: true
-            {{- end }}
-            {{- if or (include "valkey.hasInlinePasswords" . | eq "true") .Values.auth.aclConfig }}
-            - name: valkey-auth-secret
-              mountPath: /valkey-auth-secret
-              readOnly: true
-            {{- end }}
-            {{- end }}
-        {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           image: {{ include "valkey.metrics.exporter.image" . }}
@@ -374,10 +289,6 @@ spec:
                     - key: sentinel-password
                       path: inline-password
               {{- end }}
-        {{- if not .Values.replica.sentinel.persistence.enabled }}
-        - name: sentinel-data
-          emptyDir: {}
-        {{- end }}
         {{- end }}
         {{- if .Values.auth.enabled }}
         - name: valkey-acl

--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -128,7 +128,14 @@ spec:
         - name: {{ include "valkey.fullname" . }}
           image: {{ include "valkey.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.replica.sentinel.enabled }}
+          # A wrapper that keeps the credential free master record on the data
+          # volume in step with the config Sentinel makes the server rewrite.
+          # It execs the server, so valkey-server is still PID 1.
+          command: [ "/scripts/valkey-start.sh" ]
+          {{- else }}
           command: [ "valkey-server" ]
+          {{- end }}
           args: [ "/valkey-conf/valkey.conf" ]
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -163,6 +170,10 @@ spec:
               mountPath: /data
             - name: valkey-conf
               mountPath: /valkey-conf
+            {{- if .Values.replica.sentinel.enabled }}
+            - name: scripts
+              mountPath: /scripts
+            {{- end }}
             {{- if and .Values.replica.sentinel.enabled .Values.replica.sentinel.preStopFailover }}
             - name: sentinel-scripts
               mountPath: /sentinel-scripts

--- a/valkey/tests/init_config_test.yaml
+++ b/valkey/tests/init_config_test.yaml
@@ -120,6 +120,9 @@ tests:
       - matchRegex:
           path: data["init.sh"]
           pattern: 'REPL_PASSWORD=\$\(get_user_password "default" "valkey-password"\)'
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'masterauth \\"\$REPL_PASSWORD_ESCAPED\\"'
 
   - it: should default to username for replica authentication when passwordKey not configured
     set:

--- a/valkey/tests/init_config_test.yaml
+++ b/valkey/tests/init_config_test.yaml
@@ -88,6 +88,24 @@ tests:
           path: data["init.sh"]
           pattern: "ERROR.*No password found"
 
+  - it: should refuse an empty password rather than hash it into the ACL
+    set:
+      auth.enabled: true
+      auth.usersExistingSecret: "valkey-users"
+      auth.aclUsers:
+        admin:
+          permissions: "~* &* +@all"
+    asserts:
+      # A zero byte value in the secret reads back as an empty password, and
+      # the SHA of an empty password is the same in every installation, so the
+      # user would be open to anyone who can reach the port.
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'if \[ -z "\$password" \]; then'
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'ERROR: The password for user \$username is empty'
+
   - it: should use aclConfig only
     set:
       auth.enabled: true

--- a/valkey/tests/secret_test.yaml
+++ b/valkey/tests/secret_test.yaml
@@ -148,3 +148,16 @@ tests:
       - equal:
           path: data["sentinel-password"]
           value: c2VudGluZWwtcGFzc3dvcmQ=
+
+  - it: should secure sentinel even when valkey auth is disabled
+    set:
+      auth.enabled: false
+      replica.enabled: true
+      replica.sentinel.enabled: true
+      replica.sentinel.password: "sentinel-password"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: data["sentinel-password"]
+          value: c2VudGluZWwtcGFzc3dvcmQ=

--- a/valkey/tests/secret_test.yaml
+++ b/valkey/tests/secret_test.yaml
@@ -133,3 +133,18 @@ tests:
       - equal:
           path: metadata.labels["app.kubernetes.io/instance"]
           value: RELEASE-NAME
+
+  - it: should store the dedicated sentinel password separately
+    set:
+      auth.enabled: true
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          password: "default-password"
+      replica.enabled: true
+      replica.sentinel.enabled: true
+      replica.sentinel.password: "sentinel-password"
+    asserts:
+      - equal:
+          path: data["sentinel-password"]
+          value: c2VudGluZWwtcGFzc3dvcmQ=

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -1,0 +1,293 @@
+suite: sentinel configuration
+templates:
+  - templates/statefulset.yaml
+  - templates/init_config.yaml
+  - templates/sentinel-configmap.yaml
+  - templates/sentinel-service.yaml
+  - templates/service.yaml
+  - templates/service-headless.yaml
+  - templates/deploy_valkey.yaml
+set:
+  replica.enabled: true
+  replica.persistence.size: "5Gi"
+  replica.sentinel.enabled: true
+tests:
+  - it: should fail when sentinel is enabled without replication
+    set:
+      replica.enabled: false
+    template: templates/deploy_valkey.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "Sentinel requires replication.*"
+
+  - it: should fail when there are fewer than three pods
+    set:
+      replica.replicas: 1
+    template: templates/statefulset.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "Sentinel requires at least 3 pods.*"
+
+  - it: should fail when the quorum exceeds the number of sentinels
+    set:
+      replica.sentinel.quorum: 4
+    template: templates/statefulset.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "quorum \\(4\\) cannot be greater than the number of Sentinels \\(3\\).*"
+
+  - it: should fail when the quorum allows a single sentinel to fail over
+    set:
+      replica.sentinel.quorum: 1
+    template: templates/statefulset.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "quorum must be at least 2.*"
+
+  - it: should fail when the monitor user is missing from aclUsers
+    set:
+      auth.enabled: true
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          password: "pw"
+      replica.sentinel.monitorUser: "missing-user"
+    template: templates/statefulset.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "Sentinel monitor user 'missing-user' must be defined in auth.aclUsers.*"
+
+  - it: should add a sentinel container to every valkey pod
+    template: templates/statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: sentinel
+      - equal:
+          path: spec.template.spec.containers[1].command
+          value: [ "/sentinel-scripts/sentinel-start.sh" ]
+      - equal:
+          path: spec.template.spec.containers[1].ports[0].containerPort
+          value: 26379
+
+  - it: should start the pods in parallel so that the quorum can form
+    template: templates/statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.podManagementPolicy
+          value: Parallel
+
+  - it: should keep ordered startup when sentinel is disabled
+    set:
+      replica.sentinel.enabled: false
+    template: templates/statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.podManagementPolicy
+          value: OrderedReady
+
+  - it: should mount an emptyDir for the sentinel state by default
+    template: templates/statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: sentinel-data
+            emptyDir: {}
+      - lengthEqual:
+          path: spec.volumeClaimTemplates
+          count: 1
+
+  - it: should claim a volume for the sentinel state when persistence is enabled
+    set:
+      replica.sentinel.persistence.enabled: true
+      replica.sentinel.persistence.size: "200Mi"
+    template: templates/statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[1].metadata.name
+          value: sentinel-data
+      - equal:
+          path: spec.volumeClaimTemplates[1].spec.resources.requests.storage
+          value: "200Mi"
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: sentinel-data
+            emptyDir: {}
+
+  - it: should fail over gracefully before a pod is terminated
+    template: templates/statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value: [ "/sentinel-scripts/sentinel-prestop.sh" ]
+
+  - it: should not install a preStop hook when the graceful failover is disabled
+    set:
+      replica.sentinel.preStopFailover: false
+    template: templates/statefulset.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].lifecycle
+
+  - it: should stop pinning the valkey service to pod-0, the master can move
+    template: templates/service.yaml
+    asserts:
+      - notExists:
+          path: spec.selector["statefulset.kubernetes.io/pod-name"]
+
+  - it: should keep pinning the valkey service to pod-0 without sentinel
+    set:
+      replica.sentinel.enabled: false
+    template: templates/service.yaml
+    asserts:
+      - equal:
+          path: spec.selector["statefulset.kubernetes.io/pod-name"]
+          value: RELEASE-NAME-valkey-0
+
+  - it: should expose the sentinel port on the headless service
+    template: templates/service-headless.yaml
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: sentinel
+            port: 26379
+            targetPort: sentinel
+            protocol: TCP
+
+  - it: should expose a sentinel service for client discovery
+    template: templates/sentinel-service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-sentinel
+      - equal:
+          path: spec.ports[0].port
+          value: 26379
+
+  - it: should monitor pod-0 by default with the configured quorum
+    set:
+      replica.sentinel.quorum: 3
+      replica.sentinel.masterSet: "valkey-ha"
+    template: templates/sentinel-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'sentinel monitor \$\{MASTER_SET\} \$\{MASTER_HOST\} \$\{MASTER_PORT\} 3'
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'MASTER_SET="valkey-ha"'
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'DEFAULT_MASTER_HOST="RELEASE-NAME-valkey-0\.RELEASE-NAME-valkey-headless\.NAMESPACE\.svc\.cluster\.local"'
+
+  - it: should not configure authentication when auth is disabled
+    template: templates/sentinel-configmap.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'sentinel auth-pass'
+
+  - it: should authenticate to the nodes and secure the sentinel port
+    set:
+      auth.enabled: true
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          password: "pw"
+        replicator:
+          permissions: "~* &* +psync +replconf"
+          password: "replpw"
+      replica.replicationUser: replicator
+    template: templates/sentinel-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'user default on #\$\{DEFAULT_PASSHASH\}'
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'sentinel sentinel-pass \$\{DEFAULT_PASSWORD\}'
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'sentinel auth-user \$\{MASTER_SET\} replicator'
+
+  - it: should not emit an auth-user for the default user
+    set:
+      auth.enabled: true
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          password: "pw"
+    template: templates/sentinel-configmap.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'sentinel auth-user'
+
+  - it: should serve sentinel over TLS when TLS is enabled
+    set:
+      tls.enabled: true
+      tls.existingSecret: "valkey-tls"
+    template: templates/sentinel-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'tls-port 26379'
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'valkey-cli --tls --cacert /tls/ca.crt'
+
+  - it: should append extra sentinel configuration
+    set:
+      replica.sentinel.extraConfig: |
+        sentinel deny-scripts-reconfig yes
+    template: templates/sentinel-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'sentinel deny-scripts-reconfig yes'
+
+  - it: should roll the pods when the sentinel scripts change
+    template: templates/statefulset.yaml
+    asserts:
+      - exists:
+          path: spec.template.metadata.annotations["checksum/sentinelconfig"]
+
+  - it: should restore the replication target chosen by sentinel on restart
+    template: templates/init_config.yaml
+    asserts:
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'SAVED_REPLICAOF=\$\(grep -E "\^\[\[:space:\]\]\*\(replicaof\|slaveof\)'
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'REPLICATION_TARGET="\$SAVED_REPLICAOF"'
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'touch "\$BOOTSTRAP_MARKER"'
+
+  - it: should pin non-zero pods to pod-0 without sentinel
+    set:
+      replica.sentinel.enabled: false
+    template: templates/init_config.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["init.sh"]
+          pattern: 'BOOTSTRAP_MARKER'
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'REPLICATION_TARGET="replicaof \$MASTER_HOST \$MASTER_PORT"'
+
+  - it: should not render any sentinel resource when sentinel is disabled
+    set:
+      replica.sentinel.enabled: false
+    templates:
+      - templates/sentinel-configmap.yaml
+      - templates/sentinel-service.yaml
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -47,6 +47,7 @@ tests:
   - it: should fail when the monitor user is missing from aclUsers
     set:
       auth.enabled: true
+      replica.sentinel.password: "sentinelpw"
       auth.aclUsers:
         default:
           permissions: "~* &* +@all"
@@ -56,6 +57,18 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "Sentinel monitor user 'missing-user' must be defined in auth.aclUsers.*"
+
+  - it: should require a dedicated sentinel password when auth is enabled
+    set:
+      auth.enabled: true
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          password: "pw"
+    template: templates/statefulset.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "replica.sentinel.password is required.*"
 
   - it: should add a sentinel container to every valkey pod
     template: templates/statefulset.yaml
@@ -195,6 +208,7 @@ tests:
   - it: should authenticate to the nodes and secure the sentinel port
     set:
       auth.enabled: true
+      replica.sentinel.password: "sentinelpw"
       auth.aclUsers:
         default:
           permissions: "~* &* +@all"
@@ -207,10 +221,16 @@ tests:
     asserts:
       - matchRegex:
           path: data["sentinel-start.sh"]
-          pattern: 'user default on #\$\{DEFAULT_PASSHASH\}'
+          pattern: 'user default off'
       - matchRegex:
           path: data["sentinel-start.sh"]
-          pattern: 'sentinel sentinel-pass \$\{DEFAULT_PASSWORD\}'
+          pattern: 'user sentinel on #\$\{SENTINEL_PASSHASH\} ~\* &\* \+@all'
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'sentinel sentinel-user sentinel'
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'sentinel sentinel-pass \$\{SENTINEL_PASSWORD\}'
       - matchRegex:
           path: data["sentinel-start.sh"]
           pattern: 'sentinel auth-user \$\{MASTER_SET\} replicator'
@@ -218,6 +238,7 @@ tests:
   - it: should not emit an auth-user for the default user
     set:
       auth.enabled: true
+      replica.sentinel.password: "sentinelpw"
       auth.aclUsers:
         default:
           permissions: "~* &* +@all"
@@ -315,6 +336,7 @@ tests:
   - it: should keep the credentials out of the process list
     set:
       auth.enabled: true
+      replica.sentinel.password: "sentinelpw"
       auth.aclUsers:
         default:
           permissions: "~* &* +@all"

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -596,6 +596,55 @@ tests:
           path: data["sentinel-prestop.sh"]
           pattern: '> /data/conf/last-master'
 
+  - it: should keep the master record in step with runtime failovers
+    template: templates/init_config.yaml
+    asserts:
+      # Written only at start and stop, the record would still name the old
+      # master after a promotion, and an abrupt restart would then hand writes
+      # back to a node Sentinel had already demoted.
+      - matchRegex:
+          path: data["valkey-start.sh"]
+          pattern: 'track_master &'
+      - matchRegex:
+          path: data["valkey-start.sh"]
+          pattern: 'exec valkey-server "\$@"'
+      - matchRegex:
+          path: data["valkey-start.sh"]
+          pattern: '\(replicaof\|slaveof\)'
+      # It reads the config Valkey maintains, so it needs no credentials.
+      - notMatchRegex:
+          path: data["valkey-start.sh"]
+          pattern: 'REDISCLI_AUTH|valkey-cli'
+
+  - it: should run the tracker only when sentinel is enabled
+    set:
+      replica.sentinel.enabled: false
+    template: templates/init_config.yaml
+    asserts:
+      - notExists:
+          path: data["valkey-start.sh"]
+
+  - it: should exec the server through the tracker wrapper
+    template: templates/statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value: [ "/scripts/valkey-start.sh" ]
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: scripts
+            mountPath: /scripts
+
+  - it: should start the server directly without sentinel
+    set:
+      replica.sentinel.enabled: false
+    template: templates/statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value: [ "valkey-server" ]
+
   - it: should not render any sentinel resource when sentinel is disabled
     set:
       replica.sentinel.enabled: false

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -268,7 +268,10 @@ tests:
           pattern: 'REPLICATION_TARGET="\$SAVED_REPLICAOF"'
       - matchRegex:
           path: data["init.sh"]
-          pattern: 'touch "\$BOOTSTRAP_MARKER"'
+          pattern: 'HAS_PREVIOUS_CONFIG=true'
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'mv "\$VALKEY_CONFIG_TMP" "\$VALKEY_CONFIG"'
 
   - it: should pin non-zero pods to pod-0 without sentinel
     set:
@@ -277,7 +280,7 @@ tests:
     asserts:
       - notMatchRegex:
           path: data["init.sh"]
-          pattern: 'BOOTSTRAP_MARKER'
+          pattern: 'HAS_PREVIOUS_CONFIG'
       - matchRegex:
           path: data["init.sh"]
           pattern: 'REPLICATION_TARGET="replicaof \$MASTER_HOST \$MASTER_PORT"'

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -285,6 +285,103 @@ tests:
           path: data["init.sh"]
           pattern: 'REPLICATION_TARGET="replicaof \$MASTER_HOST \$MASTER_PORT"'
 
+  - it: should ask the running sentinels before falling back to the pod index
+    template: templates/init_config.yaml
+    asserts:
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'master_from_sentinels\(\) \{'
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'DISCOVERED=\$\(master_from_sentinels \|\| true\)'
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'sentinel get-master-addr-by-name mymaster'
+
+  - it: should reject an incomplete answer from a peer sentinel
+    template: templates/sentinel-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'echo "\$port" \| grep -qE "\^\[0-9\]\+\$"'
+
+  - it: should reject an incomplete peer answer in the init script too
+    template: templates/init_config.yaml
+    asserts:
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'echo "\$port" \| grep -qE "\^\[0-9\]\+\$"'
+
+  - it: should keep the credentials out of the process list
+    set:
+      auth.enabled: true
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          password: "pw"
+    template: templates/sentinel-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'REDISCLI_AUTH='
+      - notMatchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: ' -a "\$'
+      - notMatchRegex:
+          path: data["sentinel-prestop.sh"]
+          pattern: ' -a "\$'
+      - notMatchRegex:
+          path: data["sentinel-ping.sh"]
+          pattern: ' -a "\$'
+
+  - it: should render the listen port from service.port
+    set:
+      service.port: 7000
+    template: templates/init_config.yaml
+    asserts:
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'echo "port 7000"'
+      - notMatchRegex:
+          path: data["init.sh"]
+          pattern: 'echo "port 6379"'
+
+  - it: should give the graceful failover time to finish before SIGKILL
+    template: templates/statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 30
+
+  - it: should fail when the preStop failover outlasts the grace period
+    set:
+      replica.sentinel.preStopFailoverTimeoutSeconds: 30
+    template: templates/statefulset.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "preStopFailoverTimeoutSeconds \\(30\\) must be lower than replica.terminationGracePeriodSeconds \\(30\\).*"
+
+  - it: should let an existing release keep its pod management policy
+    set:
+      replica.podManagementPolicy: OrderedReady
+    template: templates/statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.podManagementPolicy
+          value: OrderedReady
+
+  - it: should render loadBalancerSourceRanges as a yaml list
+    set:
+      replica.sentinel.service.type: LoadBalancer
+      replica.sentinel.service.loadBalancerSourceRanges:
+        - 10.0.0.0/8
+        - 10.1.0.0/16
+    template: templates/sentinel-service.yaml
+    asserts:
+      - equal:
+          path: spec.loadBalancerSourceRanges
+          value: [ "10.0.0.0/8", "10.1.0.0/16" ]
+
   - it: should not render any sentinel resource when sentinel is disabled
     set:
       replica.sentinel.enabled: false

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -316,21 +316,18 @@ tests:
       - exists:
           path: spec.template.metadata.annotations["checksum/sentinelconfig"]
 
-  - it: should retain the saved replication target as a fallback on restart
+  - it: should fail closed when sentinel cannot verify a previous configuration
     template: templates/init_config.yaml
     asserts:
-      - matchRegex:
-          path: data["init.sh"]
-          pattern: 'SAVED_REPLICAOF=\$\(grep -E "\^\[\[:space:\]\]\*\(replicaof\|slaveof\)'
-      - matchRegex:
-          path: data["init.sh"]
-          pattern: 'DISCOVERED=\$\(master_from_sentinels \|\| true\)[\s\S]*elif \[ -n "\$SAVED_REPLICAOF" \][\s\S]*REPLICATION_TARGET="\$SAVED_REPLICAOF"'
       - matchRegex:
           path: data["init.sh"]
           pattern: 'HAS_PREVIOUS_CONFIG=true'
       - matchRegex:
           path: data["init.sh"]
-          pattern: 'mv "\$VALKEY_CONFIG_TMP" "\$VALKEY_CONFIG"'
+          pattern: 'DISCOVERED=\$\(master_from_sentinels \|\| true\)[\s\S]*elif \[ "\$HAS_PREVIOUS_CONFIG" = "true" \]; then[\s\S]*refusing to start with a potentially stale replication role[\s\S]*exit 1[\s\S]*elif \[ "\$POD_INDEX" = "0" \]'
+      - notMatchRegex:
+          path: data["init.sh"]
+          pattern: 'SAVED_REPLICAOF'
 
   - it: should pin non-zero pods to pod-0 without sentinel
     set:
@@ -365,13 +362,6 @@ tests:
       - matchRegex:
           path: data["init.sh"]
           pattern: 'DISCOVERED=\$\(master_from_sentinels \|\| true\)[\s\S]*elif \[ "\$HAS_PREVIOUS_CONFIG" = "true" \]'
-
-  - it: should prefer the master reported by sentinel over a saved replica target
-    template: templates/init_config.yaml
-    asserts:
-      - matchRegex:
-          path: data["init.sh"]
-          pattern: 'DISCOVERED=\$\(master_from_sentinels \|\| true\)[\s\S]*if \[ -n "\$DISCOVERED" \][\s\S]*elif \[ -n "\$SAVED_REPLICAOF" \]'
 
   - it: should mount the dedicated sentinel credential in the valkey script containers
     template: templates/statefulset.yaml

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -641,13 +641,20 @@ tests:
     template: templates/init_config.yaml
     asserts:
       # A rewrite empties the file before filling it again, so a single tick can
-      # see no replicaof line at all and record this pod as the master.
+      # see no replicaof line at all and record this pod as the master. That is
+      # the reading that has to be confirmed; a replicaof line cannot be
+      # invented by a torn read, so it is recorded on the tick that sees it.
       - matchRegex:
           path: data["valkey-start.sh"]
-          pattern: 'if \[ "\$pending" != "\$host \$port" \]; then'
+          pattern: 'if \[ "\$host" = "\$SELF" \] && \[ "\$pending" != "\$host \$port" \]; then'
       - matchRegex:
           path: data["valkey-start.sh"]
           pattern: 'pending="\$host \$port"'
+      # An unterminated last line is the tail of a file being rewritten, and a
+      # truncated port would otherwise be recorded as a real one.
+      - notMatchRegex:
+          path: data["valkey-start.sh"]
+          pattern: 'read -r cfg_line \|\|'
 
   - it: should treat replicaof no one as this pod being the master
     template: templates/init_config.yaml

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -610,11 +610,51 @@ tests:
           pattern: 'exec valkey-server "\$@"'
       - matchRegex:
           path: data["valkey-start.sh"]
-          pattern: '\(replicaof\|slaveof\)'
+          pattern: 'replicaof\|slaveof\)'
       # It reads the config Valkey maintains, so it needs no credentials.
       - notMatchRegex:
           path: data["valkey-start.sh"]
           pattern: 'REDISCLI_AUTH|valkey-cli'
+
+  - it: should check for a failover once a second by default
+    template: templates/init_config.yaml
+    asserts:
+      # The record is only useful if it names the master that was current when
+      # the pods died, so it has to follow a promotion closely.
+      - matchRegex:
+          path: data["valkey-start.sh"]
+          pattern: '(?m)^\s*sleep 1$'
+
+  - it: should read the config with builtins so a tick costs no process
+    template: templates/init_config.yaml
+    asserts:
+      # The loop runs for the life of the pod, so parsing the config with a
+      # pipeline of grep and awk would spend processes on every tick forever.
+      - notMatchRegex:
+          path: data["valkey-start.sh"]
+          pattern: 'awk|grep|\bcat '
+      - matchRegex:
+          path: data["valkey-start.sh"]
+          pattern: 'while IFS= read -r cfg_line'
+
+  - it: should ignore a config read taken during a rewrite
+    template: templates/init_config.yaml
+    asserts:
+      # A rewrite empties the file before filling it again, so a single tick can
+      # see no replicaof line at all and record this pod as the master.
+      - matchRegex:
+          path: data["valkey-start.sh"]
+          pattern: 'if \[ "\$pending" != "\$host \$port" \]; then'
+      - matchRegex:
+          path: data["valkey-start.sh"]
+          pattern: 'pending="\$host \$port"'
+
+  - it: should treat replicaof no one as this pod being the master
+    template: templates/init_config.yaml
+    asserts:
+      - matchRegex:
+          path: data["valkey-start.sh"]
+          pattern: '\[ "\$\{2:-\}" = "no" \] && \[ "\$\{3:-\}" = "one" \]'
 
   - it: should run the tracker only when sentinel is enabled
     set:

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -557,6 +557,45 @@ tests:
           path: data["init.sh"]
           pattern: 'VALKEY_CONFIG_PATH:-/data/'
 
+  - it: should fall back to the recorded master when no sentinel answers
+    template: templates/init_config.yaml
+    asserts:
+      # On a cold start every Sentinel is starting too, and a Sentinel cannot
+      # name a master until a Valkey node is up. Without this fallback the two
+      # wait for each other until Sentinel assumes pod-0, which demotes the node
+      # that really was the master.
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'MASTER_MARKER="/data/conf/last-master"'
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'No Sentinel answered; last recorded master is'
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'No Sentinel answered and no recorded topology; refusing to start'
+
+  - it: should record the master without writing a credential
+    template: templates/init_config.yaml
+    asserts:
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: '> "\$MASTER_MARKER"'
+      - notMatchRegex:
+          path: data["init.sh"]
+          pattern: 'PASSWORD.*> "\$MASTER_MARKER"'
+
+  - it: should refresh the recorded master from the local node on shutdown
+    template: templates/sentinel-configmap.yaml
+    asserts:
+      # Kubernetes stops every pod at once, so a Sentinel may already be gone
+      # while preStop runs; the local server is still up.
+      - matchRegex:
+          path: data["sentinel-prestop.sh"]
+          pattern: 'trap record_master EXIT'
+      - matchRegex:
+          path: data["sentinel-prestop.sh"]
+          pattern: '> /data/conf/last-master'
+
   - it: should not render any sentinel resource when sentinel is disabled
     set:
       replica.sentinel.enabled: false

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -316,7 +316,7 @@ tests:
       - exists:
           path: spec.template.metadata.annotations["checksum/sentinelconfig"]
 
-  - it: should restore the replication target chosen by sentinel on restart
+  - it: should retain the saved replication target as a fallback on restart
     template: templates/init_config.yaml
     asserts:
       - matchRegex:
@@ -324,7 +324,7 @@ tests:
           pattern: 'SAVED_REPLICAOF=\$\(grep -E "\^\[\[:space:\]\]\*\(replicaof\|slaveof\)'
       - matchRegex:
           path: data["init.sh"]
-          pattern: 'REPLICATION_TARGET="\$SAVED_REPLICAOF"'
+          pattern: 'DISCOVERED=\$\(master_from_sentinels \|\| true\)[\s\S]*elif \[ -n "\$SAVED_REPLICAOF" \][\s\S]*REPLICATION_TARGET="\$SAVED_REPLICAOF"'
       - matchRegex:
           path: data["init.sh"]
           pattern: 'HAS_PREVIOUS_CONFIG=true'
@@ -365,6 +365,13 @@ tests:
       - matchRegex:
           path: data["init.sh"]
           pattern: 'DISCOVERED=\$\(master_from_sentinels \|\| true\)[\s\S]*elif \[ "\$HAS_PREVIOUS_CONFIG" = "true" \]'
+
+  - it: should prefer the master reported by sentinel over a saved replica target
+    template: templates/init_config.yaml
+    asserts:
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'DISCOVERED=\$\(master_from_sentinels \|\| true\)[\s\S]*if \[ -n "\$DISCOVERED" \][\s\S]*elif \[ -n "\$SAVED_REPLICAOF" \]'
 
   - it: should mount the dedicated sentinel credential in the valkey script containers
     template: templates/statefulset.yaml

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -11,6 +11,7 @@ set:
   replica.enabled: true
   replica.persistence.size: "5Gi"
   replica.sentinel.enabled: true
+  replica.sentinel.password: "sentinelpw"
 tests:
   - it: should fail when sentinel is enabled without replication
     set:
@@ -58,13 +59,9 @@ tests:
       - failedTemplate:
           errorPattern: "Sentinel monitor user 'missing-user' must be defined in auth.aclUsers.*"
 
-  - it: should require a dedicated sentinel password when auth is enabled
+  - it: should require a dedicated sentinel password
     set:
-      auth.enabled: true
-      auth.aclUsers:
-        default:
-          permissions: "~* &* +@all"
-          password: "pw"
+      replica.sentinel.password: ""
     template: templates/statefulset.yaml
     asserts:
       - failedTemplate:
@@ -198,12 +195,21 @@ tests:
           path: data["sentinel-start.sh"]
           pattern: 'DEFAULT_MASTER_HOST="RELEASE-NAME-valkey-0\.RELEASE-NAME-valkey-headless\.NAMESPACE\.svc\.cluster\.local"'
 
-  - it: should not configure authentication when auth is disabled
+  - it: should secure the sentinel port when valkey auth is disabled
     template: templates/sentinel-configmap.yaml
     asserts:
       - notMatchRegex:
           path: data["sentinel-start.sh"]
           pattern: 'sentinel auth-pass'
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'user sentinel on #\$\{SENTINEL_PASSHASH\}'
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'sentinel sentinel-user sentinel'
+      - notMatchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'protected-mode no'
 
   - it: should authenticate to the nodes and secure the sentinel port
     set:
@@ -318,6 +324,21 @@ tests:
       - matchRegex:
           path: data["init.sh"]
           pattern: 'sentinel get-master-addr-by-name mymaster'
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'DISCOVERED=\$\(master_from_sentinels \|\| true\)[\s\S]*elif \[ "\$HAS_PREVIOUS_CONFIG" = "true" \]'
+
+  - it: should mount the dedicated sentinel credential in every script container
+    template: templates/statefulset.yaml
+    asserts:
+      - exists:
+          path: spec.template.spec.initContainers[0].volumeMounts[?(@.name == "sentinel-auth")]
+      - exists:
+          path: spec.template.spec.containers[0].volumeMounts[?(@.name == "sentinel-auth")]
+      - exists:
+          path: spec.template.spec.containers[1].volumeMounts[?(@.name == "sentinel-auth")]
+      - exists:
+          path: spec.template.spec.volumes[?(@.name == "sentinel-auth")].projected.sources[0].secret.items[0].path
 
   - it: should reject an incomplete answer from a peer sentinel
     template: templates/sentinel-configmap.yaml

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -1,9 +1,11 @@
 suite: sentinel configuration
 templates:
   - templates/statefulset.yaml
+  - templates/sentinel-statefulset.yaml
   - templates/init_config.yaml
   - templates/sentinel-configmap.yaml
   - templates/sentinel-service.yaml
+  - templates/sentinel-headless-service.yaml
   - templates/service.yaml
   - templates/service-headless.yaml
   - templates/deploy_valkey.yaml
@@ -21,13 +23,21 @@ tests:
       - failedTemplate:
           errorPattern: "Sentinel requires replication.*"
 
-  - it: should fail when there are fewer than three pods
+  - it: should fail when there are fewer than three sentinels
     set:
-      replica.replicas: 1
+      replica.sentinel.replicas: 2
     template: templates/statefulset.yaml
     asserts:
       - failedTemplate:
-          errorPattern: "Sentinel requires at least 3 pods.*"
+          errorPattern: "Sentinel requires at least 3 instances.*"
+
+  - it: should fail without a valkey replica to promote
+    set:
+      replica.replicas: 0
+    template: templates/statefulset.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: "Sentinel requires at least one Valkey replica.*"
 
   - it: should fail when the quorum exceeds the number of sentinels
     set:
@@ -35,7 +45,7 @@ tests:
     template: templates/statefulset.yaml
     asserts:
       - failedTemplate:
-          errorPattern: "quorum \\(4\\) cannot be greater than the number of Sentinels \\(3\\).*"
+          errorPattern: "quorum \\(4\\) cannot be greater than replica.sentinel.replicas \\(3\\).*"
 
   - it: should fail when the quorum allows a single sentinel to fail over
     set:
@@ -67,21 +77,39 @@ tests:
       - failedTemplate:
           errorPattern: "replica.sentinel.password is required.*"
 
-  - it: should add a sentinel container to every valkey pod
-    template: templates/statefulset.yaml
+  - it: should deploy sentinel in an independent statefulset
+    template: templates/sentinel-statefulset.yaml
     asserts:
+      - isKind:
+          of: StatefulSet
       - equal:
-          path: spec.template.spec.containers[1].name
+          path: metadata.name
+          value: RELEASE-NAME-valkey-sentinel
+      - equal:
+          path: spec.replicas
+          value: 3
+      - equal:
+          path: spec.template.spec.containers[0].name
           value: sentinel
       - equal:
-          path: spec.template.spec.containers[1].command
+          path: spec.template.spec.containers[0].command
           value: [ "/sentinel-scripts/sentinel-start.sh" ]
       - equal:
-          path: spec.template.spec.containers[1].ports[0].containerPort
+          path: spec.template.spec.containers[0].ports[0].containerPort
           value: 26379
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: valkey-sentinel
 
-  - it: should start the pods in parallel so that the quorum can form
+  - it: should not add sentinel to the valkey pods
     template: templates/statefulset.yaml
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 1
+
+  - it: should start the sentinel pods in parallel so that the quorum can form
+    template: templates/sentinel-statefulset.yaml
     asserts:
       - equal:
           path: spec.podManagementPolicy
@@ -97,28 +125,27 @@ tests:
           value: OrderedReady
 
   - it: should mount an emptyDir for the sentinel state by default
-    template: templates/statefulset.yaml
+    template: templates/sentinel-statefulset.yaml
     asserts:
       - contains:
           path: spec.template.spec.volumes
           content:
             name: sentinel-data
             emptyDir: {}
-      - lengthEqual:
+      - notExists:
           path: spec.volumeClaimTemplates
-          count: 1
 
   - it: should claim a volume for the sentinel state when persistence is enabled
     set:
       replica.sentinel.persistence.enabled: true
       replica.sentinel.persistence.size: "200Mi"
-    template: templates/statefulset.yaml
+    template: templates/sentinel-statefulset.yaml
     asserts:
       - equal:
-          path: spec.volumeClaimTemplates[1].metadata.name
+          path: spec.volumeClaimTemplates[0].metadata.name
           value: sentinel-data
       - equal:
-          path: spec.volumeClaimTemplates[1].spec.resources.requests.storage
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
           value: "200Mi"
       - notContains:
           path: spec.template.spec.volumes
@@ -156,16 +183,18 @@ tests:
           path: spec.selector["statefulset.kubernetes.io/pod-name"]
           value: RELEASE-NAME-valkey-0
 
-  - it: should expose the sentinel port on the headless service
-    template: templates/service-headless.yaml
+  - it: should expose a dedicated headless service for sentinel peers
+    template: templates/sentinel-headless-service.yaml
     asserts:
-      - contains:
-          path: spec.ports
-          content:
-            name: sentinel
-            port: 26379
-            targetPort: sentinel
-            protocol: TCP
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-sentinel-headless
+      - equal:
+          path: spec.clusterIP
+          value: None
+      - equal:
+          path: spec.ports[0].port
+          value: 26379
 
   - it: should expose a sentinel service for client discovery
     template: templates/sentinel-service.yaml
@@ -278,8 +307,8 @@ tests:
           path: data["sentinel-start.sh"]
           pattern: 'sentinel deny-scripts-reconfig yes'
 
-  - it: should roll the pods when the sentinel scripts change
-    template: templates/statefulset.yaml
+  - it: should roll the sentinel pods when the scripts change
+    template: templates/sentinel-statefulset.yaml
     asserts:
       - exists:
           path: spec.template.metadata.annotations["checksum/sentinelconfig"]
@@ -326,9 +355,15 @@ tests:
           pattern: 'sentinel get-master-addr-by-name mymaster'
       - matchRegex:
           path: data["init.sh"]
+          pattern: 'peer="RELEASE-NAME-valkey-sentinel-headless\.NAMESPACE\.svc\.cluster\.local"'
+      - notMatchRegex:
+          path: data["init.sh"]
+          pattern: 'replica\.sentinel\.replicas'
+      - matchRegex:
+          path: data["init.sh"]
           pattern: 'DISCOVERED=\$\(master_from_sentinels \|\| true\)[\s\S]*elif \[ "\$HAS_PREVIOUS_CONFIG" = "true" \]'
 
-  - it: should mount the dedicated sentinel credential in every script container
+  - it: should mount the dedicated sentinel credential in the valkey script containers
     template: templates/statefulset.yaml
     asserts:
       - exists:
@@ -336,7 +371,13 @@ tests:
       - exists:
           path: spec.template.spec.containers[0].volumeMounts[?(@.name == "sentinel-auth")]
       - exists:
-          path: spec.template.spec.containers[1].volumeMounts[?(@.name == "sentinel-auth")]
+          path: spec.template.spec.volumes[?(@.name == "sentinel-auth")].projected.sources[0].secret.items[0].path
+
+  - it: should mount the dedicated sentinel credential in the sentinel statefulset
+    template: templates/sentinel-statefulset.yaml
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].volumeMounts[?(@.name == "sentinel-auth")]
       - exists:
           path: spec.template.spec.volumes[?(@.name == "sentinel-auth")].projected.sources[0].secret.items[0].path
 
@@ -377,6 +418,13 @@ tests:
           path: data["sentinel-ping.sh"]
           pattern: ' -a "\$'
 
+  - it: should contact the independent sentinel service during graceful shutdown
+    template: templates/sentinel-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["sentinel-prestop.sh"]
+          pattern: '-h RELEASE-NAME-valkey-sentinel -p 26379 sentinel failover mymaster'
+
   - it: should render the listen port from service.port
     set:
       service.port: 7000
@@ -403,15 +451,6 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "preStopFailoverTimeoutSeconds \\(30\\) must be lower than replica.terminationGracePeriodSeconds \\(30\\).*"
-
-  - it: should let an existing release keep its pod management policy
-    set:
-      replica.podManagementPolicy: OrderedReady
-    template: templates/statefulset.yaml
-    asserts:
-      - equal:
-          path: spec.podManagementPolicy
-          value: OrderedReady
 
   - it: should render loadBalancerSourceRanges as a yaml list
     set:
@@ -483,6 +522,8 @@ tests:
     templates:
       - templates/sentinel-configmap.yaml
       - templates/sentinel-service.yaml
+      - templates/sentinel-headless-service.yaml
+      - templates/sentinel-statefulset.yaml
     asserts:
       - hasDocuments:
           count: 0

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -695,6 +695,33 @@ tests:
             mountPath: /tls
             readOnly: true
 
+  - it: should refuse an empty sentinel password
+    set:
+      auth.enabled: true
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          password: "defaultpw"
+        replicator:
+          permissions: "~* &* +@all"
+          password: "replicatorpw"
+    template: templates/sentinel-configmap.yaml
+    asserts:
+      # The password is hashed into an ACL user that can run every Sentinel
+      # command, and an empty one hashes to a value shared by every
+      # installation, so it would hand that user to anyone who can reach it.
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'if \[ -z "\$SENTINEL_PASSWORD" \]; then'
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'ERROR: The Sentinel password is empty'
+      # The monitor credential is read the same way and goes into
+      # sentinel auth-pass.
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'ERROR: No password, or an empty one, for user \$username'
+
   - it: should adopt a node sentinel cannot see
     template: templates/sentinel-configmap.yaml
     asserts:

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -727,7 +727,41 @@ tests:
       # The credential goes through the environment, never the process list.
       - matchRegex:
           path: data["init.sh"]
-          pattern: 'REDISCLI_AUTH="\$repl_password" valkey-cli'
+          pattern: 'REDISCLI_AUTH="\$monitor_password" valkey-cli'
+
+  - it: should ask as the user allowed to run info
+    set:
+      auth.enabled: true
+      replica.sentinel.monitorUser: watcher
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          password: "defaultpw"
+        replicator:
+          # The documented minimum for a replication user, which cannot run INFO
+          permissions: "+psync +replconf +ping"
+          password: "replicatorpw"
+        watcher:
+          permissions: "~* &* +info +role +slaveof +replicaof +psync +replconf"
+          password: "watcherpw"
+    template: templates/init_config.yaml
+    asserts:
+      # Sentinel already requires INFO of its monitor user, so asking as that
+      # user adds no permission the deployment does not already need.
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'get_user_password "watcher" "watcher"'
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: '--user "watcher"'
+      - notMatchRegex:
+          path: data["init.sh"]
+          pattern: 'info replication[\s\S]{0,200}--user "replicator"'
+      # A refusal is printed on stdout with a zero exit, so it has to be
+      # recognised rather than read as "this node is not the master".
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: '\*NOPERM\*\)'
 
   - it: should refuse an empty sentinel password
     set:

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -637,6 +637,29 @@ tests:
           path: data["valkey-start.sh"]
           pattern: 'while IFS= read -r cfg_line'
 
+  - it: should report a record it cannot write instead of hiding it
+    template: templates/init_config.yaml
+    asserts:
+      # A record that cannot be updated keeps naming this pod after it has been
+      # demoted, and a cold start comes back on the last record written, so a
+      # silent failure here is a pod that returns writable when it should not.
+      - matchRegex:
+          path: data["valkey-start.sh"]
+          pattern: 'cannot record the master as \$host \$port'
+      - notMatchRegex:
+          path: data["valkey-start.sh"]
+          pattern: '> "\$MARKER" 2>/dev/null \|\| true'
+      # Written to a temporary name and renamed, so a cold start reading it
+      # during an update sees the old record rather than an empty file.
+      - matchRegex:
+          path: data["valkey-start.sh"]
+          pattern: 'mv "\$MARKER.tmp" "\$MARKER"'
+      # One complaint per outage: the loop runs every second and retries by
+      # itself, because the record still does not match.
+      - matchRegex:
+          path: data["valkey-start.sh"]
+          pattern: 'elif \[ -z "\$write_failed" \]; then'
+
   - it: should ignore a config read taken during a rewrite
     template: templates/init_config.yaml
     asserts:

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -695,6 +695,48 @@ tests:
             mountPath: /tls
             readOnly: true
 
+  - it: should adopt a node sentinel cannot see
+    template: templates/sentinel-configmap.yaml
+    asserts:
+      # Sentinel discovers replicas through the master, so a node replicating
+      # from another replica is invisible to it and is never reconfigured, not
+      # even by its own fix-slave-config.
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'adopt_orphans &'
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'sentinel replicas "\$MASTER_SET"'
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'replicaof "\$current_host" "\$current_port"'
+
+  - it: should leave the nodes sentinel is already reconfiguring alone
+    template: templates/sentinel-configmap.yaml
+    asserts:
+      # Two guards keep the loop out of Sentinel's way: it stops unless the
+      # master is plainly up, and it only touches nodes Sentinel does not list,
+      # which are exactly the ones it cannot be reconfiguring.
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'if \[ "\$flags" != "master" \]; then'
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'if echo "\$known" \| grep -qx "\$node"; then'
+      # A node answering as a master is a second writable node, not an orphan.
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'if \[ "\$role" != "slave" \]; then'
+
+  - it: should take the adoption interval from the values
+    set:
+      replica.sentinel.orphanCheckSeconds: 45
+    template: templates/sentinel-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: '(?m)^\s*sleep 45$'
+
   - it: should run the tracker only when sentinel is enabled
     set:
       replica.sentinel.enabled: false

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -232,7 +232,7 @@ tests:
           pattern: 'sentinel auth-pass'
       - matchRegex:
           path: data["sentinel-start.sh"]
-          pattern: 'user sentinel on #\$\{SENTINEL_PASSHASH\}'
+          pattern: 'user sentinel on "#\$\{SENTINEL_PASSHASH_ESCAPED\}"'
       - matchRegex:
           path: data["sentinel-start.sh"]
           pattern: 'sentinel sentinel-user sentinel'
@@ -259,13 +259,16 @@ tests:
           pattern: 'user default off'
       - matchRegex:
           path: data["sentinel-start.sh"]
-          pattern: 'user sentinel on #\$\{SENTINEL_PASSHASH\} ~\* &\* \+@all'
+          pattern: 'user sentinel on "#\$\{SENTINEL_PASSHASH_ESCAPED\}" ~\* &\* \+@all'
       - matchRegex:
           path: data["sentinel-start.sh"]
           pattern: 'sentinel sentinel-user sentinel'
       - matchRegex:
           path: data["sentinel-start.sh"]
-          pattern: 'sentinel sentinel-pass \$\{SENTINEL_PASSWORD\}'
+          pattern: 'sentinel sentinel-pass "\$\{SENTINEL_PASSWORD_ESCAPED\}"'
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'sentinel auth-pass \$\{MASTER_SET\} "\$\{MONITOR_PASSWORD_ESCAPED\}"'
       - matchRegex:
           path: data["sentinel-start.sh"]
           pattern: 'sentinel auth-user \$\{MASTER_SET\} replicator'
@@ -423,7 +426,17 @@ tests:
     asserts:
       - matchRegex:
           path: data["sentinel-prestop.sh"]
-          pattern: '-h RELEASE-NAME-valkey-sentinel -p 26379 sentinel failover mymaster'
+          pattern: '-h RELEASE-NAME-valkey-sentinel-headless -p 26379 sentinel failover mymaster'
+
+  - it: should escape sentinel configuration credentials
+    template: templates/sentinel-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'escape_config_arg\(\) \{'
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'SENTINEL_PASSWORD_ESCAPED=\$\(escape_config_arg "\$SENTINEL_PASSWORD"\)'
 
   - it: should render the listen port from service.port
     set:

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -316,18 +316,15 @@ tests:
       - exists:
           path: spec.template.metadata.annotations["checksum/sentinelconfig"]
 
-  - it: should fail closed when sentinel cannot verify a previous configuration
+  - it: should fail closed when sentinel cannot confirm the topology
     template: templates/init_config.yaml
     asserts:
       - matchRegex:
           path: data["init.sh"]
-          pattern: 'HAS_PREVIOUS_CONFIG=true'
-      - matchRegex:
-          path: data["init.sh"]
-          pattern: 'DISCOVERED=\$\(master_from_sentinels \|\| true\)[\s\S]*elif \[ "\$HAS_PREVIOUS_CONFIG" = "true" \]; then[\s\S]*refusing to start with a potentially stale replication role[\s\S]*exit 1[\s\S]*elif \[ "\$POD_INDEX" = "0" \]'
+          pattern: 'DISCOVERED=\$\(master_from_sentinels \|\| true\)[\s\S]*if \[ -n "\$DISCOVERED" \]; then[\s\S]*else[\s\S]*refusing to start without a confirmed replication role[\s\S]*exit 1'
       - notMatchRegex:
           path: data["init.sh"]
-          pattern: 'SAVED_REPLICAOF'
+          pattern: 'HAS_PREVIOUS_CONFIG|SAVED_REPLICAOF|Bootstrapping cluster'
 
   - it: should pin non-zero pods to pod-0 without sentinel
     set:
@@ -341,7 +338,7 @@ tests:
           path: data["init.sh"]
           pattern: 'REPLICATION_TARGET="replicaof \$MASTER_HOST \$MASTER_PORT"'
 
-  - it: should ask the running sentinels before falling back to the pod index
+  - it: should ask the running sentinels for the current topology
     template: templates/init_config.yaml
     asserts:
       - matchRegex:
@@ -359,10 +356,6 @@ tests:
       - notMatchRegex:
           path: data["init.sh"]
           pattern: 'replica\.sentinel\.replicas'
-      - matchRegex:
-          path: data["init.sh"]
-          pattern: 'DISCOVERED=\$\(master_from_sentinels \|\| true\)[\s\S]*elif \[ "\$HAS_PREVIOUS_CONFIG" = "true" \]'
-
   - it: should mount the dedicated sentinel credential in the valkey script containers
     template: templates/statefulset.yaml
     asserts:

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -695,6 +695,38 @@ tests:
             mountPath: /tls
             readOnly: true
 
+  - it: should reject a topology wait that expires before sentinel bootstraps
+    set:
+      replica.sentinel.startupTimeoutSeconds: 300
+    template: templates/statefulset.yaml
+    asserts:
+      # The two timeouts are ordered: a fresh pod has nothing to be told until
+      # the Sentinels finish their own discovery, so a shorter wait puts the
+      # init container back to exiting just before the answer arrives.
+      - failedTemplate:
+          errorPattern: "initialTopologyWaitSeconds \\(180\\) must be at least 30s above replica.sentinel.startupTimeoutSeconds \\(300\\), which is 330"
+
+  - it: should require headroom, not merely a larger number
+    set:
+      replica.sentinel.startupTimeoutSeconds: 300
+      replica.sentinel.initialTopologyWaitSeconds: 310
+    template: templates/statefulset.yaml
+    asserts:
+      # The Sentinels need a moment after their timeout to write their config,
+      # start, and pass their probe, and this pod only polls every 5s.
+      - failedTemplate:
+          errorPattern: "initialTopologyWaitSeconds \\(310\\) must be at least 30s above"
+
+  - it: should accept a topology wait with headroom over the bootstrap
+    set:
+      replica.sentinel.startupTimeoutSeconds: 300
+      replica.sentinel.initialTopologyWaitSeconds: 330
+    template: templates/init_config.yaml
+    asserts:
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'while \[ "\$WAITED" -lt "330" \]; do'
+
   - it: should wait for the topology on a first install instead of failing
     template: templates/init_config.yaml
     asserts:
@@ -715,6 +747,7 @@ tests:
 
   - it: should take the first install wait from the values
     set:
+      replica.sentinel.startupTimeoutSeconds: 10
       replica.sentinel.initialTopologyWaitSeconds: 42
     template: templates/init_config.yaml
     asserts:

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -404,6 +404,58 @@ tests:
           path: spec.loadBalancerSourceRanges
           value: [ "10.0.0.0/8", "10.1.0.0/16" ]
 
+  - it: should hash the sentinel password byte for byte
+    set:
+      auth.enabled: true
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          password: "pw"
+      replica.sentinel.password: "sentinelpw"
+    template: templates/sentinel-configmap.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: 'echo -n .* \| sha256sum'
+      - matchRegex:
+          path: data["sentinel-start.sh"]
+          pattern: "printf '%s' .* \\| sha256sum"
+
+  - it: should hash the acl user passwords byte for byte
+    set:
+      auth.enabled: true
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          password: "pw"
+      replica.sentinel.password: "sentinelpw"
+    template: templates/init_config.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["init.sh"]
+          pattern: 'echo -n .* \| sha256sum'
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: "printf '%s' .* \\| sha256sum"
+
+  - it: should still create the auth secret when only the sentinel password is inline
+    set:
+      auth.enabled: true
+      auth.usersExistingSecret: "my-users"
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+      replica.sentinel.password: "sentinelpw"
+    template: templates/statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: valkey-auth-secret
+            secret:
+              secretName: RELEASE-NAME-valkey-auth
+              defaultMode: 0400
+
   - it: should not render any sentinel resource when sentinel is disabled
     set:
       replica.sentinel.enabled: false

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -663,6 +663,38 @@ tests:
           path: data["valkey-start.sh"]
           pattern: '\[ "\$\{2:-\}" = "no" \] && \[ "\$\{3:-\}" = "one" \]'
 
+  - it: should give the init container the CA it needs to ask sentinel
+    set:
+      tls.enabled: true
+      tls.existingSecret: "valkey-tls"
+    template: templates/statefulset.yaml
+    asserts:
+      # The init container queries Sentinel with valkey-cli --tls --cacert
+      # /tls/..., and without the mount that query fails, leaving a fresh pod
+      # with no topology at all.
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: RELEASE-NAME-valkey-tls
+            mountPath: /tls
+            readOnly: true
+
+  - it: should keep key material out of the init container without sentinel
+    set:
+      tls.enabled: true
+      tls.existingSecret: "valkey-tls"
+      replica.sentinel.enabled: false
+    template: templates/statefulset.yaml
+    asserts:
+      # Nothing in the init container talks to Sentinel then, so it has no
+      # reason to hold the server key.
+      - notContains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: RELEASE-NAME-valkey-tls
+            mountPath: /tls
+            readOnly: true
+
   - it: should run the tracker only when sentinel is enabled
     set:
       replica.sentinel.enabled: false

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -579,10 +579,39 @@ tests:
     asserts:
       - matchRegex:
           path: data["init.sh"]
-          pattern: '> "\$MASTER_MARKER"'
+          pattern: '> "\$MASTER_MARKER.tmp"'
       - notMatchRegex:
           path: data["init.sh"]
-          pattern: 'PASSWORD.*> "\$MASTER_MARKER"'
+          pattern: 'PASSWORD.*> "\$MASTER_MARKER'
+
+  - it: should replace the record atomically wherever it is written
+    template: templates/init_config.yaml
+    asserts:
+      # Three places write this record, and a pod killed part way through any
+      # of them would otherwise leave an empty or half written one behind.
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'mv "\$MASTER_MARKER.tmp" "\$MASTER_MARKER"'
+      - matchRegex:
+          path: data["valkey-start.sh"]
+          pattern: 'mv "\$MARKER.tmp" "\$MARKER"'
+
+  - it: should refuse a record that was never finished
+    template: templates/init_config.yaml
+    asserts:
+      # read fails on a line with no closing newline, which is what an
+      # interrupted write leaves. Accepting it would mean replicating from a
+      # truncated port such as "6".
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'IFS= read -r MARKED < "\$MASTER_MARKER" \|\| MARKED=""'
+      - notMatchRegex:
+          path: data["init.sh"]
+          pattern: 'head -n 1 "\$MASTER_MARKER"'
+      # A port outside the range cannot be a listening one either.
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: '\[ "\$MARKED_PORT" -ge 1 \] && \[ "\$MARKED_PORT" -le 65535 \]'
 
   - it: should refresh the recorded master from the local node on shutdown
     template: templates/sentinel-configmap.yaml
@@ -594,7 +623,7 @@ tests:
           pattern: 'trap record_master EXIT'
       - matchRegex:
           path: data["sentinel-prestop.sh"]
-          pattern: '> /data/conf/last-master'
+          pattern: 'mv /data/conf/last-master.tmp /data/conf/last-master'
 
   - it: should keep the master record in step with runtime failovers
     template: templates/init_config.yaml

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -695,6 +695,40 @@ tests:
             mountPath: /tls
             readOnly: true
 
+  - it: should prefer a node that is already up over the recorded topology
+    set:
+      auth.enabled: true
+      auth.aclUsers:
+        default:
+          permissions: "~* &* +@all"
+          password: "defaultpw"
+        replicator:
+          permissions: "~* &* +@all"
+          password: "replicatorpw"
+    template: templates/init_config.yaml
+    asserts:
+      # A pod that was down across a failover still has its own name in the
+      # record. Coming back writable next to the node that was promoted leaves
+      # two masters, and nothing reconciles that afterwards.
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'RUNNING=\$\(master_from_running_nodes \|\| true\)'
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'already up as the master, starting as REPLICA'
+      # Only a node that answers as the master counts, and this pod is not
+      # running yet, so it is skipped rather than waited for.
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: "sed -n 's/\\^role://p'\\)\" = \"master\" \\]"
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'if \[ "\$node" = "\$SELF_HOST" \]; then'
+      # The credential goes through the environment, never the process list.
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'REDISCLI_AUTH="\$repl_password" valkey-cli'
+
   - it: should refuse an empty sentinel password
     set:
       auth.enabled: true

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -695,6 +695,33 @@ tests:
             mountPath: /tls
             readOnly: true
 
+  - it: should wait for the topology on a first install instead of failing
+    template: templates/init_config.yaml
+    asserts:
+      # A fresh pod has no record, no running node and no Sentinel that can
+      # name a master yet. The Sentinels bootstrap one once their own
+      # startupTimeoutSeconds expires, so exiting here only means restarting
+      # the init container until a retry happens to land after that.
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'while \[ "\$WAITED" -lt "180" \]; do'
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'Waiting for a Sentinel or a running node to report the topology'
+      # Bounded, so a deployment that is genuinely broken still fails.
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'refusing to start without a confirmed replication role'
+
+  - it: should take the first install wait from the values
+    set:
+      replica.sentinel.initialTopologyWaitSeconds: 42
+    template: templates/init_config.yaml
+    asserts:
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'while \[ "\$WAITED" -lt "42" \]; do'
+
   - it: should prefer a node that is already up over the recorded topology
     set:
       auth.enabled: true

--- a/valkey/tests/sentinel_test.yaml
+++ b/valkey/tests/sentinel_test.yaml
@@ -124,14 +124,15 @@ tests:
           path: spec.podManagementPolicy
           value: OrderedReady
 
-  - it: should mount an emptyDir for the sentinel state by default
+  - it: should mount a memory backed emptyDir for the sentinel state by default
     template: templates/sentinel-statefulset.yaml
     asserts:
       - contains:
           path: spec.template.spec.volumes
           content:
             name: sentinel-data
-            emptyDir: {}
+            emptyDir:
+              medium: Memory
       - notExists:
           path: spec.volumeClaimTemplates
 
@@ -151,7 +152,8 @@ tests:
           path: spec.template.spec.volumes
           content:
             name: sentinel-data
-            emptyDir: {}
+            emptyDir:
+              medium: Memory
 
   - it: should fail over gracefully before a pod is terminated
     template: templates/statefulset.yaml
@@ -518,6 +520,42 @@ tests:
             secret:
               secretName: RELEASE-NAME-valkey-auth
               defaultMode: 0400
+
+  - it: should keep the config and its credentials off the data volume
+    template: templates/statefulset.yaml
+    asserts:
+      # valkey.conf carries masterauth in plain text and CONFIG REWRITE puts it
+      # back on every failover, so the file has to live on a memory backed
+      # volume rather than on the PVC.
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value: [ "/valkey-conf/valkey.conf" ]
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: valkey-conf
+            emptyDir:
+              medium: Memory
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: valkey-conf
+            mountPath: /valkey-conf
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: valkey-conf
+            mountPath: /valkey-conf
+
+  - it: should write the config outside the data directory
+    template: templates/init_config.yaml
+    asserts:
+      - matchRegex:
+          path: data["init.sh"]
+          pattern: 'VALKEY_CONFIG=\$\{VALKEY_CONFIG_PATH:-/valkey-conf/valkey.conf\}'
+      - notMatchRegex:
+          path: data["init.sh"]
+          pattern: 'VALKEY_CONFIG_PATH:-/data/'
 
   - it: should not render any sentinel resource when sentinel is disabled
     set:

--- a/valkey/tests/service_test.yaml
+++ b/valkey/tests/service_test.yaml
@@ -86,3 +86,35 @@ tests:
           content:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/name: valkey
+
+  - it: should not call itself the primary endpoint in sentinel mode
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+      replica.sentinel.enabled: true
+      replica.sentinel.password: "sentinelpw"
+    template: templates/service.yaml
+    asserts:
+      # The master can be any pod and a Service cannot select on a role that
+      # moves, so this one reaches every node. Labelling it primary would say
+      # the opposite of what the endpoint does.
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: nodes
+      - notExists:
+          path: spec.selector["statefulset.kubernetes.io/pod-name"]
+
+  - it: should pin to pod-0 and call itself primary without sentinel
+    set:
+      replica.enabled: true
+      replica.persistence.size: "5Gi"
+    template: templates/service.yaml
+    asserts:
+      # Without Sentinel the master is pod-0 for the life of the release, so
+      # the Service can and does select exactly it.
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: primary
+      - equal:
+          path: spec.selector["statefulset.kubernetes.io/pod-name"]
+          value: RELEASE-NAME-valkey-0

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -432,6 +432,9 @@
                         "monitorUser": {
                             "type": "string"
                         },
+                        "orphanCheckSeconds": {
+                            "type": "integer"
+                        },
                         "password": {
                             "type": "string"
                         },

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -399,6 +399,17 @@
                 "persistentVolumeClaimRetentionPolicy": {
                     "type": "object"
                 },
+                "podManagementPolicy": {
+                    "type": "string",
+                    "enum": [
+                        "",
+                        "OrderedReady",
+                        "Parallel"
+                    ]
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "integer"
+                },
                 "replicas": {
                     "type": "integer"
                 },

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -437,6 +437,12 @@
                         "monitorUser": {
                             "type": "string"
                         },
+                        "password": {
+                            "type": "string"
+                        },
+                        "passwordKey": {
+                            "type": "string"
+                        },
                         "parallelSyncs": {
                             "type": "integer"
                         },

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -423,6 +423,9 @@
                         "failoverTimeout": {
                             "type": "integer"
                         },
+                        "masterRecordRefreshSeconds": {
+                            "type": "integer"
+                        },
                         "masterSet": {
                             "type": "string"
                         },

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -423,6 +423,9 @@
                         "failoverTimeout": {
                             "type": "integer"
                         },
+                        "initialTopologyWaitSeconds": {
+                            "type": "integer"
+                        },
                         "masterRecordRefreshSeconds": {
                             "type": "integer"
                         },

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -405,6 +405,105 @@
                 "replicationUser": {
                     "type": "string"
                 },
+                "sentinel": {
+                    "type": "object",
+                    "properties": {
+                        "downAfterMilliseconds": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "extraConfig": {
+                            "type": "string"
+                        },
+                        "failoverTimeout": {
+                            "type": "integer"
+                        },
+                        "masterSet": {
+                            "type": "string"
+                        },
+                        "monitorUser": {
+                            "type": "string"
+                        },
+                        "parallelSyncs": {
+                            "type": "integer"
+                        },
+                        "persistence": {
+                            "type": "object",
+                            "properties": {
+                                "accessModes": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "size": {
+                                    "type": "string"
+                                },
+                                "storageClass": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "preStopFailover": {
+                            "type": "boolean"
+                        },
+                        "preStopFailoverTimeoutSeconds": {
+                            "type": "integer"
+                        },
+                        "quorum": {
+                            "type": "integer"
+                        },
+                        "resources": {
+                            "type": "object"
+                        },
+                        "securityContext": {
+                            "type": "object"
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object"
+                                },
+                                "appProtocol": {
+                                    "type": "string"
+                                },
+                                "clusterIP": {
+                                    "type": "string"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "loadBalancerClass": {
+                                    "type": "string"
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array"
+                                },
+                                "nodePort": {
+                                    "type": "integer"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                },
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "startupTimeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
+                },
                 "service": {
                     "type": "object",
                     "properties": {

--- a/valkey/values.schema.json
+++ b/valkey/values.schema.json
@@ -399,14 +399,6 @@
                 "persistentVolumeClaimRetentionPolicy": {
                     "type": "object"
                 },
-                "podManagementPolicy": {
-                    "type": "string",
-                    "enum": [
-                        "",
-                        "OrderedReady",
-                        "Parallel"
-                    ]
-                },
                 "terminationGracePeriodSeconds": {
                     "type": "integer"
                 },
@@ -466,6 +458,9 @@
                                 }
                             }
                         },
+                        "persistentVolumeClaimRetentionPolicy": {
+                            "type": "object"
+                        },
                         "port": {
                             "type": "integer"
                         },
@@ -476,6 +471,9 @@
                             "type": "integer"
                         },
                         "quorum": {
+                            "type": "integer"
+                        },
+                        "replicas": {
                             "type": "integer"
                         },
                         "resources": {

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -371,7 +371,11 @@ replica:
     # How often each Valkey pod mirrors the current master onto its data volume.
     # That record is what a cold start falls back on when no Sentinel answers,
     # so it bounds how stale the topology can be after an abrupt restart.
-    masterRecordRefreshSeconds: 10
+    # A reading has to hold for two consecutive checks before it is written, so
+    # the record trails a failover by about twice this value. The check itself
+    # only reads a file that Valkey keeps up to date, and writes nothing when
+    # the topology has not moved.
+    masterRecordRefreshSeconds: 1
 
     # Raw configuration appended to the generated sentinel.conf.
     # Supports templating, e.g. "sentinel notification-script {{ .Release.Name }} /script.sh"

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -378,6 +378,13 @@ replica:
     # when the topology has not moved.
     masterRecordRefreshSeconds: 1
 
+    # How often each Sentinel looks for a Valkey node that is replicating from
+    # something other than the current master and that Sentinel itself cannot
+    # see. Sentinel only discovers replicas through the master, so a node that
+    # attached to another replica is invisible to it and would never be
+    # reconfigured.
+    orphanCheckSeconds: 30
+
     # Raw configuration appended to the generated sentinel.conf.
     # Supports templating, e.g. "sentinel notification-script {{ .Release.Name }} /script.sh"
     extraConfig: ""

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -320,8 +320,7 @@ replica:
   # master through Sentinel (SENTINEL get-master-addr-by-name).
   sentinel:
     # Enable Sentinel (requires replica.enabled and at least 3 pods).
-    # When auth.enabled is false the Sentinel port accepts commands such as
-    # SENTINEL FAILOVER from anything that can reach it, like the Valkey port.
+    # The Sentinel endpoint always requires its dedicated password, independently of whether authentication is enabled for the Valkey data endpoint.
     enabled: false
 
     # Port on which Sentinel listens
@@ -353,11 +352,11 @@ replica:
     # and, because the same user replicates, +psync +replconf
     monitorUser: ""
 
-    # Dedicated password for Sentinel's own ACL. Do not reuse a Valkey user
-    # password: Sentinel permissions are independent from Valkey ACLs.
-    # When auth.usersExistingSecret is set, passwordKey is looked up in that
-    # Secret first and this inline value is only used if the key is missing,
-    # the same priority the other ACL users follow.
+    # Dedicated password for Sentinel's own ACL.
+    # Do not reuse a Valkey user password because Sentinel permissions are independent from Valkey ACLs.
+    # This password is required whenever Sentinel is enabled.
+    # When auth.usersExistingSecret is set, passwordKey is looked up in that Secret first.
+    # This inline value is used as a fallback when the key is missing.
     password: ""
     passwordKey: "sentinel"
 

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -406,8 +406,10 @@ replica:
       # Restricts traffic through the cloud-provider load balancer to these client IPs
       loadBalancerSourceRanges: []
 
-    # Persistence for the Sentinel state directory. Optional: the chart
-    # rediscovers the current master on every start, so an emptyDir is enough.
+    # Persistence for the Sentinel state directory. Optional, and off for a
+    # reason: Sentinel rewrites its own credentials into sentinel.conf, so
+    # enabling this writes them to persistent storage. With it disabled the
+    # state sits on a memory backed emptyDir instead.
     persistence:
       # Enable a PVC for the Sentinel state instead of an emptyDir
       enabled: false

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -300,6 +300,107 @@ replica:
   # More info: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
   persistentVolumeClaimRetentionPolicy: {}
 
+  # Valkey Sentinel for automatic failover.
+  # Sentinel runs as a sidecar in every Valkey pod, monitors the master and
+  # promotes a replica when the master becomes unreachable.
+  # NOTE: with Sentinel enabled the Valkey service load balances across all pods,
+  # because the master can move at any time. Clients must therefore discover the
+  # master through Sentinel (SENTINEL get-master-addr-by-name).
+  sentinel:
+    # Enable Sentinel (requires replica.enabled and at least 3 pods)
+    enabled: false
+
+    # Port on which Sentinel listens
+    port: 26379
+
+    # Name Sentinel uses to identify the monitored master
+    masterSet: mymaster
+
+    # Number of Sentinels that must agree the master is down before a failover
+    # starts. Use a majority of the Sentinel count, e.g. 2 for 3 pods.
+    quorum: 2
+
+    # Time in milliseconds after which an unresponsive master is considered down
+    downAfterMilliseconds: 5000
+
+    # Time in milliseconds before a failover attempt is considered failed
+    failoverTimeout: 60000
+
+    # Number of replicas that resynchronise with the new master simultaneously
+    parallelSyncs: 1
+
+    # User Sentinel authenticates with against the Valkey nodes, ignored if
+    # auth.enabled is false. Defaults to replica.replicationUser.
+    # The user must be defined in auth.aclUsers. Sentinel promotes replicas by
+    # sending them SLAVEOF, so a user without those permissions makes every
+    # failover abort with -failover-abort-slave-timeout. The minimum is:
+    #   ~* &* +multi +exec +ping +info +role +subscribe +publish +slaveof
+    #   +replicaof +config|rewrite +client|setname +client|kill +script|kill
+    # and, because the same user replicates, +psync +replconf
+    monitorUser: ""
+
+    # Ask Sentinel to promote a replica before this pod shuts down, so that a
+    # rolling update does not leave clients writing to a terminating master.
+    preStopFailover: true
+    # How long to wait for that failover to complete before shutting down anyway.
+    # Keep it below terminationGracePeriodSeconds.
+    preStopFailoverTimeoutSeconds: 20
+
+    # How long Sentinel waits for the local Valkey server on startup before it
+    # gives up on discovering the current master and assumes pod-0 is the master
+    startupTimeoutSeconds: 60
+
+    # Raw configuration appended to the generated sentinel.conf.
+    # Supports templating, e.g. "sentinel notification-script {{ .Release.Name }} /script.sh"
+    extraConfig: ""
+
+    # Resource limits/requests for the Sentinel container
+    resources: {}
+      # Example:
+      # limits:
+      #   cpu: 100m
+      #   memory: 128Mi
+      # requests:
+      #   cpu: 10m
+      #   memory: 64Mi
+
+    # Security context for the Sentinel container, defaults to securityContext
+    securityContext: {}
+
+    # Service exposing the Sentinel endpoints to clients
+    service:
+      # Enable the Sentinel service
+      enabled: true
+      # Service type (ClusterIP, NodePort, LoadBalancer)
+      type: ClusterIP
+      # Port on which the Sentinel service will be exposed
+      port: 26379
+      # Optional annotations for the Sentinel service
+      annotations: {}
+      # NodePort value (if service.type is NodePort)
+      nodePort: 0
+      # ClusterIP value
+      clusterIP: ""
+      # Application protocol
+      appProtocol: ""
+      # Class of a load balancer implementation
+      loadBalancerClass: ""
+      # Restricts traffic through the cloud-provider load balancer to these client IPs
+      loadBalancerSourceRanges: []
+
+    # Persistence for the Sentinel state directory. Optional: the chart
+    # rediscovers the current master on every start, so an emptyDir is enough.
+    persistence:
+      # Enable a PVC for the Sentinel state instead of an emptyDir
+      enabled: false
+      # Size of the PVC for each Sentinel
+      size: 100Mi
+      # Storage class name (empty = use default storage class)
+      storageClass: ""
+      # Access modes for the PVC
+      accessModes:
+        - ReadWriteOnce
+
 tls:
   # Enable TLS
   enabled: false

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -371,10 +371,11 @@ replica:
     # How often each Valkey pod mirrors the current master onto its data volume.
     # That record is what a cold start falls back on when no Sentinel answers,
     # so it bounds how stale the topology can be after an abrupt restart.
-    # A reading has to hold for two consecutive checks before it is written, so
-    # the record trails a failover by about twice this value. The check itself
-    # only reads a file that Valkey keeps up to date, and writes nothing when
-    # the topology has not moved.
+    # A pod that finds itself named as the master has to see that twice before
+    # it is written, because a check landing inside a config rewrite sees the
+    # same thing; a pod that finds a master to follow records it at once. The
+    # check only reads a file that Valkey keeps up to date, and writes nothing
+    # when the topology has not moved.
     masterRecordRefreshSeconds: 1
 
     # Raw configuration appended to the generated sentinel.conf.

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -353,6 +353,13 @@ replica:
     # and, because the same user replicates, +psync +replconf
     monitorUser: ""
 
+    # Dedicated password for Sentinel's own ACL. Do not reuse a Valkey user
+    # password: Sentinel permissions are independent from Valkey ACLs. When
+    # auth.usersExistingSecret is set, passwordKey is read from that Secret and
+    # this inline value is ignored.
+    password: ""
+    passwordKey: "sentinel"
+
     # Ask Sentinel to promote a replica before this pod shuts down, so that a
     # rolling update does not leave clients writing to a terminating master.
     preStopFailover: true

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -368,6 +368,11 @@ replica:
     # gives up on discovering the current master and assumes pod-0 is the master
     startupTimeoutSeconds: 60
 
+    # How often each Valkey pod mirrors the current master onto its data volume.
+    # That record is what a cold start falls back on when no Sentinel answers,
+    # so it bounds how stale the topology can be after an abrupt restart.
+    masterRecordRefreshSeconds: 10
+
     # Raw configuration appended to the generated sentinel.conf.
     # Supports templating, e.g. "sentinel notification-script {{ .Release.Name }} /script.sh"
     extraConfig: ""

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -368,6 +368,14 @@ replica:
     # gives up on discovering the current master and assumes pod-0 is the master
     startupTimeoutSeconds: 60
 
+    # How long a pod with no recorded topology waits for a Sentinel, or for
+    # another node, to tell it what the topology is. This is the fresh install
+    # case: the Sentinels bootstrap a master once their own
+    # startupTimeoutSeconds expires, so this has to be comfortably longer than
+    # that. A pod that gives up exits, and Kubernetes restarts the init
+    # container, so this bounds one attempt rather than the whole startup.
+    initialTopologyWaitSeconds: 180
+
     # How often each Valkey pod mirrors the current master onto its data volume.
     # That record is what a cold start falls back on when no Sentinel answers,
     # so it bounds how stale the topology can be after an abrupt restart.

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -354,9 +354,10 @@ replica:
     monitorUser: ""
 
     # Dedicated password for Sentinel's own ACL. Do not reuse a Valkey user
-    # password: Sentinel permissions are independent from Valkey ACLs. When
-    # auth.usersExistingSecret is set, passwordKey is read from that Secret and
-    # this inline value is ignored.
+    # password: Sentinel permissions are independent from Valkey ACLs.
+    # When auth.usersExistingSecret is set, passwordKey is looked up in that
+    # Secret first and this inline value is only used if the key is missing,
+    # the same priority the other ACL users follow.
     password: ""
     passwordKey: "sentinel"
 

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -372,8 +372,9 @@ replica:
     # another node, to tell it what the topology is. This is the fresh install
     # case: the Sentinels bootstrap a master once their own
     # startupTimeoutSeconds expires, so this has to be comfortably longer than
-    # that. A pod that gives up exits, and Kubernetes restarts the init
-    # container, so this bounds one attempt rather than the whole startup.
+    # that: the chart refuses to render unless it is at least 30s above it.
+    # A pod that gives up exits, and Kubernetes restarts the init container, so
+    # this bounds one attempt rather than the whole startup.
     initialTopologyWaitSeconds: 180
 
     # How often each Valkey pod mirrors the current master onto its data volume.

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -244,6 +244,18 @@ replica:
   # Number of replica instances (total pods = replicas + 1 master)
   replicas: 2
 
+  # Pod management policy for the StatefulSet. Empty means OrderedReady, or
+  # Parallel when Sentinel is enabled so that the quorum can form without
+  # waiting for pod-0. This field is immutable: setting it explicitly to
+  # OrderedReady lets an existing release enable Sentinel without recreating
+  # the StatefulSet.
+  podManagementPolicy: ""
+
+  # Grace period for a terminating pod. It must be longer than
+  # sentinel.preStopFailoverTimeoutSeconds, otherwise Kubernetes sends SIGKILL
+  # while the graceful failover is still running.
+  terminationGracePeriodSeconds: 30
+
   # Username for replicas to authenticate to master, ignored if auth.enabled is false.
   # IMPORTANT: When auth.enabled is true, this user MUST be defined in auth.aclUsers.
   # The chart requires this to retrieve the password for replica authentication.

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -244,13 +244,6 @@ replica:
   # Number of replica instances (total pods = replicas + 1 master)
   replicas: 2
 
-  # Pod management policy for the StatefulSet. Empty means OrderedReady, or
-  # Parallel when Sentinel is enabled so that the quorum can form without
-  # waiting for pod-0. This field is immutable: setting it explicitly to
-  # OrderedReady lets an existing release enable Sentinel without recreating
-  # the StatefulSet.
-  podManagementPolicy: ""
-
   # Grace period for a terminating pod. It must be longer than
   # sentinel.preStopFailoverTimeoutSeconds, otherwise Kubernetes sends SIGKILL
   # while the graceful failover is still running.
@@ -313,15 +306,19 @@ replica:
   persistentVolumeClaimRetentionPolicy: {}
 
   # Valkey Sentinel for automatic failover.
-  # Sentinel runs as a sidecar in every Valkey pod, monitors the master and
+  # Sentinel runs in an independent StatefulSet, monitors the master and
   # promotes a replica when the master becomes unreachable.
   # NOTE: with Sentinel enabled the Valkey service load balances across all pods,
   # because the master can move at any time. Clients must therefore discover the
   # master through Sentinel (SENTINEL get-master-addr-by-name).
   sentinel:
-    # Enable Sentinel (requires replica.enabled and at least 3 pods).
+    # Enable Sentinel (requires replica.enabled and at least one replica).
     # The Sentinel endpoint always requires its dedicated password, independently of whether authentication is enabled for the Valkey data endpoint.
     enabled: false
+
+    # Number of Sentinel instances. Keep this at 3 or more so a majority can
+    # authorize failover while one Sentinel is unavailable.
+    replicas: 3
 
     # Port on which Sentinel listens
     port: 26379
@@ -367,7 +364,7 @@ replica:
     # Keep it below terminationGracePeriodSeconds.
     preStopFailoverTimeoutSeconds: 20
 
-    # How long Sentinel waits for the local Valkey server on startup before it
+    # How long Sentinel waits for a peer or Valkey node on startup before it
     # gives up on discovering the current master and assumes pod-0 is the master
     startupTimeoutSeconds: 60
 
@@ -421,6 +418,9 @@ replica:
       # Access modes for the PVC
       accessModes:
         - ReadWriteOnce
+
+    # PersistentVolumeClaim retention policy for the Sentinel StatefulSet.
+    persistentVolumeClaimRetentionPolicy: {}
 
 tls:
   # Enable TLS

--- a/valkey/values.yaml
+++ b/valkey/values.yaml
@@ -307,7 +307,9 @@ replica:
   # because the master can move at any time. Clients must therefore discover the
   # master through Sentinel (SENTINEL get-master-addr-by-name).
   sentinel:
-    # Enable Sentinel (requires replica.enabled and at least 3 pods)
+    # Enable Sentinel (requires replica.enabled and at least 3 pods).
+    # When auth.enabled is false the Sentinel port accepts commands such as
+    # SENTINEL FAILOVER from anything that can reach it, like the Valkey port.
     enabled: false
 
     # Port on which Sentinel listens


### PR DESCRIPTION
Supersedes #137, rebased onto current `main` with the review feedback applied.
This PR adds Sentinel only; the HAProxy front-end follows separately.

Replication mode cannot recover from a primary failure on its own: pod 0 remains the configured primary until someone intervenes.
This change adds optional Valkey Sentinel support through `replica.sentinel.enabled`, allowing a replica to be promoted automatically.

## Architecture

Sentinel runs in its own StatefulSet rather than as a Valkey sidecar.
The default topology is three Sentinel pods, independently of the number of Valkey pods.
This keeps Sentinel quorum and data-replica count separate, so Valkey can run with one primary and one replica while retaining three Sentinels.

- A dedicated headless Service provides stable DNS identities for Sentinel peer discovery.
- A separate client-facing Service lets applications resolve the current primary through Sentinel.
- Sentinel and Valkey have independent replica counts, storage, rollout lifecycles, and selectors.
- Sentinel pods cannot become endpoints of the Valkey Services.

## Failover and recovery

- The `valkey` Service no longer pins its selector to pod 0 when Sentinel is enabled, because the primary can move, and is labelled `app.kubernetes.io/component: nodes` rather than `primary` to match.
- A starting pod asks Sentinel which node is the primary, then the other nodes, and only then the topology it recorded itself.
- The generated config carries the replication credentials, so it lives on a memory-backed volume and nothing in it outlives the pod.
  Each pod therefore keeps a credential-free record of the current primary on its data volume, refreshed while it runs, and that is what a cold start falls back on when no Sentinel and no node can be reached.
- A pod that finds none of the three waits to be told rather than exiting, which is what a first install spends.
- Sentinel pods discover the current primary from existing Sentinel peers first and the Valkey nodes second.
- Sentinel learns which nodes are replicas from the primary, so a node replicating from another replica is invisible to it and is never repaired. Each Sentinel reattaches those.
- A Valkey `preStop` hook requests failover before terminating the current primary.
- Sentinel uses stable pod hostnames instead of ephemeral pod IPs.

## Authentication

Sentinel has a dedicated ACL identity and password, independently of whether authentication is enabled for the Valkey data endpoint.
When Valkey authentication is enabled, Sentinel uses `replica.sentinel.monitorUser` to monitor nodes and promote replicas, and a starting pod asks that same user which node is the primary, since the documented minimum for a replication user cannot run `INFO`.
Credentials are mounted from Secrets and passed to `valkey-cli` through `REDISCLI_AUTH` rather than command-line arguments.
Generated Valkey and Sentinel configuration quotes and escapes credentials containing whitespace, double quotes, or backslashes.
An empty value in a Secret is refused rather than hashed into an ACL, because the hash of an empty password is the same in every installation.

## Testing

- `just validate`: 285 unit tests across all three charts.
- `helm lint ./valkey`.
- Template rendering against Kubernetes 1.28, 1.35, and 1.36.
- A kind cluster with ACL authentication using [`valkey/examples/ha-sentinel.yaml`](https://github.com/pat-s/valkey-helm/blob/feat/sentinel-ha/valkey/examples/ha-sentinel.yaml).
- A clean install reached three healthy pods and accepted writes on the primary Sentinel had chosen.
- Three independent Sentinels formed a quorum and discovered the Valkey topology.
- Sentinel promoted a replica and all peers agreed on the new primary.
- Valkey scaled from three pods to two while retaining the Sentinel quorum.
- Sentinel scaled from three pods to four without restarting either Valkey pod.
- Graceful removal of the current primary triggered failover before termination.
- A forced full restart preserved a primary that had moved away from pod 0.
- Special-character Sentinel and replication passwords reached full workload readiness and authenticated successfully.
- Graceful failover succeeded with the optional Sentinel client Service disabled and its external port changed.

One drive-by fix removes a stray tab from `statefulset.yaml` that caused strict YAML parsers to reject the rendered manifest.

Credit to @khtee, @jose-10000, @yoannrt, @tkarger, @lazariv, and @dmaes, whose work in #137 this builds on.
