### PR TITLE
Fix formatting in statefulset.yaml

### DIFF
--- a/valkey/templates/statefulset.yaml
+++ b/valkey/templates/statefulset.yaml
@@ -24,7 +24,7 @@ spec:
     matchLabels:
       {{- include "valkey.selectorLabels" . | nindent 6 }}
   volumeClaimTemplates:
-  - apiVersion: v1	
+  - apiVersion: v1
     kind: PersistentVolumeClaim
     metadata:
       name: valkey-data


### PR DESCRIPTION
# Summary

There was a trailing `<TAB>` in the `statefulset.yaml`. Some YAML parsers (like PyYAML) throw an error on the resulting template as invalid YAML. I checked the rest of the repo with `grep -rn $'\t' .` and could not find any other cases.