### PR TITLE
Release valkey-resources 0.2.0

### DIFF
--- a/valkey-resources/CHANGELOG.md
+++ b/valkey-resources/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.2.0
+
+### Changed
+
+- `appVersion` defaults to operator **v0.6.0** (up from v0.4.0). Workloads created from this chart must target a cluster whose ValkeyCluster CRD matches v0.6.0 (install or upgrade the `valkey-operator` chart / CRDs first). See the [v0.6.0 release notes](https://github.com/valkey-io/valkey-operator/releases/tag/v0.6.0).
+- Reworked [`examples/scheduling-zone-spread.yaml`](examples/scheduling-zone-spread.yaml) to use the first-class `scheduling.zone.spread` API (added in operator v0.5.0) instead of hand-written `topologySpreadConstraints`. The operator now owns the emitted constraints, and the example uses `shard.mode: Preferred` for soft, zone-aware placement.
+
+Breaking ValkeyCluster API change that matters for `cluster.spec` drop-in values:
+
+- TLS certificate reference moved from `spec.networking.tls.certificate.secretName` to `spec.networking.tls.certificates.server.secretName`. Update TLS-enabled clusters accordingly.
+
+### Notes
+
+- This release skips operator v0.5.0. If upgrading from a chart release on appVersion v0.4.0, note that v0.5.0 first moved `spec.tls` to `spec.networking.tls`; v0.6.0 then moved `certificate` to `certificates.server`. Both changes are reflected in the current examples and values.
+- Operator v0.5.0 also added the `scheduling.zone.spread` and `scheduling.zone.pinning` axes (zone-aware placement mirroring `scheduling.node.spread`). The `scheduling-zone-spread.yaml` example uses `zone.spread`; `zone.spread` and `zone.pinning` are mutually exclusive.
+
 ## 0.1.3
 
 ### Added

--- a/valkey-resources/Chart.yaml
+++ b/valkey-resources/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: valkey-resources
 description: Helm chart for operator-managed Valkey resources (ValkeyCluster)
 type: application
-version: 0.1.3
-appVersion: "v0.4.0"
+version: 0.2.0
+appVersion: "v0.6.0"
 kubeVersion: ">=1.20.0-0"
 home: https://valkey.io/valkey-helm/
 sources:

--- a/valkey-resources/README.md
+++ b/valkey-resources/README.md
@@ -1,6 +1,6 @@
 # valkey-resources
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.0](https://img.shields.io/badge/AppVersion-v0.4.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.0](https://img.shields.io/badge/AppVersion-v0.6.0-informational?style=flat-square)
 
 Deploys a single operator managed `ValkeyCluster`. Does not install the operator.
 
@@ -8,9 +8,9 @@ Deploys a single operator managed `ValkeyCluster`. Does not install the operator
 
 * Kubernetes 1.20+
 * Helm 3.5+
-* [valkey-operator](../valkey-operator/) **v0.4.0+** installed (CRDs present)
+* [valkey-operator](../valkey-operator/) **v0.6.0+** installed (CRDs present)
 
-Without matching CRDs the API server rejects `ValkeyCluster` on apply. Helm does not upgrade CRDs for you; apply the operator chart CRDs when moving to v0.4.0. See [CHANGELOG.md](CHANGELOG.md) and the [operator v0.4.0 notes](https://github.com/valkey-io/valkey-operator/releases/tag/v0.4.0).
+Without matching CRDs the API server rejects `ValkeyCluster` on apply. Helm does not upgrade CRDs for you; apply the operator chart CRDs when moving to v0.6.0. See [CHANGELOG.md](CHANGELOG.md) and the [operator v0.6.0 notes](https://github.com/valkey-io/valkey-operator/releases/tag/v0.6.0).
 
 ## Install
 
@@ -23,7 +23,7 @@ helm install my-cluster valkey/valkey-resources -n valkey
 
 ### Examples
 
-Copy-paste values for common shapes live under [`examples/`](examples/) (operator v0.4.0+). Start with `minimal.yaml` and `scheduling-node-spread.yaml` for production node HA via `scheduling.node.spread`. See [`examples/README.md`](examples/README.md).
+Copy-paste values for common shapes live under [`examples/`](examples/) (operator v0.6.0+). Start with `minimal.yaml` and `scheduling-node-spread.yaml` for production node HA via `scheduling.node.spread`. See [`examples/README.md`](examples/README.md).
 
 ```bash
 helm install my-cluster ./valkey-resources -n valkey \
@@ -46,12 +46,14 @@ cluster:
   spec:
     shards: 3
     replicas: 1
-    tls:
-      certificate:
-        secretName: "{{ .Values.extraValues.tlsSecret }}"
+    networking:
+      tls:
+        certificates:
+          server:
+            secretName: "{{ .Values.extraValues.tlsSecret }}"
 ```
 
-### Operator v0.4.0 `cluster.spec` shape
+### `cluster.spec` scheduling and PDB shape (since operator v0.4.0)
 
 Placement and PDB fields changed in the CRD. Use the nested forms in values:
 

--- a/valkey-resources/examples/README.md
+++ b/valkey-resources/examples/README.md
@@ -1,6 +1,6 @@
 # valkey-resources examples
 
-Helm values overlays for common `ValkeyCluster` shapes (operator **v0.4.0+**).
+Helm values overlays for common `ValkeyCluster` shapes (operator **v0.6.0+**).
 
 Each file is meant for `helm install` / `helm upgrade` with `-f`. Merge multiple files when needed.
 
@@ -25,7 +25,7 @@ helm install my-cluster valkey/valkey-resources -n valkey \
 |---|---|
 | [minimal.yaml](minimal.yaml) | Explicit shards / replicas only |
 | [scheduling-node-spread.yaml](scheduling-node-spread.yaml) | `scheduling.node.spread` (shard-aware node HA) + PDB |
-| [scheduling-zone-spread.yaml](scheduling-zone-spread.yaml) | Zone `topologySpreadConstraints` escape hatch |
+| [scheduling-zone-spread.yaml](scheduling-zone-spread.yaml) | `scheduling.zone.spread` (zone-aware placement) |
 | [tls.yaml](tls.yaml) | TLS Secret ref via `extraValues` + `tpl` |
 | [persistence.yaml](persistence.yaml) | PVC size on StatefulSet |
 | [metrics-podmonitor.yaml](metrics-podmonitor.yaml) | PodMonitor for exporter sidecars |
@@ -34,7 +34,8 @@ helm install my-cluster valkey/valkey-resources -n valkey \
 ## Notes
 
 - Chart defaults leave `node.spread` off (operator default `Disabled`). Production clusters should set `shard` to at least `Preferred`; see `scheduling-node-spread.yaml`.
-- Prefer `node.spread` for hostname / node anti-colocation. Use raw `topologySpreadConstraints` for other keys (for example zones). Do not stack a hostname TSC with `node.spread.primaries` / `pods` at the same strength.
+- Prefer `node.spread` for hostname / node anti-colocation and `zone.spread` for zone-aware placement over hand-written `topologySpreadConstraints`; the operator owns the emitted constraints. Do not enable two dimensions at the same strength on the same axis (admission rejects duplicate constraints).
+- `zone.spread` and `zone.pinning` are mutually exclusive.
 - Secrets are references only; create them out of band.
 - CRDs come from the `valkey-operator` chart. Helm does not upgrade CRDs automatically.
 

--- a/valkey-resources/examples/scheduling-zone-spread.yaml
+++ b/valkey-resources/examples/scheduling-zone-spread.yaml
@@ -1,19 +1,32 @@
-# Zone-level topology spread (escape hatch). Operator renders TSC verbatim;
-# you must supply labelSelector. Prefer node.spread for hostname / node HA.
+# Zone-aware placement on topology.kubernetes.io/zone via scheduling.zone.spread.
+# Prefer this over hand-written topologySpreadConstraints: the operator emits and
+# owns the constraints, and a shard with more members than zones balances across
+# them rather than becoming unschedulable.
 #
-# fullnameOverride pins ValkeyCluster metadata.name so valkey.io/cluster matches
-# the selector. Change both together if you rename the cluster.
-fullnameOverride: my-cluster
-
+# Modes: Disabled | Preferred | Required
+# - shard: pods of each shard spread across zones
+# - primaries: each shard's node-index-0 pod (creation-time primary) spread across zones
+# - pods: all cluster pods spread across zones
+#
+# Preferred (ScheduleAnyway) is the safe default: the scheduler spreads shards
+# across zones when it can, but still places a pod if a perfect spread is not
+# possible, so a zone outage or shortage never leaves pods Pending. Use Required
+# (DoNotSchedule) only when you would rather a pod stay unschedulable than share
+# a zone.
+#
+# Do not enable two dimensions at the same strength on this axis; admission
+# rejects duplicate constraints.
+# zone.spread is mutually exclusive with zone.pinning.
 cluster:
   spec:
     shards: 3
     replicas: 1
     scheduling:
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: topology.kubernetes.io/zone
-          whenUnsatisfiable: ScheduleAnyway
-          labelSelector:
-            matchLabels:
-              valkey.io/cluster: my-cluster
+      zone:
+        spread:
+          shard:
+            mode: Preferred
+          primaries:
+            mode: Disabled
+          pods:
+            mode: Disabled

--- a/valkey-resources/examples/tls.yaml
+++ b/valkey-resources/examples/tls.yaml
@@ -7,6 +7,8 @@ cluster:
   spec:
     shards: 3
     replicas: 1
-    tls:
-      certificate:
-        secretName: "{{ .Values.extraValues.tlsSecret }}"
+    networking:
+      tls:
+        certificates:
+          server:
+            secretName: "{{ .Values.extraValues.tlsSecret }}"

--- a/valkey-resources/tests/valkeycluster_test.yaml
+++ b/valkey-resources/tests/valkeycluster_test.yaml
@@ -43,9 +43,11 @@ tests:
           persistence:
             size: 10Gi
             reclaimPolicy: Retain
-          tls:
-            certificate:
-              secretName: valkey-tls
+          networking:
+            tls:
+              certificates:
+                server:
+                  secretName: valkey-tls
           exporter:
             enabled: false
     asserts:
@@ -71,7 +73,7 @@ tests:
           path: spec.persistence.size
           value: 10Gi
       - equal:
-          path: spec.tls.certificate.secretName
+          path: spec.networking.tls.certificates.server.secretName
           value: valkey-tls
       - equal:
           path: spec.exporter.enabled
@@ -107,15 +109,17 @@ tests:
           shards: 3
           replicas: 1
           image: "valkey/valkey:{{ .Chart.AppVersion }}"
-          tls:
-            certificate:
-              secretName: "{{ .Release.Name }}-tls"
+          networking:
+            tls:
+              certificates:
+                server:
+                  secretName: "{{ .Release.Name }}-tls"
     asserts:
       - equal:
           path: spec.image
-          value: valkey/valkey:v0.4.0
+          value: valkey/valkey:v0.6.0
       - equal:
-          path: spec.tls.certificate.secretName
+          path: spec.networking.tls.certificates.server.secretName
           value: RELEASE-NAME-tls
 
   - it: templates using extraValues
@@ -128,13 +132,15 @@ tests:
         spec:
           shards: 3
           replicas: 0
-          tls:
-            certificate:
-              secretName: "{{ .Values.extraValues.tlsSecret }}"
+          networking:
+            tls:
+              certificates:
+                server:
+                  secretName: "{{ .Values.extraValues.tlsSecret }}"
     asserts:
       - equal:
           path: metadata.annotations.note
           value: tls=shared-valkey-tls
       - equal:
-          path: spec.tls.certificate.secretName
+          path: spec.networking.tls.certificates.server.secretName
           value: shared-valkey-tls

--- a/valkey-resources/values.yaml
+++ b/valkey-resources/values.yaml
@@ -13,9 +13,11 @@ commonLabels: {}
 #     tlsSecret: my-tls
 #   cluster:
 #     spec:
-#       tls:
-#         certificate:
-#           secretName: "{{ .Values.extraValues.tlsSecret }}"
+#       networking:
+#         tls:
+#           certificates:
+#             server:
+#               secretName: "{{ .Values.extraValues.tlsSecret }}"
 extraValues: {}
 
 # Scrape ValkeyNode metrics-exporter sidecars (port name "metrics", default 9121).
@@ -56,11 +58,11 @@ cluster:
   labels: {}
 
   # ValkeyCluster.spec drop-in (any CRD field allowed). Tested against operator
-  # appVersion (v0.4.0): scheduling under spec.scheduling, PDB as {mode: ...},
+  # appVersion (v0.6.0): scheduling under spec.scheduling, PDB as {mode: ...},
   # node.spread.shard|primaries|pods. See CHANGELOG.md.
   # Rendered via tpl so string values may use Helm templates, e.g.
   #   image: "valkey/valkey:{{ .Chart.AppVersion }}"
-  #   tls.certificate.secretName: "{{ .Release.Name }}-tls"
+  #   networking.tls.certificates.server.secretName: "{{ .Release.Name }}-tls"
   # API: https://github.com/valkey-io/valkey-operator/blob/main/docs/valkeycluster.md
   spec:
     shards: 3


### PR DESCRIPTION
Bump `appVersion` to `v0.6.0` and update examples/tests for the `v0.6.0` ValkeyCluster CRD (TLS certificates.server, zone.spread)