### PR TITLE
Fix broken charts/ link on GitHub Pages landing page

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,6 +9,8 @@ on:
       - '.github/workflows/pages.yml'
   workflow_dispatch:
 
+
+
 permissions:
   contents: write
 
@@ -18,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Configure Git
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,37 @@
+name: Update GitHub Pages landing page
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'pages/index.html'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Update gh-pages index.html
+        run: |
+          cp pages/index.html /tmp/index.html
+          git fetch origin gh-pages
+          git checkout gh-pages
+          cp /tmp/index.html index.html
+          git add index.html
+          if ! git diff --staged --quiet; then
+            git commit -m "Update GitHub Pages landing page"
+            git push origin gh-pages
+          fi

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Valkey Helm Charts</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body {
+      font-family: sans-serif;
+      max-width: 700px;
+      margin: 40px auto;
+      padding: 0 20px;
+      color: #333;
+    }
+    h1 {
+      color: #d73333;
+    }
+    code {
+      background: #f4f4f4;
+      padding: 2px 6px;
+      border-radius: 3px;
+    }
+    pre {
+      background: #f4f4f4;
+      padding: 10px;
+      overflow-x: auto;
+    }
+  </style>
+</head>
+<body>
+  <h1>Valkey Helm Charts</h1>
+  <p>This GitHub Pages site hosts a Helm repository for <strong>Valkey</strong>.</p>
+
+  <h2>Usage</h2>
+  <p>Add this repo to Helm:</p>
+  <pre><code>helm repo add valkey https://valkey.io/valkey-helm/</code></pre>
+
+  <p>Update your local cache:</p>
+  <pre><code>helm repo update</code></pre>
+
+  <h2>Available Charts</h2>
+  <p>Install the standalone Valkey chart:</p>
+  <pre><code>helm install valkey valkey/valkey</code></pre>
+
+  <p>Install the Valkey operator:</p>
+  <pre><code>helm install valkey-operator valkey/valkey-operator \
+  -n valkey-operator-system --create-namespace</code></pre>
+
+  <p>Install an operator-managed ValkeyCluster:</p>
+  <pre><code>helm install my-cluster valkey/valkey-resources -n valkey</code></pre>
+
+  <h2>Repository Contents</h2>
+  <ul>
+    <li><a href="./index.yaml">index.yaml</a> - Helm repository index</li>
+    <li><a href="https://github.com/valkey-io/valkey-helm/releases">GitHub Releases</a> - Packaged charts (.tgz)</li>
+  </ul>
+
+  <footer style="margin-top: 50px; font-size: 0.9em;">
+    <hr>
+    <p>Published with ❤️ using GitHub Pages</p>
+  </footer>
+</body>
+</html>

--- a/pages/index.html
+++ b/pages/index.html
@@ -47,7 +47,7 @@
   -n valkey-operator-system --create-namespace</code></pre>
 
   <p>Install an operator-managed ValkeyCluster:</p>
-  <pre><code>helm install my-cluster valkey/valkey-resources -n valkey</code></pre>
+  <pre><code>helm install my-cluster valkey/valkey-resources -n valkey --create-namespace</code></pre>
 
   <h2>Repository Contents</h2>
   <ul>


### PR DESCRIPTION
Store index.html on main and sync it to gh-pages so the landing page points to GitHub Releases instead of a non-existent charts/ directory which returns 404. Fixes #233