### PR TITLE
Release valkey-operator 0.6.0

### DIFF
--- a/valkey-operator/CHANGELOG.md
+++ b/valkey-operator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.0
+
+- Valkey Operator version defaults to v0.6.0. See the [v0.6.0 release notes](https://github.com/valkey-io/valkey-operator/releases/tag/v0.6.0) for the upstream changes.
+
+> **Note:** CRDs are not upgraded automatically by Helm. See [UPGRADE.md](UPGRADE.md) for manual steps required before upgrading to this version.
+
 ## 0.5.0
 
 - Valkey Operator version defaults to v0.5.0. See the [v0.5.0 release notes](https://github.com/valkey-io/valkey-operator/releases/tag/v0.5.0) for the upstream changes.

--- a/valkey-operator/Chart.yaml
+++ b/valkey-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: valkey-operator
 description: A Helm chart for the Valkey Operator
 type: application
-version: 0.5.0
-appVersion: "v0.5.0"
+version: 0.6.0
+appVersion: "v0.6.0"
 kubeVersion: ">=1.20.0-0"
 home: https://valkey.io/valkey-helm/
 sources:

--- a/valkey-operator/README.md
+++ b/valkey-operator/README.md
@@ -1,6 +1,6 @@
 # valkey-operator
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.5.0](https://img.shields.io/badge/AppVersion-v0.5.0-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.0](https://img.shields.io/badge/AppVersion-v0.6.0-informational?style=flat-square)
 
 A Helm chart for deploying the [Valkey Operator](https://github.com/valkey-io/valkey-operator) on Kubernetes.
 

--- a/valkey-operator/UPGRADE.md
+++ b/valkey-operator/UPGRADE.md
@@ -1,5 +1,25 @@
 # Upgrade
 
+## From 0.5.x to 0.6.0
+
+There are breaking changes in `ValkeyCluster` migrating from `spec.networking.tls.certificate` to `spec.networking.tls.certificates.server`. See the [release notes](https://github.com/valkey-io/valkey-operator/releases/tag/v0.6.0) for steps on how to mitigate them.
+
+This version updates the CRDs to match the valkey-operator release bundled in this chart.
+Helm does not upgrade CRDs during `helm upgrade`, so you must apply them manually before upgrading.
+
+Run these commands to update the CRDs before applying the upgrade:
+
+```console
+kubectl apply --server-side -f https://raw.githubusercontent.com/valkey-io/valkey-operator/v0.6.0/config/crd/bases/valkey.io_valkeyclusters.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/valkey-io/valkey-operator/v0.6.0/config/crd/bases/valkey.io_valkeynodes.yaml
+```
+
+Then upgrade the chart:
+
+```console
+helm upgrade <release-name> valkey/valkey-operator --version 0.6.0
+```
+
 ## From 0.4.x to 0.5.0
 
 There are breaking changes in `ValkeyCluster` migrating from `spec.tls` to `spec.networking.tls`. See the [release notes](https://github.com/valkey-io/valkey-operator/releases/tag/v0.5.0) for steps on how to mitigate them.

--- a/valkey-operator/crds/valkey.io_valkeyclusters.yaml
+++ b/valkey-operator/crds/valkey.io_valkeyclusters.yaml
@@ -1598,7 +1598,10 @@ spec:
                       type: string
                     type: array
                   enabled:
-                    description: Enable or disable the exporter sidecar container
+                    description: |-
+                      Enable or disable the exporter sidecar container. Unset means enabled
+                      on a ValkeyCluster; a ValkeyNode runs the sidecar only on an explicit
+                      true, which the cluster controller propagates when enabled.
                     type: boolean
                   image:
                     description: Override the default exporter image
@@ -1890,25 +1893,32 @@ spec:
                   tls:
                     description: TLS configuration for the cluster.
                     properties:
-                      certificate:
-                        description: |-
-                          Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS.
-                          The referenced secret should contain the following:
-
-                          - `ca.crt`: The certificate authority.
-                          - `tls.crt`: The certificate (or a chain).
-                          - `tls.key`: The private key to the first certificate in the certificate chain.
+                      certificates:
+                        description: Certificates holds the certificate slots used
+                          by the cluster.
                         properties:
-                          secretName:
-                            description: SecretName is the name of the secret.
-                            maxLength: 253
-                            minLength: 1
-                            type: string
+                          server:
+                            description: |-
+                              Server is the node identity presented to clients and peers, and the
+                              trust root for the cluster. The referenced secret must contain:
+
+                              - `ca.crt`: The certificate authority.
+                              - `tls.crt`: The certificate (or a chain).
+                              - `tls.key`: The private key to the first certificate in the certificate chain.
+                            properties:
+                              secretName:
+                                description: SecretName is the name of the secret.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                            required:
+                            - secretName
+                            type: object
                         required:
-                        - secretName
+                        - server
                         type: object
                     required:
-                    - certificate
+                    - certificates
                     type: object
                 type: object
               persistence:
@@ -3612,11 +3622,13 @@ spec:
                         allow:
                           description: Allowed commands for this user
                           items:
+                            pattern: ^(@[A-Za-z]+|[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*(\.[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*)*(\|[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*(\.[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*)*)?)$
                             type: string
                           type: array
                         deny:
                           description: Denied commands for this user
                           items:
+                            pattern: ^(@[A-Za-z]+|[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*(\.[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*)*(\|[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*(\.[A-Za-z0-9_]+(-[A-Za-z0-9_]+)*)*)?)$
                             type: string
                           type: array
                       type: object

--- a/valkey-operator/crds/valkey.io_valkeynodes.yaml
+++ b/valkey-operator/crds/valkey.io_valkeynodes.yaml
@@ -2520,7 +2520,10 @@ spec:
                       type: string
                     type: array
                   enabled:
-                    description: Enable or disable the exporter sidecar container
+                    description: |-
+                      Enable or disable the exporter sidecar container. Unset means enabled
+                      on a ValkeyCluster; a ValkeyNode runs the sidecar only on an explicit
+                      true, which the cluster controller propagates when enabled.
                     type: boolean
                   image:
                     description: Override the default exporter image
@@ -3133,13 +3136,6 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
-              serverConfigHash:
-                description: |-
-                  ServerConfigHash is a hash of the server ConfigMap contents. When set by
-                  the ValkeyCluster controller it bumps the spec Generation, which triggers
-                  the ValkeyNode controller to reconcile and update the pod template
-                  annotation — causing a rolling restart when the cluster config changes.
-                type: string
               serverConfigMapName:
                 description: |-
                   ServerConfigMapName specifies the name of the ConfigMap that contains the
@@ -3156,25 +3152,29 @@ spec:
               tls:
                 description: TLS configuration for the node
                 properties:
-                  certificate:
-                    description: |-
-                      Certificate is a reference to a Kubernetes secret that contains the certificate and private key for enabling TLS.
-                      The referenced secret should contain the following:
-
-                      - `ca.crt`: The certificate authority.
-                      - `tls.crt`: The certificate (or a chain).
-                      - `tls.key`: The private key to the first certificate in the certificate chain.
+                  certificates:
+                    description: Certificates holds the certificate slots mounted
+                      into the node pod.
                     properties:
-                      secretName:
-                        description: SecretName is the name of the secret.
-                        maxLength: 253
-                        minLength: 1
-                        type: string
+                      server:
+                        description: |-
+                          Server is the node identity presented to clients and peers, and the
+                          trust root for the node. The referenced secret must contain `ca.crt`,
+                          `tls.crt` and `tls.key`.
+                        properties:
+                          secretName:
+                            description: SecretName is the name of the secret.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                        required:
+                        - secretName
+                        type: object
                     required:
-                    - secretName
+                    - server
                     type: object
                 required:
-                - certificate
+                - certificates
                 type: object
               tolerations:
                 description: Tolerations defines the pod tolerations.


### PR DESCRIPTION
Releases 0.6.0 of Operator with the helm-chart:
https://github.com/valkey-io/valkey-operator/releases/tag/v0.6.0
