### PR TITLE
feat(valkey-resources): add networkPolicy support

### DIFF
--- a/valkey-resources/examples/networkpolicy.yaml
+++ b/valkey-resources/examples/networkpolicy.yaml
@@ -1,0 +1,18 @@
+---
+# Creates networkPolicy with necessary rules and extraIngress for application ->
+# valkey communication
+networkPolicy:
+  enabled: true
+  extraIngress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: demo-application
+      ports:
+        - protocol: TCP
+          port: 6379
+
+cluster:
+  spec:
+    shards: 3
+    replicas: 1

--- a/valkey-resources/templates/netpolicy.yaml
+++ b/valkey-resources/templates/netpolicy.yaml
@@ -1,0 +1,93 @@
+{{- if .Values.networkPolicy.enabled }}
+{{- with .Values.networkPolicy }}
+{{- $useDefaults := true }}
+{{- if hasKey . "defaultRules" }}
+{{- $useDefaults = .defaultRules }}
+{{- end }}
+{{- $valkeyPort := 6379 }}
+{{- $valkeyClusterBusPort := 16379 }}
+{{- $hasEgress := or .extraEgress $useDefaults }}
+{{- $hasIngress := or .extraIngress $useDefaults }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "valkey-resources.fullname" $ }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "valkey-resources.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      valkey.io/cluster: {{ include "valkey-resources.fullname" $ | quote }}
+  policyTypes:
+    - Ingress
+  {{- if $hasEgress }}
+    - Egress
+  {{- end }}
+
+  {{- if $hasIngress }}
+  ingress:
+    {{- if $useDefaults }}
+    # valkey-operator management
+    - from:
+        -
+          {{- toYaml .operatorSelector | nindent 10 }}
+      ports:
+        - port: {{ $valkeyPort }}
+          protocol: TCP
+    # valkey cross instance
+    - from:
+        - podSelector:
+            matchLabels:
+              valkey.io/cluster: {{ include "valkey-resources.fullname" $ | quote }}
+      ports:
+        - port: {{ $valkeyPort }}
+          protocol: TCP
+        - port: {{ $valkeyClusterBusPort }}
+          protocol: TCP
+    {{- end }}
+    {{- with .extraIngress }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+  {{- end }}
+
+  {{- if $hasEgress }}
+  egress:
+    {{- if $useDefaults }}
+    # DNS resolution (kube-dns / CoreDNS)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # valkey cross instance
+    - to:
+        - podSelector:
+            matchLabels:
+              valkey.io/cluster: {{ include "valkey-resources.fullname" $ | quote }}
+      ports:
+        - port: {{ $valkeyPort }}
+          protocol: TCP
+        - port: {{ $valkeyClusterBusPort }}
+          protocol: TCP
+    {{- end }}
+    {{- with .extraEgress }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/valkey-resources/tests/netpolicy_test.yaml
+++ b/valkey-resources/tests/netpolicy_test.yaml
@@ -1,0 +1,175 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: network policy
+
+templates:
+  - templates/netpolicy.yaml
+
+tests:
+  - it: should not render anything when disabled by default
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should render a NetworkPolicy when enabled
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: apiVersion
+          value: networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-resources
+  - it: uses fullnameOverride for name and cluster selector
+    set:
+      fullnameOverride: my-cluster
+      networkPolicy.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-cluster
+      - equal:
+          path: spec.podSelector.matchLabels["valkey.io/cluster"]
+          value: my-cluster
+  - it: should select the instance pods
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - equal:
+          path: spec.podSelector.matchLabels["valkey.io/cluster"]
+          value: RELEASE-NAME-valkey-resources
+  - it: should inject default rules when enabled
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - lengthEqual:
+          path: spec.egress
+          count: 2
+      - contains:
+          path: spec.policyTypes
+          content: Ingress
+      - lengthEqual:
+          path: spec.ingress
+          count: 2
+  - it: should omit default rules when defaultRules is false
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.defaultRules: false
+    asserts:
+      - notExists:
+          path: spec.egress
+      - notExists:
+          path: spec.ingress
+  - it: should set correct PolicyTypes when defaultRules is false
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.defaultRules: false
+    asserts:
+      - equal:
+          path: spec.policyTypes
+          value:
+            - Ingress
+  - it: should append extraIngress rules and set the Ingress policyType
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.extraIngress:
+        - from:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: monitoring
+          ports:
+            - protocol: TCP
+              port: 8443
+    asserts:
+      - contains:
+          path: spec.policyTypes
+          content: Ingress
+      - lengthEqual:
+          path: spec.ingress
+          count: 3
+  - it: should append extraIngress rules and set the Ingress policyType
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.extraIngress:
+        - from:
+            - podSelector:
+                matchLabels:
+                  app.kubernetes.io/name: demo-application
+          ports:
+            - protocol: TCP
+              port: 6379
+    asserts:
+      - contains:
+          path: spec.policyTypes
+          content: Ingress
+      - lengthEqual:
+          path: spec.ingress
+          count: 3
+  - it: should merge extraEgress with the default egress rules
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.extraEgress:
+        - to:
+            - ipBlock:
+                cidr: 10.0.0.0/8
+          ports:
+            - protocol: TCP
+              port: 443
+    asserts:
+      - lengthEqual:
+          path: spec.egress
+          count: 3
+  - it: should keep extra rules when default egress is disabled
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.defaultRules: false
+      networkPolicy.extraEgress:
+        - to:
+            - ipBlock:
+                cidr: 10.0.0.0/8
+          ports:
+            - protocol: TCP
+              port: 443
+      networkPolicy.extraIngress:
+        - from:
+            - podSelector:
+                matchLabels:
+                  app.kubernetes.io/name: demo-application
+          ports:
+            - protocol: TCP
+              port: 6379
+    asserts:
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - lengthEqual:
+          path: spec.egress
+          count: 1
+      - contains:
+          path: spec.policyTypes
+          content: Ingress
+      - lengthEqual:
+          path: spec.ingress
+          count: 1
+  - it: should apply custom operator selector in default rules
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.operatorSelector: &customOperatorSelector
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: valkeyoperator-demo-namespace
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/instance: valkey-operator-demo
+            app.kubernetes.io/name: valkey-operator
+    asserts:
+      - equal:
+          path: spec.ingress[0].from[0]
+          value: *customOperatorSelector

--- a/valkey-resources/values.schema.json
+++ b/valkey-resources/values.schema.json
@@ -27,6 +27,33 @@
         }
       }
     },
+    "networkPolicy": {
+      "additionalProperties": true,
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "defaultRules": {
+          "type": "boolean"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "extraEgress": {
+          "type": "array"
+        },
+        "extraIngress": {
+          "type": "array"
+        },
+        "labels": {
+          "type": "object"
+        },
+        "operatorSelector": {
+          "type": "object"
+        }
+      }
+    },
     "cluster": {
       "type": "object",
       "required": ["spec"],

--- a/valkey-resources/values.yaml
+++ b/valkey-resources/values.yaml
@@ -18,6 +18,46 @@ commonLabels: {}
 #           secretName: "{{ .Values.extraValues.tlsSecret }}"
 extraValues: {}
 
+# Network policy to control traffic to/from the instance pods.
+# Disabled by default. When enabled, the instance's required
+# rules are added automatically: Valkey operator can manage the
+# Valkey instance and cluster nodes can communicate with each other.
+# Ingress PolicyType is always set, Egress is derived from the rules in effect.
+# More info: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+networkPolicy:
+  # Enable creation of a NetworkPolicy for the valkey instances
+  enabled: false
+  # Inject the necessary rules for operation as described above
+  # Set false to manage all egress yourself via extra{Ingress,Egress}.
+  defaultRules: true
+  # Selector for operator pods
+  operatorSelector:
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: valkey-operator-system
+    podSelector:
+      matchLabels:
+        app.kubernetes.io/instance: valkey-operator
+        app.kubernetes.io/name: valkey-operator
+
+  # Extra labels to add to the NetworkPolicy
+  labels: {}
+  # Extra annotations to add to the NetworkPolicy
+  annotations: {}
+  # Additional ingress rules merged with the default rules if enabled (templated with tpl)
+  extraIngress: []
+  # Additional egress rules merged with the default rules if enabled (templated with tpl)
+  extraEgress: []
+  # Example (allow application to connect to Valkey):
+  #   extraIngress:
+  #     - from:
+  #         - podSelector:
+  #             matchLabels:
+  #               app.kubernetes.io/name: demo-application
+  #       ports:
+  #         - protocol: TCP
+  #           port: 6379
+
 # Scrape ValkeyNode metrics-exporter sidecars (port name "metrics", default 9121).
 # Requires Prometheus Operator CRDs. Operator enables the exporter by default
 # (cluster.spec.exporter.enabled); disable the exporter there if you do not want metrics.


### PR DESCRIPTION
# Summary

Adds an optional NetworkPolicy to valkey-resources for restricting network traffic with necessary default rules to make configuration easy.



# Basic Usage

```yaml
networkPolicy:
  enabled: true
  extraIngress:
    - from:
        - podSelector:
            matchLabels:
              app.kubernetes.io/name: demo-application
      ports:
        - protocol: TCP
          port: 6379
```

Is all you need to configure a strict networkpolicy where valkey-operator and valkey instance internal communication is already taken care of and only a few custom rule lines are necessary to allow applications to connect to the Valkey Cluster.
 


## Testing

Added chart tests, all `just` targets run.